### PR TITLE
[Impl] Initial support for Linux

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,9 +1,16 @@
 import json
 import os
+import platform
 
 # 설정 파일 경로 (AppData 디렉토리에 저장)
 APP_NAME = "chzzk-vod-downloader-v2"
-CONFIG_DIR = os.path.join(os.getenv("APPDATA"), APP_NAME)  # C:\Users\<User>\AppData\Roaming\chzzk-vod-downloader
+
+if platform.system() == "Windows":
+    CONFIG_DIR = os.path.join(os.getenv("APPDATA"), APP_NAME)  # C:\Users\<User>\AppData\Roaming\chzzk-vod-downloader
+
+elif platform.system() == "Linux":
+    CONFIG_DIR = config_dir = os.path.join(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), APP_NAME)
+
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 
 # 초기 설정


### PR DESCRIPTION
I have confirmed that it works correctly on Arch Linux with the KDE Plasma environment using Python 3.13.2.
The configuration file is stored at ~/.config/chzzk-vod-downloader-v2/config.json.


![image](https://github.com/user-attachments/assets/efb794fa-6f58-4d69-b415-a464203e27cc)
