### PR TITLE
test: URL 파싱·매니페스트 파싱·범위 계산 박제 테스트 1차 (Phase 0)

### DIFF
--- a/download/download.py
+++ b/download/download.py
@@ -8,6 +8,38 @@ from concurrent.futures import ThreadPoolExecutor
 from download.task import DownloadTask
 from download.state import DownloadState
 
+
+def decide_part_size(content_type: str, resolution: int) -> int:
+    """
+    해상도에 따라 파트 크기 가중치를 달리 부여한다.
+
+    테스트를 위해 DownloadThread._decide_part_size에서 분리한 순수 함수 (#27).
+    """
+    base_part_size = 1024 * 1024  # 1MB
+    if content_type == 'clips':
+        return base_part_size * 1
+    elif resolution == 144:
+        return base_part_size * 1
+    elif resolution in [360, 480]:
+        return base_part_size * 2
+    elif resolution == 720:
+        return base_part_size * 5
+    else:
+        return base_part_size * 10
+
+
+def split_ranges(total_size: int, part_size: int) -> list[tuple[int, int]]:
+    """
+    total_size 바이트를 part_size 단위의 (start, end) 구간 목록으로 분할한다.
+
+    테스트를 위해 DownloadThread.run의 인라인 계산에서 분리한 순수 함수 (#27).
+    """
+    return [
+        (i * part_size, min((i + 1) * part_size - 1, total_size - 1))
+        for i in range((total_size + part_size - 1) // part_size)
+    ]
+
+
 class DownloadThread(QThread):
     """
     VOD 파일을 multi-thread로 다운로드하는 작업 스레드 클래스
@@ -37,10 +69,7 @@ class DownloadThread(QThread):
             part_size = self._decide_part_size()
 
             # 다운로드할 구간 분할
-            ranges = [
-                (i * part_size, min((i + 1) * part_size - 1, total_size - 1))
-                for i in range((total_size + part_size - 1) // part_size)
-            ]
+            ranges = split_ranges(total_size, part_size)
             self.s.max_threads = self.s.total_ranges = len(ranges)
             self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
             self.s.threads_progress = [0] * self.s.total_ranges
@@ -228,17 +257,7 @@ class DownloadThread(QThread):
         """
         해상도에 따라 파트 크기 가중치를 달리 부여한다.
         """
-        base_part_size = 1024 * 1024  # 1MB
-        if self.s.content_type == 'clips':
-            return base_part_size * 1
-        elif self.s.resolution == 144:
-            return base_part_size * 1
-        elif self.s.resolution in [360, 480]:
-            return base_part_size * 2
-        elif self.s.resolution == 720:
-            return base_part_size * 5
-        else:
-            return base_part_size * 10
+        return decide_part_size(self.s.content_type, self.s.resolution)
 
     def _get_remaining_ranges(self, ranges):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""pytest 공통 설정.
+
+저장소 루트를 import 경로에 추가해 `content`, `download` 등 최상위 모듈을
+어느 위치에서 pytest를 실행하든 import할 수 있게 한다.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# 외부 API 응답을 흉내 내는 픽스처 파일 저장 위치
+MOCK_RESPONSES_DIR = Path(__file__).resolve().parent / "fixtures" / "mock_responses"
+
+
+@pytest.fixture
+def load_mock_response():
+    """mock_responses 디렉토리의 픽스처 파일 내용을 문자열로 읽어 오는 헬퍼를 반환한다."""
+
+    def _load(name: str) -> str:
+        return (MOCK_RESPONSES_DIR / name).read_text(encoding="utf-8")
+
+    return _load

--- a/tests/fixtures/mock_responses/dash_manifest.xml
+++ b/tests/fixtures/mock_responses/dash_manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 치지직 DASH 매니페스트 응답 픽스처.
+     get_video_dash_manifest의 파싱 로직이 소비하는 형태 기준으로 작성 (#27).
+     - 해상도 3종(1080/720/480)을 내림차순으로 배치해 정렬 동작을 검증
+     - BaseURL이 '/hls/'로 끝나는 Representation은 파서가 건너뛰어야 함 -->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static" mediaPresentationDuration="PT1H2M3S">
+  <Period>
+    <AdaptationSet mimeType="video/mp4" contentType="video">
+      <Representation id="1080p" width="1920" height="1080" bandwidth="8000000" codecs="avc1.640028">
+        <BaseURL>https://vod-example.invalid/chzzk/video_1080p.mp4</BaseURL>
+      </Representation>
+      <Representation id="720p" width="1280" height="720" bandwidth="4000000" codecs="avc1.64001f">
+        <BaseURL>https://vod-example.invalid/chzzk/video_720p.mp4</BaseURL>
+      </Representation>
+      <Representation id="480p" width="854" height="480" bandwidth="2000000" codecs="avc1.64001e">
+        <BaseURL>https://vod-example.invalid/chzzk/video_480p.mp4</BaseURL>
+      </Representation>
+      <Representation id="hls" width="1920" height="1080" bandwidth="8000000">
+        <BaseURL>https://vod-example.invalid/chzzk/hls/</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/fixtures/mock_responses/dash_manifest_portrait.xml
+++ b/tests/fixtures/mock_responses/dash_manifest_portrait.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 세로 영상(width < height) 단일 해상도 매니페스트 픽스처.
+     해상도가 min(width, height)로 계산되는 현재 동작을 고정하기 위한 경계 케이스 (#27). -->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static">
+  <Period>
+    <AdaptationSet mimeType="video/mp4" contentType="video">
+      <Representation id="portrait" width="720" height="1280" bandwidth="3000000">
+        <BaseURL>https://vod-example.invalid/chzzk/portrait_720.mp4</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/mocks/mock_http.py
+++ b/tests/mocks/mock_http.py
@@ -1,0 +1,25 @@
+"""HTTP 응답 목(mock) 객체.
+
+테스트에서 실제 네트워크 호출 없이 `requests.Response`의 최소 인터페이스를 흉내 낸다.
+"""
+
+import json
+
+import requests
+
+
+class MockResponse:
+    """`requests.Response`를 대신하는 최소 목 객체."""
+
+    def __init__(self, text: str = "", status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        """실제 Response처럼 4xx/5xx 상태 코드면 HTTPError를 던진다."""
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"Mock HTTP {self.status_code}")
+
+    def json(self) -> object:
+        """본문 텍스트를 JSON으로 파싱해 반환한다."""
+        return json.loads(self.text)

--- a/tests/unit/test_download_ranges.py
+++ b/tests/unit/test_download_ranges.py
@@ -1,0 +1,87 @@
+"""download.download의 파트 크기 결정·구간 분할 박제 테스트.
+
+목적은 "올바른 동작" 검증이 아니라 현재 동작의 보존이다 (#27).
+"""
+
+import pytest
+
+from download.download import decide_part_size, split_ranges
+
+MB = 1024 * 1024
+
+
+class TestDecidePartSize:
+    """decide_part_size의 content_type·해상도별 가중치 박제."""
+
+    @pytest.mark.parametrize(
+        ("content_type", "resolution", "expected"),
+        [
+            # clips는 해상도와 무관하게 항상 1MB
+            ("clips", 1080, 1 * MB),
+            ("clips", 144, 1 * MB),
+            # video는 해상도별 가중치
+            ("video", 144, 1 * MB),
+            ("video", 360, 2 * MB),
+            ("video", 480, 2 * MB),
+            ("video", 720, 5 * MB),
+            ("video", 1080, 10 * MB),
+            ("video", 1440, 10 * MB),
+            # 경계 케이스: 목록에 없는 해상도는 전부 else 분기(10MB)로 떨어진다
+            ("video", 0, 10 * MB),
+            ("video", 719, 10 * MB),
+        ],
+    )
+    def test_decide_part_size(self, content_type: str, resolution: int, expected: int):
+        """조합별 part_size를 현재 동작 그대로 고정한다."""
+        assert decide_part_size(content_type, resolution) == expected
+
+
+class TestSplitRanges:
+    """split_ranges의 (start, end) 구간 분할 결과 박제."""
+
+    @pytest.mark.parametrize(
+        ("total_size", "part_size", "expected"),
+        [
+            # 정확히 나누어떨어지는 경우
+            (20, 10, [(0, 9), (10, 19)]),
+            # 나머지가 있는 경우: 마지막 구간은 total_size - 1에서 끝난다
+            (25, 10, [(0, 9), (10, 19), (20, 24)]),
+            # total이 part보다 작으면 구간 1개
+            (5, 10, [(0, 4)]),
+            # total == part
+            (10, 10, [(0, 9)]),
+            # 경계 케이스: 1바이트 파일
+            (1, 10, [(0, 0)]),
+            # 경계 케이스: 0바이트 파일이면 구간 없음
+            (0, 10, []),
+        ],
+    )
+    def test_split_ranges(self, total_size: int, part_size: int, expected: list):
+        """total_size·part_size 조합별 분할 결과를 현재 동작 그대로 고정한다."""
+        assert split_ranges(total_size, part_size) == expected
+
+    def test_realistic_720p_video(self):
+        """실제와 유사한 조합: 10.5MB 파일을 720p part_size(5MB)로 분할."""
+        total_size = 10 * MB + 512 * 1024  # 10.5MB
+        part_size = decide_part_size("video", 720)  # 5MB
+
+        ranges = split_ranges(total_size, part_size)
+
+        assert ranges == [
+            (0, 5 * MB - 1),
+            (5 * MB, 10 * MB - 1),
+            (10 * MB, total_size - 1),
+        ]
+
+    @pytest.mark.parametrize(
+        ("total_size", "part_size"),
+        [(1, 1), (99, 10), (100, 10), (101, 10), (10 * MB + 3, 2 * MB)],
+    )
+    def test_ranges_cover_whole_file_without_gap(self, total_size: int, part_size: int):
+        """분할 구간이 빈틈·겹침 없이 파일 전체 [0, total_size-1]을 덮는 불변식을 고정한다."""
+        ranges = split_ranges(total_size, part_size)
+
+        assert ranges[0][0] == 0
+        assert ranges[-1][1] == total_size - 1
+        for (_, prev_end), (next_start, _) in zip(ranges, ranges[1:]):
+            assert next_start == prev_end + 1

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1,0 +1,95 @@
+"""content.network의 URL 파싱·DASH 매니페스트 파싱 박제 테스트.
+
+목적은 "올바른 동작" 검증이 아니라 현재 동작의 보존이다 (#27).
+현재 결과가 이상해 보여도 그 결과 그대로를 기대값으로 삼는다.
+"""
+
+import pytest
+
+import content.network as network
+from content.network import NetworkManager
+from tests.mocks.mock_http import MockResponse
+
+
+class TestExtractContentNo:
+    """NetworkManager.extract_content_no의 (type, content_no) 결과 박제."""
+
+    @pytest.mark.parametrize(
+        ("vod_url", "expected"),
+        [
+            # 정상 케이스: video / clips, 스킴 유무
+            ("https://chzzk.naver.com/video/1510760", ("video", "1510760")),
+            ("http://chzzk.naver.com/video/1510760", ("video", "1510760")),
+            ("chzzk.naver.com/video/1510760", ("video", "1510760")),
+            ("https://chzzk.naver.com/clips/abcDEF12345", ("clips", "abcDEF12345")),
+            ("chzzk.naver.com/clips/abcDEF12345", ("clips", "abcDEF12345")),
+            # content_no는 \w+ 이므로 언더스코어는 허용된다
+            ("https://chzzk.naver.com/clips/abc_123", ("clips", "abc_123")),
+            # 경계 케이스: 현재 구현은 fullmatch라서 아래는 전부 (None, None)
+            ("https://chzzk.naver.com/video/1510760?t=120", (None, None)),  # 쿼리스트링
+            ("https://chzzk.naver.com/video/1510760/", (None, None)),  # 후행 슬래시
+            ("https://chzzk.naver.com/clips/abc-def", (None, None)),  # 하이픈은 \w 미포함
+            ("https://chzzk.naver.com/live/channelid00", (None, None)),  # live는 미지원
+            ("https://chzzk.naver.com/video/", (None, None)),  # content_no 누락
+            ("https://www.chzzk.naver.com/video/1510760", (None, None)),  # www 서브도메인
+            ("https://youtube.com/video/1510760", (None, None)),  # 다른 도메인
+            ("ftp://chzzk.naver.com/video/1510760", (None, None)),  # 다른 스킴
+            ("", (None, None)),  # 빈 문자열
+        ],
+    )
+    def test_extract_content_no(self, vod_url: str, expected: tuple):
+        """URL별 (type, content_no) 추출 결과를 현재 동작 그대로 고정한다."""
+        assert NetworkManager.extract_content_no(vod_url) == expected
+
+
+class TestGetVideoDashManifest:
+    """NetworkManager.get_video_dash_manifest의 XML 파싱 결과 박제 (HTTP는 mock)."""
+
+    def _patch_get(self, monkeypatch: pytest.MonkeyPatch, xml_text: str) -> list:
+        """content.network.requests.get을 목으로 바꾸고 호출 기록 리스트를 반환한다."""
+        calls = []
+
+        def fake_get(url, **kwargs):
+            calls.append((url, kwargs))
+            return MockResponse(text=xml_text)
+
+        monkeypatch.setattr(network.requests, "get", fake_get)
+        return calls
+
+    def test_parses_sorts_and_skips_hls(self, monkeypatch, load_mock_response):
+        """해상도 오름차순 정렬, min(width, height) 계산, '/hls/' 항목 스킵을 고정한다."""
+        calls = self._patch_get(monkeypatch, load_mock_response("dash_manifest.xml"))
+
+        sorted_reps, auto_resolution, auto_base_url = NetworkManager.get_video_dash_manifest(
+            "test-video-id", "test-in-key"
+        )
+
+        assert sorted_reps == [
+            [480, "https://vod-example.invalid/chzzk/video_480p.mp4"],
+            [720, "https://vod-example.invalid/chzzk/video_720p.mp4"],
+            [1080, "https://vod-example.invalid/chzzk/video_1080p.mp4"],
+        ]
+        # auto는 목록 중 가장 높은 해상도
+        assert auto_resolution == 1080
+        assert auto_base_url == "https://vod-example.invalid/chzzk/video_1080p.mp4"
+
+        # 요청 URL·헤더 구성도 현재 동작 그대로 고정 (실호출 없음)
+        assert calls == [
+            (
+                "https://apis.naver.com/neonplayer/vodplay/v2/playback/test-video-id"
+                "?key=test-in-key",
+                {"headers": {"Accept": "application/dash+xml"}},
+            )
+        ]
+
+    def test_portrait_single_representation(self, monkeypatch, load_mock_response):
+        """세로 영상(720x1280) 단일 항목: 해상도는 min(width, height)=720으로 계산된다."""
+        self._patch_get(monkeypatch, load_mock_response("dash_manifest_portrait.xml"))
+
+        sorted_reps, auto_resolution, auto_base_url = NetworkManager.get_video_dash_manifest(
+            "portrait-video-id", "portrait-in-key"
+        )
+
+        assert sorted_reps == [[720, "https://vod-example.invalid/chzzk/portrait_720.mp4"]]
+        assert auto_resolution == 720
+        assert auto_base_url == "https://vod-example.invalid/chzzk/portrait_720.mp4"


### PR DESCRIPTION
## 관련 이슈

Closes #27

## 변경 내용

박제 테스트(characterization test) 1차 — 목적은 "올바른 동작" 검증이 아니라 **현재 동작 보존**입니다. 총 39개 테스트.

- **tests/ 구조 신설**: `tests/unit/`, `tests/fixtures/mock_responses/`, `tests/mocks/`, `tests/conftest.py` (루트를 import 경로에 추가 + 픽스처 로더 제공)
- **① URL 파싱** (`tests/unit/test_network.py`): `NetworkManager.extract_content_no`의 URL 케이스 15종 고정 — video/clips 정상 케이스, 스킴 생략, 그리고 현재 fullmatch 구현이 (None, None)을 반환하는 경계 케이스(쿼리스트링, 후행 슬래시, 하이픈 id, live URL, www 서브도메인, 타 도메인, 빈 문자열 등)
- **② DASH 매니페스트 파싱** (`tests/unit/test_network.py`): XML 픽스처 2종(`dash_manifest.xml`: 해상도 3종+`/hls/` 스킵 항목, `dash_manifest_portrait.xml`: 세로 영상 단일 항목)으로 해상도 오름차순 정렬, `min(width, height)` 계산, `/hls/` BaseURL 스킵, auto 해상도 선택, 요청 URL·헤더 구성까지 고정. HTTP는 `tests/mocks/mock_http.py`의 `MockResponse` + monkeypatch로 대체 — **실호출 없음**
- **③ 범위 분할 계산** (`tests/unit/test_download_ranges.py`): content_type·해상도 조합 10종의 part_size 고정(clips 우선, 미정의 해상도의 else 분기 포함), total_size·part_size 조합별 분할 결과 고정(정확히 나누어떨어짐/나머지/1바이트/0바이트), 빈틈·겹침 없는 커버리지 불변식
- **최소 함수 분리** (`download/download.py`, 이슈에서 허용된 범위): `_decide_part_size`의 본문과 `run()`의 인라인 ranges 계산을 모듈 순수 함수 `decide_part_size(content_type, resolution)` / `split_ranges(total_size, part_size)`로 추출. 기존 메서드·호출부는 이 함수들에 위임하며 **호출 결과·동작 완전 동일** (식 자체를 그대로 이동)

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 39 passed (로컬 Windows; CI에서 xvfb-run으로 재확인)
- [x] 새 로직에 대한 테스트 추가됨 — 이 PR 자체가 테스트 추가
- [x] 실제 네트워크 호출 없음 — 유일한 HTTP 경로(`get_video_dash_manifest`)는 monkeypatch로 대체, 나머지는 순수 함수
- [x] 기존 앱 동작 무변경 — `uv run python main.py` 스모크 확인 (12초 이상 정상 구동, 크래시 없음)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — 소스 변경은 download/download.py 내 함수 추출뿐
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #27 (approved, tests/ 신규 + 최소 함수 분리 허용 명시)

## 리뷰어에게

- 픽스처 XML은 실제 API 응답이 아니라 **파서가 소비하는 형태 기준**으로 작성했습니다(이슈 명세). 도메인은 실서비스와 무관한 `vod-example.invalid`를 사용해 실수로도 호출되지 않게 했습니다.
- 이번에 고정된 특이 동작(수정하지 않고 그대로 박제): 쿼리스트링이 붙은 정상 VOD URL이 (None, None)으로 거부됨, 하이픈 포함 클립 id 미매칭, `split_ranges(0, n) == []`. 개선이 필요하면 후속 이슈에서 기대값을 바꾸는 방식으로 다루면 됩니다.
- 테스트 위치는 `tests/unit/` 바로 아래로 했습니다. CLAUDE 규칙의 `tests/unit/core/`는 core/ 디렉토리가 생기는 구조 개편(Phase 2~) 때 함께 옮기는 게 자연스럽다고 판단했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
