### PR TITLE
refactor: print 디버깅을 표준 logging으로 전환 (Phase 1)

### DIFF
--- a/application/mainWindow.py
+++ b/application/mainWindow.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import config.config as config
@@ -11,6 +12,8 @@ from content.manager import ContentManager
 from download.manager import DownloadManager
 from download.state import DownloadState
 from ui.mainWindow import Ui_VodDownloader
+
+logger = logging.getLogger(__name__)
 
 
 class VodDownloader(QMainWindow, Ui_VodDownloader):
@@ -226,7 +229,7 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
             elif os_type == "Linux":
                 os.system("systemctl suspend")
             else:
-                print(f"절전 모드는 {os_type}에서 지원되지 않습니다.")
+                logger.warning(f"절전 모드는 {os_type}에서 지원되지 않습니다.")
         elif afterDownload == "shutdown":
             if os_type == "Windows":
                 os.system("shutdown -s -t 0")
@@ -235,7 +238,7 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
             elif os_type == "Linux":
                 os.system("shutdown -h now")
             else:
-                print(f"시스템 종료는 {os_type}에서 지원되지 않습니다.")
+                logger.warning(f"시스템 종료는 {os_type}에서 지원되지 않습니다.")
 
         QMessageBox.information(self, self.tr("Completed"), self.tr("Download completed."))
 

--- a/config/config.py
+++ b/config/config.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import os
 import platform
 from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
 
 # 설정 파일 경로 (AppData 디렉토리에 저장)
 APP_NAME = "chzzk-vod-downloader-v2"
@@ -42,7 +45,7 @@ def load_config(): # TODO: config.json에서 추출한 값들을 ENUM으로 변�
         with open(CONFIG_FILE, "r", encoding="utf-8") as f:
             config = json.load(f)
     except json.JSONDecodeError as e:
-        print(f"Error reading config file: {e}")
+        logger.error(f"Error reading config file: {e}")
         return DEFAULT_CONFIG  # 기본값을 반환하거나 예외 처리
         
     return config
@@ -62,7 +65,7 @@ def update_config():
     current_version = config.get("version", 1)
 
     if current_version < CONFIG_VERSION:
-        print(f"Migrating config from version {current_version} to {CONFIG_VERSION}...")
+        logger.info(f"Migrating config from version {current_version} to {CONFIG_VERSION}...")
         while current_version < CONFIG_VERSION:
             migrate_func = MIGRATIONS.get(current_version)
             if not migrate_func:
@@ -70,9 +73,9 @@ def update_config():
             config = migrate_func(config)
             current_version = config["version"]
 
-        print("Configuration file has been updated to the latest version.")
+        logger.info("Configuration file has been updated to the latest version.")
     else:
-        print("Configuration file is up to date.")
+        logger.info("Configuration file is up to date.")
     config = reorder_config(config) # 순서 변경이 필요한 경우에만 정렬
     save_config(config)
     return config

--- a/config/log_setup.py
+++ b/config/log_setup.py
@@ -1,0 +1,64 @@
+"""공통 logging 설정 모듈 (#30).
+
+앱 전역에서 사용할 표준 logging 핸들러(콘솔 + 회전 파일)를 루트 로거에 연결한다.
+각 모듈은 `logging.getLogger(__name__)`로 로거를 얻어 쓰기만 하면 되고,
+핸들러·포맷 구성은 이 모듈에서만 관리한다.
+"""
+
+import logging
+import logging.handlers
+import os
+
+import config.config as config
+
+# 포맷: 시간·레벨·모듈·메시지
+LOG_FORMAT = "%(asctime)s - %(levelname)s - [%(name)s] - %(message)s"
+LOG_FILE_NAME = "app.log"
+
+# 파일 회전 설정: 1MB × 5개 백업
+MAX_BYTES = 1024 * 1024
+BACKUP_COUNT = 5
+
+# 중복 초기화 방지 플래그
+_configured = False
+
+
+def setup_logging(log_level: int = logging.DEBUG) -> None:
+    """루트 로거에 콘솔·회전 파일 핸들러를 설정한다.
+
+    앱 시작 시 한 번만 호출한다. 재호출은 무시된다(핸들러 중복 방지).
+
+    Args:
+        log_level: 루트 로거에 적용할 로깅 레벨 (기본값: DEBUG)
+    """
+    global _configured
+    if _configured:
+        return
+
+    # 로그 파일 위치는 기존 규칙(CONFIG_DIR/logs)을 그대로 따른다
+    log_dir = os.path.join(config.CONFIG_DIR, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+
+    formatter = logging.Formatter(LOG_FORMAT)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        os.path.join(log_dir, LOG_FILE_NAME),
+        maxBytes=MAX_BYTES,
+        backupCount=BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+    # 서드파티 라이브러리의 과도한 DEBUG 출력은 억제한다
+    # (다운로드 시 요청 1건마다 urllib3 로그가 쌓여 로그가 불어나는 것 방지)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    _configured = True

--- a/content/widget.py
+++ b/content/widget.py
@@ -8,6 +8,9 @@ from ui.contentItemWidget import Ui_ContentItemWidget
 from io import BytesIO
 from time import strftime, gmtime
 import platform
+import logging
+
+logger = logging.getLogger(__name__)
 
 class ContentItemWidget(QWidget, Ui_ContentItemWidget):
     """컨텐츠 정보를 표시하는 커스텀 위젯"""
@@ -150,7 +153,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
             )
             label.setPixmap(scaled_image)
         except Exception as e:
-            print(f"Error loading image from {url}: {e}")
+            logger.error(f"Error loading image from {url}: {e}")
 
     def setData(self, item: ContentItem, index: int):
         """✅ 모델 데이터를 위젯에 반영"""

--- a/download/logger.py
+++ b/download/logger.py
@@ -39,24 +39,19 @@ class DownloadLogger:
         for handler in self.logger.handlers[:]:
             self.logger.removeHandler(handler)
         
-        # 파일 핸들러 설정
+        # 파일 핸들러 설정 (다운로드 전용 로그 파일)
         file_handler = logging.FileHandler(self.log_file, encoding='utf-8')
         file_handler.setLevel(self.log_level)
-        
-        # 콘솔 핸들러 설정
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(self.log_level)
-        
+
         # 포맷터 설정
         formatter = logging.Formatter(
             '%(asctime)s - %(levelname)s - [%(threadName)s] - %(message)s'
         )
         file_handler.setFormatter(formatter)
-        console_handler.setFormatter(formatter)
-        
-        # 핸들러 추가
+
+        # 핸들러 추가 — 콘솔 출력은 자체 핸들러 대신 공통 로깅 설정(루트 로거,
+        # config/log_setup.py)으로 전파되어 처리된다 (#30)
         self.logger.addHandler(file_handler)
-        self.logger.addHandler(console_handler)
 
     def save_and_close(self):
         """

--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
 import sys
 import os
+import logging
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 from PySide6.QtCore import QTranslator, QLocale
 
 from application.mainWindow import VodDownloader
 import config.config as config
+from config.log_setup import setup_logging
+
+logger = logging.getLogger(__name__)
 
 def resource_path(relative_path):
     """Get absolute path to resource, works for dev and for PyInstaller"""
@@ -13,7 +17,7 @@ def resource_path(relative_path):
         # PyInstaller creates a temp folder and stores path in _MEIPASS
         base_path = sys._MEIPASS
     except Exception:
-        print("sys._MEIPASS not found")
+        logger.debug("sys._MEIPASS not found")
         base_path = os.path.abspath(".")
     
     return os.path.join(base_path, relative_path)
@@ -23,21 +27,21 @@ def set_language(app_config, translator):
     # 1. 설정 파일에서 언어 가져오기
     language = app_config.get('language')
     is_language_in_config = language is not None
-    print("config_language :", language)
-    print("is_language_in_config :", is_language_in_config)
-    
+    logger.debug("config_language : %s", language)
+    logger.debug("is_language_in_config : %s", is_language_in_config)
+
     if not is_language_in_config:
         # 설정 파일에 언어가 없는 경우 시스템 언어 사용
         language = QLocale.system().name()
-        print("local_language :", language)
-    
+        logger.debug("local_language : %s", language)
+
     # 2. 번역 파일 로드 시도
     translation_file = resource_path(f"translations/{language}.qm")
-    print(f"translation_file path: {translation_file}")
-    print("translation_file :", os.path.exists(translation_file))
+    logger.debug(f"translation_file path: {translation_file}")
+    logger.debug("translation_file : %s", os.path.exists(translation_file))
 
     if os.path.exists(translation_file) and translator.load(translation_file):
-        print("translation file load success")
+        logger.info("translation file load success")
         # 번역 파일 로드 성공   
         app.installTranslator(translator)
         
@@ -46,7 +50,7 @@ def set_language(app_config, translator):
             app_config['language'] = language
             config.save_config(app_config)
     else:
-        print("translation file load failed")
+        logger.warning("translation file load failed")
         # 번역 파일 로드 실패 -> 기본 언어(en_US) 사용
         language = "en_US"
         if translator.load(f"translations/{language}.qm"):
@@ -57,6 +61,9 @@ def set_language(app_config, translator):
 
 
 if __name__ == '__main__':
+    # 공통 로깅 설정 (콘솔 + logs/ 회전 파일)
+    setup_logging()
+
     app = QApplication(sys.argv)
 
     # 설정 파일 로드

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -1,0 +1,73 @@
+"""config.log_setup 공통 로깅 설정 단위 테스트 (#30)."""
+
+import logging
+import logging.handlers
+
+import pytest
+
+import config.config
+import config.log_setup as log_setup
+
+
+@pytest.fixture
+def isolated_logging(monkeypatch, tmp_path):
+    """로그 저장 위치를 임시 경로로 돌리고, 테스트 후 루트 로거 상태를 복원한다."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+
+    monkeypatch.setattr(config.config, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(log_setup, "_configured", False)
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    yield tmp_path
+
+    # setup_logging이 추가한 핸들러를 닫고 원래 핸들러·레벨을 복원한다
+    for handler in root.handlers[:]:
+        handler.close()
+        root.removeHandler(handler)
+    for handler in saved_handlers:
+        root.addHandler(handler)
+    root.setLevel(saved_level)
+
+
+def test_setup_adds_console_and_rotating_file_handlers(isolated_logging):
+    """루트 로거에 콘솔 핸들러와 회전 파일 핸들러가 각각 1개씩 연결된다."""
+    # pytest 로깅 플러그인이 끼워 넣는 캡처 핸들러를 제외하기 위해 전후 차집합으로 비교한다
+    before = set(logging.getLogger().handlers)
+
+    log_setup.setup_logging()
+
+    added = [h for h in logging.getLogger().handlers if h not in before]
+    rotating = [
+        h for h in added if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    consoles = [
+        h
+        for h in added
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    ]
+    assert len(rotating) == 1
+    assert len(consoles) == 1
+
+
+def test_log_message_is_written_to_logs_file(isolated_logging):
+    """모듈 로거로 남긴 메시지가 logs/app.log 파일에 기록된다."""
+    log_setup.setup_logging()
+
+    logging.getLogger("smoke.test").info("hello log file")
+
+    log_file = isolated_logging / "logs" / log_setup.LOG_FILE_NAME
+    assert log_file.exists()
+    assert "hello log file" in log_file.read_text(encoding="utf-8")
+
+
+def test_setup_logging_is_idempotent(isolated_logging):
+    """setup_logging을 여러 번 호출해도 핸들러가 중복 추가되지 않는다."""
+    log_setup.setup_logging()
+    handler_count = len(logging.getLogger().handlers)
+
+    log_setup.setup_logging()
+
+    assert len(logging.getLogger().handlers) == handler_count


### PR DESCRIPTION
## 관련 이슈

Closes #30

## 변경 내용

- **공통 로깅 설정 모듈 신규** (`config/log_setup.py`): `setup_logging()`이 루트 로거에 콘솔 핸들러 + 회전 파일 핸들러(`logs/app.log`, 1MB × 백업 5개)를 연결. 포맷은 `시간 - 레벨 - [모듈] - 메시지`. 중복 호출 가드 포함. 각 모듈은 `logging.getLogger(__name__)`만 사용하고 핸들러 구성은 이 모듈이 전담. 다운로드 시 요청 1건마다 로그가 불어나는 것을 막기 위해 urllib3 로거는 WARNING으로 억제
- **print() 15건 → logging 교체** (메시지 원문 유지, 로직 무변경):
  - `main.py` 8건 — 디버그성 출력(언어·번역 파일 경로 등) → `debug`, 로드 성공 → `info`, 로드 실패 → `warning`. 앱 시작 시 `setup_logging()` 호출 추가
  - `config/config.py` 4건 — 설정 파일 읽기 오류 → `error`, 마이그레이션·최신 상태 안내 → `info`
  - `application/mainWindow.py` 2건 — 절전/종료 미지원 OS 안내 → `warning`
  - `content/widget.py` 1건 — 썸네일 로드 실패 → `error`
  - 주석 처리된 `# print(...)` 디버깅 흔적은 조건(주석 제외)대로 건드리지 않음
- **`download/logger.py` 핸들러 연결만 조정**: 자체 콘솔 핸들러를 제거하고 루트 로거로의 전파(propagation)에 맡김 — 공통 설정 도입 후 자체 핸들러를 남기면 콘솔에 이중 출력되기 때문. 다운로드 전용 로그 파일(`download_<timestamp>.log`)과 클래스 구조·포맷은 무변경
- **단위 테스트** (`tests/unit/test_log_setup.py`): 핸들러 구성(콘솔+회전 파일 각 1개), logs/ 파일 기록, 중복 초기화 방지를 검증. 로그 위치는 tmp_path로 격리하고 테스트 후 루트 로거 상태 복원

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 42 passed (기존 39 + 신규 3)
- [x] 새 로직에 대한 테스트 추가됨 — log_setup 단위 테스트 3건
- [x] 소스 전체 print() 호출 0건 — 주석 제외 grep 기준 확인
- [x] 앱 실행 시 `logs/app.log` 생성 확인 — 콘솔과 파일에 동일 내용, 시간·레벨·모듈·메시지 포맷
- [x] `uv run python main.py` 스모크 정상 — GUI 정상 구동
- [x] **다운로드 1회 포함 스모크** — 공개 클립(36초, 4.7MB)을 앱의 실제 파이프라인(NetworkManager → DownloadTask → DownloadThread)으로 다운로드. 크기 일치(4,722,762 bytes), 1.46초 완료. DownloadLogger 출력이 이중 출력 없이 콘솔·app.log·전용 다운로드 로그 파일에 정상 기록됨. 검증 후 다운로드 파일은 삭제

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음 (채널 교체만)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #30 (approved, 로깅 설정 모듈 신규 1개 명시)

## 리뷰어에게

- 새 모듈 위치는 `config/log_setup.py`로 했습니다. 로그 저장 위치가 기존 규칙(`CONFIG_DIR/logs`)을 따르는 만큼 설정 관련 모듈과 같은 곳이 자연스럽고, `config.config`를 import하므로 순환 없이 배치됩니다.
- 루트 로거 기본 레벨은 DEBUG입니다(기존 print가 전부 보이던 것과 동일하게 유지). 배포판에서 레벨을 낮추는 것은 후속 이슈에서 config.json 옵션으로 다루면 됩니다.
- `download/logger.py`의 콘솔 핸들러 제거는 "핸들러 연결만 조정"의 범위입니다 — 남겨두면 루트 핸들러와 이중으로 콘솔에 찍힙니다. 전용 파일 로그는 기존 포맷([threadName] 포함) 그대로입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
