### PR TITLE
refactor: requests.Session 도입 — 연결 재사용 (Phase 1)

### DIFF
--- a/content/network.py
+++ b/content/network.py
@@ -1,12 +1,48 @@
 import re
 import requests
 import json
+import threading
+from http.cookiejar import DefaultCookiePolicy
 from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
 
 NAVER_API = "https://apis.naver.com"
 CHZZK_API = "https://api.chzzk.naver.com"
 VIDEOHUB_API = "https://api-videohub.naver.com"
+
+
+def _make_session() -> requests.Session:
+    """연결 재사용용 Session을 만든다 (#31).
+
+    기존에는 매 호출 requests.get()이 독립적이라 응답의 Set-Cookie가 다음 요청으로
+    이어지지 않았다. 이 이슈는 연결 재사용만 도입하므로, 응답 쿠키 저장을 차단해
+    쿠키 동작을 기존과 동일하게 유지한다. 요청별 cookies= 인자는 그대로 전송된다.
+    """
+    session = requests.Session()
+    session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
+    return session
+
+
+# NetworkManager API 호출용 모듈 수준 공유 세션.
+# 응답 쿠키를 저장하지 않으므로 여러 스레드에서 호출해도 상태 공유 문제가 없다.
+_session = _make_session()
+
+# 다운로드 워커용 스레드로컬 세션 저장소
+_thread_local = threading.local()
+
+
+def get_thread_session() -> requests.Session:
+    """호출한 스레드 전용 Session을 반환한다 (없으면 생성).
+
+    requests.Session은 스레드 간 완전한 안전이 보장되지 않으므로, 다운로드 워커처럼
+    동시 요청이 많은 경로는 스레드마다 별도 Session을 사용해 연결 재사용만 취한다.
+    """
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = _make_session()
+        _thread_local.session = session
+    return session
+
 
 class NetworkManager:
 
@@ -35,7 +71,7 @@ class NetworkManager:
         """
         api_url = f"{CHZZK_API}/service/v2/videos/{video_no}"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = requests.get(api_url, cookies=cookies, headers=headers)
+        response = _session.get(api_url, cookies=cookies, headers=headers)
         response.raise_for_status()
 
         content = response.json().get('content', {})
@@ -63,7 +99,7 @@ class NetworkManager:
         """
         manifest_url = f"{NAVER_API}/neonplayer/vodplay/v2/playback/{video_id}?key={in_key}"
         headers = {"Accept": "application/dash+xml"}
-        response = requests.get(manifest_url, headers=headers)
+        response = _session.get(manifest_url, headers=headers)
         response.raise_for_status()
 
         root = ET.fromstring(response.text)
@@ -116,7 +152,7 @@ class NetworkManager:
         data = json.loads(json_str)
         media = data.get("media", [])
         path = media[0].get("path")
-        response = requests.get(path)
+        response = _session.get(path)
         response.raise_for_status()
         content = response.text.splitlines()
 
@@ -139,7 +175,7 @@ class NetworkManager:
         """
         api_url = f"{CHZZK_API}/service/v1/clips/{clip_no}/detail?optionalProperties=OWNER_CHANNEL"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = requests.get(api_url, cookies=cookies, headers=headers)
+        response = _session.get(api_url, cookies=cookies, headers=headers)
         response.raise_for_status()
 
         content = response.json().get('content', {})
@@ -164,7 +200,7 @@ class NetworkManager:
         """
         manifest_url = f"{VIDEOHUB_API}/shortformhub/feeds/v3/card?serviceType=CHZZK&seedMediaId={clip_id}&mediaType=VOD"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = requests.get(manifest_url, cookies=cookies, headers=headers)
+        response = _session.get(manifest_url, cookies=cookies, headers=headers)
         response.raise_for_status()
 
         data = response.json()

--- a/content/widget.py
+++ b/content/widget.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QWidget, QPushButton, QMessageBox
 from PySide6.QtGui import QPixmap, QDesktopServices
 from PySide6.QtCore import Qt, QSize, Signal, QUrl, QDir, QProcess
 from content.data import ContentItem
+from content.network import get_thread_session
 from download.state import DownloadState
 from ui.contentItemWidget import Ui_ContentItemWidget
 from io import BytesIO
@@ -79,11 +80,11 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         def update_button_text():
             try:
                 if self.item.content_type != "m3u8":
-                    resp = requests.head(base_url)
+                    resp = get_thread_session().head(base_url)
                     resp.raise_for_status()
                     size = int(resp.headers.get('content-length', 0))
                     if size == 0:
-                        resp = requests.get(base_url, stream=True)
+                        resp = get_thread_session().get(base_url, stream=True)
                         resp.raise_for_status()
                         size = int(resp.headers.get('content-length', 0))
                         resp.close()
@@ -128,7 +129,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
     def fetchImage(self, label, url, maxHeight, type):
         try:
-            response = requests.get(url)
+            response = get_thread_session().get(url)
             response.raise_for_status()
             image = QPixmap()
             image.loadFromData(response.content)

--- a/download/download.py
+++ b/download/download.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import QThread, Signal
 from concurrent.futures import ThreadPoolExecutor
 from download.task import DownloadTask
 from download.state import DownloadState
+from content.network import get_thread_session
 
 
 def decide_part_size(content_type: str, resolution: int) -> int:
@@ -143,7 +144,8 @@ class DownloadThread(QThread):
         while not self.task.state == DownloadState.WAITING:
             try:
                 headers = {'Range': f'bytes={start}-{end}'}
-                response = requests.get(self.s.base_url, headers=headers, stream=True, timeout=30)
+                # 스레드로컬 세션으로 같은 워커의 반복 요청 간 연결을 재사용한다 (#31)
+                response = get_thread_session().get(self.s.base_url, headers=headers, stream=True, timeout=30)
                 response.raise_for_status()
                 part_start_time = tm.time()
 
@@ -243,11 +245,11 @@ class DownloadThread(QThread):
         """
         HEAD 요청으로 total_size를 구한다.
         """
-        response = requests.head(self.s.base_url)
+        response = get_thread_session().head(self.s.base_url)
         response.raise_for_status()
         size = int(response.headers.get('content-length', 0))
         if size == 0:
-            resp = requests.get(self.s.base_url, stream=True)
+            resp = get_thread_session().get(self.s.base_url, stream=True)
             resp.raise_for_status()
             size = int(resp.headers.get('content-length', 0))
             resp.close()

--- a/download/download_m3u8.py
+++ b/download/download_m3u8.py
@@ -10,7 +10,7 @@ from PySide6.QtCore import QThread, Signal
 from concurrent.futures import ThreadPoolExecutor
 from download.task import DownloadTask
 from download.state import DownloadState
-from content.network import NetworkManager
+from content.network import NetworkManager, get_thread_session
 
 class DownloadM3U8Thread(QThread):
     """
@@ -44,7 +44,7 @@ class DownloadM3U8Thread(QThread):
             threading.current_thread().name = "DownloadM3U8Thread"  # 스레드 시작 시 이름 재설정
             self.s.start_time = tm.time()
 
-            response = requests.get(self.s.base_url)
+            response = get_thread_session().get(self.s.base_url)
             response.raise_for_status()
             lines = response.text.splitlines()
             segments = [line for line in lines if line and not line.startswith("#")]
@@ -73,7 +73,7 @@ class DownloadM3U8Thread(QThread):
             init_segment_path = os.path.join(self.temp_dir, f"{0:0{self.width}d}.m4s")
             # 초기화 세그먼트 다운로드
             with open(init_segment_path, 'wb') as f:
-                f.write(requests.get(init_url).content)
+                f.write(get_thread_session().get(init_url).content)
 
             with ThreadPoolExecutor(max_workers=self.s.max_threads, thread_name_prefix="DownloadM3U8Worker") as executor:
                 self.s.remaining_ranges = list(enumerate(segments))
@@ -170,7 +170,8 @@ class DownloadM3U8Thread(QThread):
         segment_url = urljoin(self.s.base_url, segment)
         while not self.task.state == DownloadState.WAITING:
             try:
-                response = requests.get(segment_url, stream=True, timeout=30)
+                # 스레드로컬 세션으로 같은 워커의 세그먼트 요청 간 연결을 재사용한다 (#31)
+                response = get_thread_session().get(segment_url, stream=True, timeout=30)
                 response.raise_for_status()
                 part_start_time = tm.time()
 

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -46,14 +46,14 @@ class TestGetVideoDashManifest:
     """NetworkManager.get_video_dash_manifest의 XML 파싱 결과 박제 (HTTP는 mock)."""
 
     def _patch_get(self, monkeypatch: pytest.MonkeyPatch, xml_text: str) -> list:
-        """content.network.requests.get을 목으로 바꾸고 호출 기록 리스트를 반환한다."""
+        """공유 세션(network._session)의 get을 목으로 바꾸고 호출 기록 리스트를 반환한다."""
         calls = []
 
         def fake_get(url, **kwargs):
             calls.append((url, kwargs))
             return MockResponse(text=xml_text)
 
-        monkeypatch.setattr(network.requests, "get", fake_get)
+        monkeypatch.setattr(network._session, "get", fake_get)
         return calls
 
     def test_parses_sorts_and_skips_hls(self, monkeypatch, load_mock_response):

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -1,0 +1,71 @@
+"""content.network의 Session 도입(연결 재사용) 단위 테스트 (#31)."""
+
+import threading
+
+import requests
+
+import content.network as network
+
+
+def test_module_session_is_a_requests_session():
+    """API 호출용 모듈 수준 공유 세션이 requests.Session이어야 한다."""
+    assert isinstance(network._session, requests.Session)
+
+
+def test_thread_session_is_reused_within_same_thread():
+    """같은 스레드에서 get_thread_session은 항상 같은 Session을 돌려준다."""
+    first = network.get_thread_session()
+    second = network.get_thread_session()
+
+    assert isinstance(first, requests.Session)
+    assert first is second
+
+
+def test_thread_session_is_distinct_across_threads():
+    """다른 스레드에서는 별도의 Session이 생성된다 (스레드 안전성 확보 방식)."""
+    main_session = network.get_thread_session()
+    other_sessions = []
+
+    def worker():
+        other_sessions.append(network.get_thread_session())
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+
+    assert len(other_sessions) == 1
+    assert isinstance(other_sessions[0], requests.Session)
+    assert other_sessions[0] is not main_session
+
+
+def test_session_does_not_store_response_cookies():
+    """응답의 Set-Cookie가 세션에 저장되지 않아야 한다 (기존 동작 유지).
+
+    쿠키 차단 정책이 적용된 세션은 어떤 도메인의 쿠키도 저장(set_ok)하지 않는다.
+    """
+    from http.cookiejar import Cookie
+    from urllib.request import Request
+
+    policy = network._make_session().cookies.get_policy()
+
+    cookie = Cookie(
+        version=0,
+        name="NID_AUT",
+        value="dummy",
+        port=None,
+        port_specified=False,
+        domain="api.chzzk.naver.com",
+        domain_specified=False,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=False,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={},
+    )
+    request = Request("https://api.chzzk.naver.com/service")
+
+    assert policy.set_ok(cookie, request) is False


### PR DESCRIPTION
## 관련 이슈

Closes #31

## 변경 내용

- **`content/network.py`** — 모듈 수준 공유 세션 `_session` 도입, NetworkManager의 API 호출 5건 전부 교체. 요청 파라미터(헤더·쿠키·타임아웃)는 호출부마다 기존 그대로 유지
- **`download/download.py` / `download/download_m3u8.py`** — 워커의 범위/세그먼트 요청, HEAD 크기 조회, 플레이리스트·초기화 세그먼트 요청을 스레드로컬 세션(`get_thread_session()`) 경유로 교체
- **`content/widget.py`** — 파일 크기 조회(head/get)·썸네일 로드 3건도 스레드로컬 세션으로 교체. 이슈 작업 범위에는 명시돼 있지 않지만, 완료 조건인 "직접 호출 0건" grep에 걸리는 잔여 호출이라 최소한으로 포함했습니다 (ad-hoc 데몬 스레드에서 실행되므로 스레드로컬 방식이 맞음)
- **테스트** — 기존 DASH 매니페스트 테스트의 monkeypatch 대상만 `network._session.get`으로 조정(기대값 무변경), 세션 동작 검증 테스트 4건 신규(`tests/unit/test_network_session.py`)

## 스레드 안전성: 선택한 방식과 근거

**다운로드 워커: 스레드로컬 세션(`threading.local`)**
- `requests.Session`은 커넥션 풀(urllib3)은 스레드 안전하지만 쿠키 저장소 등 세션 상태의 동시 변경은 안전이 보장되지 않습니다.
- 다운로드 워커는 같은 스레드에서 같은 호스트로 반복 요청하는 패턴이라, 스레드마다 세션 1개면 keep-alive 이득을 온전히 얻으면서 스레드 간 상태 공유가 아예 없어 경합 자체가 성립하지 않습니다.
- 전역 락 방식은 다운로드 병렬성을 해치고, 세션 1개 공유 방식은 쿠키 저장소 경합 우려가 있어 배제했습니다.

**API 호출(NetworkManager): 모듈 수준 공유 세션** (이슈에서 허용된 방식)
- 추가로 **응답 쿠키 저장을 차단**했습니다(`DefaultCookiePolicy(allowed_domains=[])`). 기존에는 매 호출이 독립적이라 응답의 Set-Cookie가 다음 요청으로 이어지지 않았는데, 세션 도입으로 이 동작이 바뀌면 "쿠키는 기존과 동일하게 유지" 조건에 위배되고, 스레드 간 쿠키 상태 공유 문제도 생기기 때문입니다. 요청별 `cookies=` 인자는 기존대로 전송됩니다(단위 테스트로 차단 동작 검증).

## 검증

- [x] `requests.get(`/`requests.post(` 직접 호출 0건 — grep 기준 (docstring 내 언급 1건만 잔존, `requests.head` 포함 전부 세션 경유)
- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 46 passed (기존 42 + 신규 4). 기존 mock 테스트는 mock 대상만 조정, 기대값 무변경
- [x] **스모크: 실제 VOD 1건 다운로드 정상 완료** — 공개 VOD(28초)를 앱의 실제 m3u8 파이프라인(NetworkManager → DownloadM3U8Thread, 세그먼트 14개 병렬 다운로드)으로 다운로드 완료(692,653 bytes). API·매니페스트는 공유 세션, 세그먼트 워커는 스레드로컬 세션 사용 확인. 검증 후 파일 삭제
- [x] `uv run python main.py` 구동 스모크 정상 (widget.py 변경 반영 확인)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — widget.py는 기존에도 requests를 직접 쓰던 코드로, 호출 채널만 교체 (viewmodel 구조는 Phase 2+ 범위)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #31 (approved)

## 리뷰어에게

- 스모크 중 발견한 기존 이슈(이 PR과 무관, 수정 안 함): 일부 VOD의 DASH 매니페스트에 width/height 속성이 없는 Representation(오디오 전용 추정)이 있으면 `get_video_dash_manifest`가 `TypeError`로 실패합니다 (예: videoNo 14158884). 별도 이슈로 제보할 가치가 있어 보이면 말씀 주세요 — 원하시면 재현 정보를 정리해 이슈로 올리겠습니다.
- `requests` import는 예외 타입(`requests.RequestException` 등) 참조를 위해 각 파일에 그대로 남아 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
