### PR TITLE
fix: ruff 베이스라인 해소 — per-file-ignores 제거 (Phase 1)

### DIFF
--- a/config/dialog.py
+++ b/config/dialog.py
@@ -1,7 +1,6 @@
 import os
 import config.config as config
 from PySide6.QtWidgets import QDialog, QMessageBox
-from PySide6.QtCore import Signal
 
 from ui.settingDialog import Ui_SettingDialog
 

--- a/content/manager.py
+++ b/content/manager.py
@@ -1,4 +1,4 @@
-import os, re, platform
+import os
 
 from PySide6.QtCore import Qt, Signal, QThreadPool, QObject
 from content.model import ContentListModel
@@ -152,6 +152,6 @@ class ContentManager(QObject):
         for row in range(row_count):
             index = self.model.index(row, 0)
             item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-            if not item.downloadState in [DownloadState.FINISHED, DownloadState.FAILED]:
+            if item.downloadState not in [DownloadState.FINISHED, DownloadState.FAILED]:
                 return True, item, index
         return False, None, None

--- a/content/widget.py
+++ b/content/widget.py
@@ -1,4 +1,5 @@
-import os, requests, threading
+import os
+import threading
 from PySide6.QtWidgets import QWidget, QPushButton, QMessageBox
 from PySide6.QtGui import QPixmap, QDesktopServices
 from PySide6.QtCore import Qt, QSize, Signal, QUrl, QDir, QProcess
@@ -6,7 +7,6 @@ from content.data import ContentItem
 from content.network import get_thread_session
 from download.state import DownloadState
 from ui.contentItemWidget import Ui_ContentItemWidget
-from io import BytesIO
 from time import strftime, gmtime
 import platform
 import logging
@@ -95,7 +95,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
                 if len(self.item.unique_reps) - 1 == index:
                     self.setresolutionUrlSize(resolution, base_url, index, button)
 
-            except Exception as e:
+            except Exception:
                 pass
 
         thread = threading.Thread(target=update_button_text, daemon=True)

--- a/download/data.py
+++ b/download/data.py
@@ -1,6 +1,4 @@
-import os
 import threading
-import config.config as config
 
 class DownloadData:
     def __init__(self, base_url, vod_url, output_path, resolution, content_type):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,17 +20,11 @@ dev = [
 line-length = 100
 target-version = "py313"
 
-# Phase 0 베이스라인: 기존 코드의 위반은 이 단계에서 고치지 않는다 (#26).
-# 아래 파일별 예외는 후속 이슈에서 코드 정리와 함께 점진적으로 제거한다.
-# F401(미사용 import), E401(한 줄 다중 import), E713(not-in 표현), F841(미사용 변수)
 [tool.ruff.lint.per-file-ignores]
-"config/dialog.py" = ["F401"]                   # F401 1건
-"content/manager.py" = ["E401", "E713", "F401"] # E401 1건, E713 1건, F401 2건
-"content/widget.py" = ["E401", "F401", "F841"]  # E401 1건, F401 1건, F841 1건
-"download/data.py" = ["F401"]                   # F401 2건
-"ui/contentItemWidget.py" = ["F401"]            # F401 26건
-"ui/mainWindow.py" = ["F401"]                   # F401 28건
-"ui/settingDialog.py" = ["F401"]                # F401 30건
+# ui/*.py는 pyside6-uic 자동 생성 파일(.ui 원본 존재)이다. 수동으로 미사용 import를
+# 지워도 재생성 시 되살아나므로 F401 예외를 유지한다 (#32). 손으로 작성한 파일의
+# 예외는 전부 해소되어 제거됨.
+"ui/*.py" = ["F401"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## 관련 이슈

Closes #32

## 변경 내용

per-file-ignores 목록(#26에서 잡은 베이스라인)을 해소했습니다. `ruff check --fix`(이슈에서 허용)로 수정한 뒤 diff를 전건 검토했습니다.

**손으로 작성한 4개 파일 — 위반 11건 전부 수정, 예외 항목 삭제**
- `config/dialog.py`: 미사용 `Signal` import 삭제 (F401)
- `content/manager.py`: `import os, re, platform` → 미사용 `re`/`platform` 삭제·분리 (E401+F401×2), `not x in` → `x not in` (E713)
- `content/widget.py`: 미사용 `requests`(#31에서 세션 전환 후 미사용화)·`BytesIO` 삭제, import 분리 (E401+F401×2), `except Exception as e:` → `except Exception:` (F841)
- `download/data.py`: 미사용 `os`·`config.config` 삭제 (F401×2)

**잔여 항목과 사유 (완료 조건의 명시 경로)**
- `"ui/*.py" = ["F401"]` 한 줄만 유지 — `ui/contentItemWidget.py`·`ui/mainWindow.py`·`ui/settingDialog.py`(F401 합계 84건)는 **pyside6-uic 자동 생성 파일**입니다(.ui 원본 존재, 파일 헤더에 "recompiling 시 변경 소실" 경고). 수동으로 미사용 import를 지워도 `.ui` 재컴파일 시 전부 되살아나 린트 게이트가 다시 깨지므로, 생성 코드에 대한 표준 관행대로 F401 예외를 glob 한 줄로 유지했습니다. 개별 파일 3항목 → glob 1항목으로 축소되어 기술 부채 장부는 손으로 쓴 코드 기준 완전 해소입니다.

**사이드이펙트 검토** (이슈 제안 4항)
- 삭제한 import는 전부 stdlib(`os`, `re`, `platform`, `BytesIO`) 또는 이미 다른 모듈이 독립적으로 import하는 것(`requests`, `config.config`)으로, import 시점 사이드이펙트에 의존하는 코드가 없음을 확인했습니다. 동작 변경으로 수정을 보류한 항목은 없습니다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 46 passed
- [x] `uv run python main.py` 스모크 정상 (구동·로그 출력 확인)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — 해당 없음 (import·표현식 정리만, 로직 무변경)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #32 (approved)

## 리뷰어에게

- ui/*.py 예외 유지가 "완전 제거" 목표와 다른 유일한 지점입니다. 완전 제거를 원하시면 (a) 생성 파일도 직접 수정(재생성 시 재발), (b) uic 재생성 파이프라인에 후처리 추가(별도 이슈 필요) 중 선택이 필요합니다 — 지시 주시면 반영하겠습니다.
- `content/manager.py` 끝의 "No newline at end of file"은 기존 상태 그대로입니다 (W292는 현재 규칙 세트에 없어 손대지 않았습니다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
