### PR TITLE
feat: URL 파싱 허용 범위 개선 — 쿼리스트링·후행 슬래시·www (Phase 1)

### DIFF
--- a/content/network.py
+++ b/content/network.py
@@ -50,16 +50,24 @@ class NetworkManager:
     def extract_content_no(vod_url: str) -> tuple[str, str]:
         """
         치지직 VOD URL에서 type과 content_no를 추출한다.
-        
+
+        브라우저 주소창에서 그대로 복사한 URL 변형을 허용한다 (#33):
+        쿼리스트링(`?t=123` 등)은 무시하고, 후행 슬래시와 www 서브도메인을 허용한다.
+        live URL·다른 도메인·형식이 깨진 URL은 계속 거부한다.
+
         Args:
             vod_url (str): 치지직 VOD URL
-            
+
         Returns:
             tuple[str, str]: (type, content_no) 형식의 튜플. 매칭되지 않으면 (None, None) 반환
         """
         if not vod_url.startswith("http://") and not vod_url.startswith("https://"):
             vod_url = "https://" + vod_url
-        match = re.fullmatch(r'https?://chzzk\.naver\.com/(?P<content_type>video|clips)/(?P<content_no>\w+)', vod_url)
+        match = re.fullmatch(
+            r'https?://(?:www\.)?chzzk\.naver\.com'
+            r'/(?P<content_type>video|clips)/(?P<content_no>\w+)/?(?:\?.*)?',
+            vod_url,
+        )
         if match:
             return match.group("content_type"), match.group("content_no")
         return None, None

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1,7 +1,7 @@
-"""content.network의 URL 파싱·DASH 매니페스트 파싱 박제 테스트.
+"""content.network의 URL 파싱·DASH 매니페스트 파싱 테스트.
 
-목적은 "올바른 동작" 검증이 아니라 현재 동작의 보존이다 (#27).
-현재 결과가 이상해 보여도 그 결과 그대로를 기대값으로 삼는다.
+- URL 파싱(TestExtractContentNo): #33에서 허용 범위를 넓힌 **요구 동작 검증** 테스트다.
+- DASH 매니페스트 파싱(TestGetVideoDashManifest): #27의 현재 동작 보존(박제) 테스트다.
 """
 
 import pytest
@@ -12,12 +12,16 @@ from tests.mocks.mock_http import MockResponse
 
 
 class TestExtractContentNo:
-    """NetworkManager.extract_content_no의 (type, content_no) 결과 박제."""
+    """NetworkManager.extract_content_no의 요구 동작 검증 (#33).
+
+    브라우저 주소창을 그대로 복사한 URL 변형(쿼리스트링·후행 슬래시·www)은 허용하고,
+    live URL·다른 도메인·형식이 깨진 URL은 거부해야 한다.
+    """
 
     @pytest.mark.parametrize(
         ("vod_url", "expected"),
         [
-            # 정상 케이스: video / clips, 스킴 유무
+            # 기본 형태: video / clips, 스킴 유무
             ("https://chzzk.naver.com/video/1510760", ("video", "1510760")),
             ("http://chzzk.naver.com/video/1510760", ("video", "1510760")),
             ("chzzk.naver.com/video/1510760", ("video", "1510760")),
@@ -25,20 +29,32 @@ class TestExtractContentNo:
             ("chzzk.naver.com/clips/abcDEF12345", ("clips", "abcDEF12345")),
             # content_no는 \w+ 이므로 언더스코어는 허용된다
             ("https://chzzk.naver.com/clips/abc_123", ("clips", "abc_123")),
-            # 경계 케이스: 현재 구현은 fullmatch라서 아래는 전부 (None, None)
-            ("https://chzzk.naver.com/video/1510760?t=120", (None, None)),  # 쿼리스트링
-            ("https://chzzk.naver.com/video/1510760/", (None, None)),  # 후행 슬래시
-            ("https://chzzk.naver.com/clips/abc-def", (None, None)),  # 하이픈은 \w 미포함
-            ("https://chzzk.naver.com/live/channelid00", (None, None)),  # live는 미지원
+            # 쿼리스트링은 무시하고 파싱한다 (#33)
+            ("https://chzzk.naver.com/video/1510760?t=120", ("video", "1510760")),
+            ("https://chzzk.naver.com/video/1510760?t=120&utm_source=share", ("video", "1510760")),
+            ("https://chzzk.naver.com/clips/abcDEF12345?sharePlatform=web", ("clips", "abcDEF12345")),
+            ("chzzk.naver.com/video/1510760?t=120", ("video", "1510760")),  # 스킴 생략 + 쿼리
+            # 후행 슬래시를 허용한다 (#33)
+            ("https://chzzk.naver.com/video/1510760/", ("video", "1510760")),
+            ("https://chzzk.naver.com/video/1510760/?t=120", ("video", "1510760")),  # 슬래시+쿼리
+            # www 서브도메인을 허용한다 (#33)
+            ("https://www.chzzk.naver.com/video/1510760", ("video", "1510760")),
+            ("https://www.chzzk.naver.com/clips/abcDEF12345/", ("clips", "abcDEF12345")),
+            # 계속 거부: live URL (녹화 기능 전까지 미지원)
+            ("https://chzzk.naver.com/live/channelid00", (None, None)),
+            # 계속 거부: 다른 도메인·스킴
+            ("https://youtube.com/video/1510760", (None, None)),
+            ("https://mchzzk.naver.com/video/1510760", (None, None)),  # 유사 도메인
+            ("ftp://chzzk.naver.com/video/1510760", (None, None)),
+            # 계속 거부: 형식이 깨진 URL
             ("https://chzzk.naver.com/video/", (None, None)),  # content_no 누락
-            ("https://www.chzzk.naver.com/video/1510760", (None, None)),  # www 서브도메인
-            ("https://youtube.com/video/1510760", (None, None)),  # 다른 도메인
-            ("ftp://chzzk.naver.com/video/1510760", (None, None)),  # 다른 스킴
+            ("https://chzzk.naver.com/clips/abc-def", (None, None)),  # 하이픈은 \w 미포함
+            ("https://chzzk.naver.com/video/1510760//", (None, None)),  # 이중 슬래시
             ("", (None, None)),  # 빈 문자열
         ],
     )
     def test_extract_content_no(self, vod_url: str, expected: tuple):
-        """URL별 (type, content_no) 추출 결과를 현재 동작 그대로 고정한다."""
+        """URL별 (type, content_no) 추출 결과가 요구 동작과 일치해야 한다."""
         assert NetworkManager.extract_content_no(vod_url) == expected
 
 


### PR DESCRIPTION
## 관련 이슈

Closes #33

## 변경 내용

Phase 1에서 유일하게 **의도된 동작 변경**입니다. `extract_content_no`의 정규식을 확장해 브라우저 주소창에서 그대로 복사한 URL 변형을 허용하고, 박제 테스트를 기대값 변경 방식으로 요구 동작 검증 테스트로 전환했습니다.

- `content/network.py` — 정규식을 `https?://(?:www\.)?chzzk\.naver\.com/(video|clips)/(\w+)/?(?:\?.*)?` (fullmatch)로 확장. content_no 문자 규칙(`\w+`)과 반환 형식은 무변경
- `tests/unit/test_network.py` — TestExtractContentNo를 "현재 동작 박제"에서 "요구 동작 검증"으로 전환(클래스·테스트 docstring, 주석 갱신). 케이스 15종 → 22종

## 변경 전후 허용/거부 표

| URL 형태 | 예시 | 변경 전 | 변경 후 |
|---|---|---|---|
| 기본 video/clips | `chzzk.naver.com/video/1510760` | ✅ 허용 | ✅ 허용 |
| 스킴 생략 / http | `chzzk.naver.com/...`, `http://...` | ✅ 허용 | ✅ 허용 |
| **쿼리스트링** | `.../video/1510760?t=120&utm_source=share` | ❌ 거부 | ✅ **허용** (쿼리 무시) |
| **후행 슬래시** | `.../video/1510760/` (슬래시+쿼리 포함) | ❌ 거부 | ✅ **허용** |
| **www 서브도메인** | `www.chzzk.naver.com/video/1510760` | ❌ 거부 | ✅ **허용** |
| live URL | `.../live/channelid00` | ❌ 거부 | ❌ 거부 (녹화 기능 전까지 미지원) |
| 다른 도메인·유사 도메인 | `youtube.com/...`, `mchzzk.naver.com/...` | ❌ 거부 | ❌ 거부 |
| 다른 스킴 | `ftp://chzzk.naver.com/...` | ❌ 거부 | ❌ 거부 |
| content_no 누락 | `.../video/` | ❌ 거부 | ❌ 거부 |
| 하이픈 포함 id | `.../clips/abc-def` | ❌ 거부 | ❌ 거부 (`\w+` 규칙 무변경) |
| 이중 후행 슬래시 | `.../video/1510760//` | ❌ 거부 | ❌ 거부 |
| URL 프래그먼트 | `.../video/1510760#foo` | ❌ 거부 | ❌ 거부 (이슈 허용 목록 외) |

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 53 passed (URL 파싱 22케이스 포함)
- [x] 새 로직에 대한 테스트 추가됨 — 허용 3종(쿼리·슬래시·www) 각각 복수 케이스 + 거부 유지 케이스
- [x] **스모크: 쿼리스트링 붙은 실제 VOD URL로 다운로드 1회 정상** — `https://chzzk.naver.com/video/13977039?t=5&sharePlatform=web`(28초 공개 VOD)을 앱 파이프라인(NetworkManager → DownloadM3U8Thread)으로 파싱·다운로드 완료(692,653 bytes, #31 스모크와 동일 크기). 검증 후 파일 삭제

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #33 (approved, 의도된 동작 변경)

## 리뷰어에게

- 이슈의 허용 목록(쿼리스트링·후행 슬래시·www) 외에는 기존 거부를 유지했습니다. 특히 URL 프래그먼트(`#...`)와 하이픈 id는 허용 목록에 없어 거부 그대로이며, 필요해지면 별도 이슈로 다루는 게 맞다고 판단했습니다.
- 메모: 이 이슈로 Phase 1 이슈(#30~#33)가 전부 처리되었습니다. 이 PR이 머지되면 지시하신 대로 DASH 매니페스트 파서 버그(videoNo 14158884)를 bug 템플릿으로 등록하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
