### PR TITLE
fix: resource_path를 __file__ 기준으로 교체 — Nuitka onefile 번역 로드 (#43)

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,13 +49,11 @@ def set_language(app_config, translator):
             config.save_config(app_config)
     else:
         logger.warning("translation file load failed")
-        # 번역 파일 로드 실패 -> 기본 언어(en_US) 사용
+        # 번역 파일 로드 실패 -> 이번 실행에 한해 기본 언어(en_US) 사용.
+        # 실패는 일시적일 수 있으므로 유저가 저장한 language 설정은 덮어쓰지 않는다
         language = "en_US"
         if translator.load(resource_path(f"translations/{language}.qm")):
             app.installTranslator(translator)
-            # 기본 언어로 설정 저장
-            app_config['language'] = language
-            config.save_config(app_config)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -11,15 +11,13 @@ from config.log_setup import setup_logging
 
 logger = logging.getLogger(__name__)
 
-def resource_path(relative_path):
-    """Get absolute path to resource, works for dev and for PyInstaller"""
-    try:
-        # PyInstaller creates a temp folder and stores path in _MEIPASS
-        base_path = sys._MEIPASS
-    except Exception:
-        logger.debug("sys._MEIPASS not found")
-        base_path = os.path.abspath(".")
-    
+def resource_path(relative_path: str) -> str:
+    """소스 실행과 Nuitka onefile 빌드 양쪽에서 동작하는 리소스 절대 경로를 반환한다.
+
+    Nuitka onefile은 리소스를 임시 해제 경로에 풀고 __file__도 그 안을 가리키므로,
+    CWD가 아니라 이 파일의 위치를 기준으로 해석해야 한다 (#43).
+    """
+    base_path = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(base_path, relative_path)
 
 def set_language(app_config, translator):
@@ -53,7 +51,7 @@ def set_language(app_config, translator):
         logger.warning("translation file load failed")
         # 번역 파일 로드 실패 -> 기본 언어(en_US) 사용
         language = "en_US"
-        if translator.load(f"translations/{language}.qm"):
+        if translator.load(resource_path(f"translations/{language}.qm")):
             app.installTranslator(translator)
             # 기본 언어로 설정 저장
             app_config['language'] = language
@@ -74,7 +72,8 @@ if __name__ == '__main__':
     
     set_language(app_config, translator)
 
-    icon_path = os.path.join(os.path.dirname(__file__), 'resources', 'chzzk.ico')
+    # 아이콘도 번역과 같은 기준(__file__)으로 해석한다 (#43)
+    icon_path = resource_path('resources/chzzk.ico')
     app.setWindowIcon(QIcon(icon_path))
     # 메인 UI 실행
     ex = VodDownloader()

--- a/tests/unit/test_resource_path.py
+++ b/tests/unit/test_resource_path.py
@@ -1,0 +1,27 @@
+"""main.resource_path의 경로 해석 단위 테스트 (#43).
+
+Nuitka onefile 빌드에서는 CWD가 리소스 해제 경로와 무관하므로,
+리소스 경로는 CWD가 아닌 main.py(__file__) 위치 기준으로 해석되어야 한다.
+"""
+
+import os
+from pathlib import Path
+
+import main
+
+ROOT_DIR = Path(main.__file__).resolve().parent
+
+
+def test_resource_path_is_anchored_to_main_file(monkeypatch, tmp_path):
+    """CWD를 바꿔도 main.py 위치 기준으로 해석되어야 한다 (Nuitka onefile 대응)."""
+    monkeypatch.chdir(tmp_path)
+
+    result = Path(main.resource_path("translations/ko_KR.qm"))
+
+    assert result == ROOT_DIR / "translations" / "ko_KR.qm"
+
+
+def test_resource_path_finds_existing_resources():
+    """저장소의 실제 번역 파일·아이콘이 존재하는 경로로 해석된다."""
+    assert os.path.exists(main.resource_path("translations/en_US.qm"))
+    assert os.path.exists(main.resource_path("resources/chzzk.ico"))

--- a/tests/unit/test_set_language.py
+++ b/tests/unit/test_set_language.py
@@ -1,0 +1,80 @@
+"""main.set_language의 en_US 폴백 동작 단위 테스트 (PR #44 리뷰 반영).
+
+번역 로드 실패 시 en_US는 이번 실행에만 적용되고,
+유저가 저장한 language 설정(config)은 보존되어야 한다.
+"""
+
+import main
+
+
+class _StubTranslator:
+    """QTranslator 대역: en_US 번역 파일만 로드에 성공한다."""
+
+    def __init__(self):
+        self.loaded_paths = []
+
+    def load(self, path: str) -> bool:
+        self.loaded_paths.append(path)
+        return "en_US" in path
+
+
+class _StubApp:
+    """QApplication 대역: installTranslator 호출만 기록한다."""
+
+    def __init__(self):
+        self.installed = []
+
+    def installTranslator(self, translator) -> None:
+        self.installed.append(translator)
+
+
+def _patch_environment(monkeypatch):
+    """set_language가 참조하는 전역 app과 config 저장 함수를 대역으로 바꾼다."""
+    stub_app = _StubApp()
+    saves = []
+    monkeypatch.setattr(main, "app", stub_app, raising=False)
+    monkeypatch.setattr(main.config, "save_config", lambda cfg: saves.append(dict(cfg)))
+    return stub_app, saves
+
+
+def test_fallback_preserves_saved_language(monkeypatch):
+    """저장된 언어의 번역 로드에 실패해도 config의 language 값은 보존된다."""
+    stub_app, saves = _patch_environment(monkeypatch)
+    app_config = {"language": "xx_XX"}  # 번역 파일이 존재하지 않는 로케일
+
+    main.set_language(app_config, _StubTranslator())
+
+    assert app_config["language"] == "xx_XX"  # 저장된 설정 보존
+    assert saves == []  # config를 저장(덮어쓰기)하지 않는다
+    assert len(stub_app.installed) == 1  # 이번 실행에는 en_US 폴백이 적용된다
+
+
+def test_fallback_does_not_persist_on_first_run(monkeypatch):
+    """설정에 언어가 없고 시스템 언어 로드도 실패하면, en_US를 저장하지 않고 적용만 한다."""
+    stub_app, saves = _patch_environment(monkeypatch)
+    monkeypatch.setattr(
+        main.QLocale, "system", lambda: main.QLocale("xx_XX"), raising=False
+    )
+    app_config = {}
+
+    main.set_language(app_config, _StubTranslator())
+
+    assert "language" not in app_config
+    assert saves == []
+    assert len(stub_app.installed) == 1
+
+
+def test_successful_load_still_saves_detected_language(monkeypatch, tmp_path):
+    """(기존 동작 보존) 설정에 언어가 없고 로드에 성공하면 감지된 언어를 저장한다."""
+    stub_app, saves = _patch_environment(monkeypatch)
+    monkeypatch.setattr(
+        main.QLocale, "system", lambda: main.QLocale("en_US"), raising=False
+    )
+    monkeypatch.setattr(main.os.path, "exists", lambda path: True)
+    app_config = {}
+
+    main.set_language(app_config, _StubTranslator())
+
+    assert app_config["language"] == "en_US"
+    assert saves == [{"language": "en_US"}]
+    assert len(stub_app.installed) == 1


### PR DESCRIPTION
## 관련 이슈

Closes #43

## 변경 내용

`main.py`의 리소스 경로 해석을 **`__file__` 기준**으로 교체했습니다 (소스 실행·Nuitka onefile 양쪽 동작).

- **`resource_path()` 재작성** — PyInstaller 전용 `sys._MEIPASS` 의존과 CWD 폴백을 제거하고 `os.path.dirname(os.path.abspath(__file__))` 기준으로 해석. Nuitka onefile은 리소스를 임시 해제 경로에 풀고 main 모듈의 `__file__`도 그 안을 가리키므로, 릴리즈 빌드의 `--include-data-dir=translations=translations` / `--include-data-dir=resources=resources` 배치와 정확히 맞물립니다. 소스 실행에서는 저장소 루트 기준이 되어 기존과 동일하게 동작합니다.
- **폴백 경로 통일** — en_US 폴백 로드가 CWD 상대경로(`translations/en_US.qm`)를 직접 쓰고 있었는데(다른 CWD에서 실행하면 소스 실행에서도 깨지는 잠복 버그), `resource_path()` 경유로 통일했습니다.
- **아이콘 경로 점검** (이슈의 "다른 리소스 경로도 같은 기준" 항목) — 기존에도 `__file__` 기준이라 동작엔 문제가 없었지만, `resource_path('resources/chzzk.ico')`로 통일했습니다. 리소스 경로를 다루는 지점은 이 두 곳(번역·아이콘)이 전부임을 grep으로 확인했습니다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — 56 passed (신규 2: CWD를 바꿔도 main.py 기준으로 해석되는지, 실제 번역 파일·아이콘이 실존 경로로 해석되는지)
- [x] `uv run python main.py` 스모크 정상 — 저장소 디렉토리 실행 기준 번역 로드 성공
- [x] **버그 조건 재현 스모크** — 저장소 밖 디렉토리를 CWD로 앱 실행(onefile의 "CWD ≠ 리소스 위치" 조건 재현). 수정 전에는 이 조건에서 `translation file load failed`였으나, 수정 후 `translation_file path: ...\cvdv2\translations/ko_KR.qm` → `translation file load success` 확인

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #43 (approved)

## 리뷰어에게

- 실제 Nuitka onefile exe에서의 최종 확인은 릴리즈 빌드가 필요합니다(로컬에서 PySide6 onefile 빌드는 수십 분 소요라 수행하지 않았습니다). 다음 rc 태그 빌드에서 UI 언어가 ko_KR로 뜨는지 확인을 부탁드립니다. CWD 불일치 조건은 위 스모크로 소스 수준에서 재현·검증했습니다.
- 기존 `sys._MEIPASS not found` debug 로그는 함수 재작성과 함께 사라졌습니다 (PyInstaller를 더 이상 고려하지 않으므로 의도된 제거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
