### PR TITLE
chore: rc2 준비

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,12 @@ jobs:
           files: dist/*
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+      - name: VirusTotal scan
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          update_release_body: true
+          files: |
+            dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cvdv2"
-version = "2.8.0-rc1"
+version = "2.8.0-rc2"
 description = "Chzzk VOD Downloader v2"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "cvdv2"
-version = "2.8.0"
+version = "2.8.0rc2"
 source = { virtual = "." }
 dependencies = [
     { name = "pyside6" },


### PR DESCRIPTION
버전 범프, rc1 때 누락된 uv.lock 동기화, 릴리즈 산출물 VirusTotal 자동 스캔·링크 첨부