### PR TITLE
chore: macOS 패키징 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,28 +64,23 @@ jobs:
         if: runner.os == 'macOS'
         run: >
           uv run python -m nuitka
-          --onefile
+          --standalone
           --assume-yes-for-downloads
           --enable-plugin=pyside6
           --macos-create-app-bundle
+          --macos-app-name=CVDv2
           --include-data-dir=resources=resources
           --include-data-dir=translations=translations
-          --output-filename=${{ matrix.artifact }}
           --output-dir=build
           main.py
 
-      # macOS: 유저 배포용 zip 하나만 남긴다 (.app 번들만 포장, 원시 바이너리·빌드 잔여물 제외)
       - name: Package app bundle (macOS)
         if: runner.os == 'macOS'
         run: |
           cd build
           ls -la
-          if compgen -G "*.app" > /dev/null; then
-            zip -r "${{ matrix.artifact }}.zip" *.app
-          else
-            zip "${{ matrix.artifact }}.zip" "${{ matrix.artifact }}"
-          fi
-          rm -f "${{ matrix.artifact }}"
+          mv main.app CVDv2.app
+          zip -r "${{ matrix.artifact }}.zip" CVDv2.app
 
       - name: Build (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,17 +48,27 @@ jobs:
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
-        run: >
-          uv run python -m nuitka
-          --onefile
-          --assume-yes-for-downloads
-          --enable-plugin=pyside6
-          --windows-console-mode=disable
-          --include-data-dir=resources=resources
-          --include-data-dir=translations=translations
-          --output-filename=${{ matrix.artifact }}
-          --output-dir=build
-          main.py
+        shell: bash
+        run: |
+          VERSION_NUM="${GITHUB_REF_NAME#v}"
+          VERSION_NUM="${VERSION_NUM%%-*}"
+          uv run python -m nuitka \
+            --onefile \
+            --assume-yes-for-downloads \
+            --enable-plugin=pyside6 \
+            --windows-console-mode=disable \
+            --windows-icon-from-ico=resources/chzzk.ico \
+            --company-name=honey720 \
+            --product-name="Chzzk VOD Downloader" \
+            --file-description="Chzzk VOD Downloader v2" \
+            --file-version="$VERSION_NUM" \
+            --product-version="$VERSION_NUM" \
+            --copyright="honey720" \
+            --include-data-dir=resources=resources \
+            --include-data-dir=translations=translations \
+            --output-filename="${{ matrix.artifact }}" \
+            --output-dir=build \
+            main.py
 
       - name: Build (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
onefile+app-bundle 비양립으로 빈 zip이 생성되던 문제 — standalone 번들로 전환