### PR TITLE
chore: onefile 압축 의존성 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     "pytest",
     "pytest-qt",
     "ruff",
-    "nuitka",
+    "nuitka[onefile]",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "nuitka" },
+    { name = "nuitka", extras = ["onefile"] },
     { name = "pytest" },
     { name = "pytest-qt" },
     { name = "ruff" },


### PR DESCRIPTION
zstandard 부재로 Linux 산출물이 무압축 141MB로 나가던 문제 — nuitka[onefile] 의존으로 3-OS 결정적 압축 보장. 다음 릴리즈부터 적용