### PR TITLE
refactor: DASH 매니페스트 파싱을 HTTP와 분리해 core로 이주 (#51)

### DIFF
--- a/content/network.py
+++ b/content/network.py
@@ -4,8 +4,8 @@ import json
 import threading
 from http.cookiejar import DefaultCookiePolicy
 from urllib.parse import urljoin
-import xml.etree.ElementTree as ET
 
+from core.api.dash import parse_dash_manifest
 from core.api.url_parser import extract_content_no
 
 NAVER_API = "https://apis.naver.com"
@@ -96,36 +96,16 @@ class NetworkManager:
     def get_video_dash_manifest(video_id: str, in_key: str):
         """
         DASH 매니페스트를 요청하여 Representation 목록을 파싱한다.
+
+        HTTP 요청만 담당하고, XML 파싱은 core/api/dash.py의 순수 함수에 위임한다 (#51).
+        시그니처·반환 형식은 기존과 동일하다.
         """
         manifest_url = f"{NAVER_API}/neonplayer/vodplay/v2/playback/{video_id}?key={in_key}"
         headers = {"Accept": "application/dash+xml"}
         response = _session.get(manifest_url, headers=headers)
         response.raise_for_status()
 
-        root = ET.fromstring(response.text)
-        ns = {"mpd": "urn:mpeg:dash:schema:mpd:2011"}
-        reps = []
-        for rep in root.findall(".//mpd:Representation", namespaces=ns):
-            width = rep.get('width')
-            height = rep.get('height')
-            # 오디오 전용 Representation(audio/mp4)은 width/height 속성이 없다.
-            # 해상도를 계산할 수 없으므로 목록에서 제외한다 (#38)
-            if width is None or height is None:
-                continue
-            resolution = min(int(width), int(height))
-            # print(width, height) # Debugging
-            # print(f"Resolution: {resolution}") # Debugging
-            base_url = rep.find(".//mpd:BaseURL", namespaces=ns).text
-            if base_url.endswith('/hls/'):
-                continue
-            reps.append([resolution, base_url])
-        
-        sorted_reps = sorted(reps, key=lambda x: x[0])
-        auto_resolution = sorted_reps[-1][0]
-        auto_base_url = sorted_reps[-1][1]
-
-        # 중복 제거한 뒤, 리스트로 변환
-        return sorted_reps, auto_resolution, auto_base_url
+        return parse_dash_manifest(response.text)
     
     @staticmethod
     def get_video_m3u8_manifest(json_str: str):

--- a/core/api/dash.py
+++ b/core/api/dash.py
@@ -1,0 +1,44 @@
+"""DASH 매니페스트(XML) 파싱 유틸.
+
+content/network.py의 NetworkManager.get_video_dash_manifest에서 HTTP를 떼어 내고
+파싱만 이동한 순수 함수 (#51). 동작은 기존과 완전 동일하다.
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def parse_dash_manifest(xml_text: str) -> tuple[list[list], int, str]:
+    """
+    DASH 매니페스트 XML 문자열에서 Representation 목록을 파싱한다.
+
+    해상도는 min(width, height)로 계산하고 오름차순으로 정렬한다.
+    BaseURL이 '/hls/'로 끝나는 항목은 스킵한다.
+
+    Args:
+        xml_text (str): DASH 매니페스트 XML 문자열
+
+    Returns:
+        tuple[list[list], int, str]: ([해상도, base_url] 목록(오름차순),
+            auto 해상도(최고), auto base_url) 형식의 튜플
+    """
+    root = ET.fromstring(xml_text)
+    ns = {"mpd": "urn:mpeg:dash:schema:mpd:2011"}
+    reps = []
+    for rep in root.findall(".//mpd:Representation", namespaces=ns):
+        width = rep.get('width')
+        height = rep.get('height')
+        # 오디오 전용 Representation(audio/mp4)은 width/height 속성이 없다.
+        # 해상도를 계산할 수 없으므로 목록에서 제외한다 (#38)
+        if width is None or height is None:
+            continue
+        resolution = min(int(width), int(height))
+        base_url = rep.find(".//mpd:BaseURL", namespaces=ns).text
+        if base_url.endswith('/hls/'):
+            continue
+        reps.append([resolution, base_url])
+
+    sorted_reps = sorted(reps, key=lambda x: x[0])
+    auto_resolution = sorted_reps[-1][0]
+    auto_base_url = sorted_reps[-1][1]
+
+    return sorted_reps, auto_resolution, auto_base_url

--- a/tests/unit/core/test_dash.py
+++ b/tests/unit/core/test_dash.py
@@ -1,0 +1,57 @@
+"""core.api.dash의 DASH 매니페스트 파싱 박제 테스트.
+
+tests/unit/test_network.py의 HTTP mock 기반 테스트를 core 파서 직접 호출로 전환 (#51).
+파싱이 순수 함수가 되어 HTTP mock 없이 픽스처 XML만으로 검증한다. 기대값 무변경 (#27, #38).
+"""
+
+
+from core.api.dash import parse_dash_manifest
+
+
+class TestParseDashManifest:
+    """parse_dash_manifest의 XML 파싱 결과 박제."""
+
+    def test_parses_sorts_and_skips_hls(self, load_mock_response):
+        """해상도 오름차순 정렬, min(width, height) 계산, '/hls/' 항목 스킵을 고정한다."""
+        sorted_reps, auto_resolution, auto_base_url = parse_dash_manifest(
+            load_mock_response("dash_manifest.xml")
+        )
+
+        assert sorted_reps == [
+            [480, "https://vod-example.invalid/chzzk/video_480p.mp4"],
+            [720, "https://vod-example.invalid/chzzk/video_720p.mp4"],
+            [1080, "https://vod-example.invalid/chzzk/video_1080p.mp4"],
+        ]
+        # auto는 목록 중 가장 높은 해상도
+        assert auto_resolution == 1080
+        assert auto_base_url == "https://vod-example.invalid/chzzk/video_1080p.mp4"
+
+    def test_skips_audio_only_representation(self, load_mock_response):
+        """width/height 없는 오디오 전용 Representation은 건너뛰어야 한다 (#38).
+
+        픽스처는 videoNo 14158884의 실제 매니페스트 박제본이다: video/mp4 3종(1080/720/144)
+        + video/mp2t 3종(BaseURL이 '/hls/'로 끝나 기존 로직이 스킵) + audio/mp4 1종
+        (width/height 없음 — 기존에는 여기서 TypeError로 전체 파싱이 실패했다).
+        """
+        sorted_reps, auto_resolution, auto_base_url = parse_dash_manifest(
+            load_mock_response("dash_manifest_audio_only_14158884.xml")
+        )
+
+        # 영상 3종만 남는다: 오디오 전용(m4a)·hls 항목은 제외, 해상도 오름차순
+        assert [rep[0] for rep in sorted_reps] == [144, 720, 1080]
+        assert auto_resolution == 1080
+        for _, base_url in sorted_reps:
+            assert base_url.endswith(".mp4?_lsu_sa_=REDACTED")
+            assert "/hls/" not in base_url
+            assert ".m4a" not in base_url
+        assert auto_base_url == sorted_reps[-1][1]
+
+    def test_portrait_single_representation(self, load_mock_response):
+        """세로 영상(720x1280) 단일 항목: 해상도는 min(width, height)=720으로 계산된다."""
+        sorted_reps, auto_resolution, auto_base_url = parse_dash_manifest(
+            load_mock_response("dash_manifest_portrait.xml")
+        )
+
+        assert sorted_reps == [[720, "https://vod-example.invalid/chzzk/portrait_720.mp4"]]
+        assert auto_resolution == 720
+        assert auto_base_url == "https://vod-example.invalid/chzzk/portrait_720.mp4"

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1,13 +1,15 @@
 """content.network의 URL 파싱·DASH 매니페스트 파싱 테스트.
 
 - URL 파싱(TestExtractContentNo): #33에서 허용 범위를 넓힌 **요구 동작 검증** 테스트다.
-- DASH 매니페스트 파싱(TestGetVideoDashManifest): #27의 현재 동작 보존(박제) 테스트다.
+- DASH 매니페스트(TestGetVideoDashManifest): HTTP 요청 구성·core 파서 위임 검증이다.
+  파싱 자체의 박제 테스트는 tests/unit/core/test_dash.py로 이전했다 (#51).
 """
 
 import pytest
 
 import content.network as network
 from content.network import NetworkManager
+from core.api.dash import parse_dash_manifest
 from core.api.url_parser import extract_content_no
 from tests.mocks.mock_http import MockResponse
 
@@ -68,35 +70,28 @@ class TestExtractContentNo:
 
 
 class TestGetVideoDashManifest:
-    """NetworkManager.get_video_dash_manifest의 XML 파싱 결과 박제 (HTTP는 mock)."""
+    """NetworkManager.get_video_dash_manifest의 HTTP 경로(요청 구성·위임) 검증.
 
-    def _patch_get(self, monkeypatch: pytest.MonkeyPatch, xml_text: str) -> list:
-        """공유 세션(network._session)의 get을 목으로 바꾸고 호출 기록 리스트를 반환한다."""
+    XML 파싱 자체는 core/api/dash.py로 이동해 tests/unit/core/test_dash.py에서
+    픽스처로 검증한다 (#51). 여기서는 요청 URL·헤더와 core 파서 위임만 확인한다.
+    """
+
+    def test_requests_manifest_and_delegates_to_core_parser(
+        self, monkeypatch, load_mock_response
+    ):
+        """요청 URL·헤더 구성을 고정하고, 응답 본문이 core 파서 결과로 반환되는지 확인한다."""
         calls = []
+        xml_text = load_mock_response("dash_manifest.xml")
 
         def fake_get(url, **kwargs):
             calls.append((url, kwargs))
             return MockResponse(text=xml_text)
 
         monkeypatch.setattr(network._session, "get", fake_get)
-        return calls
-
-    def test_parses_sorts_and_skips_hls(self, monkeypatch, load_mock_response):
-        """해상도 오름차순 정렬, min(width, height) 계산, '/hls/' 항목 스킵을 고정한다."""
-        calls = self._patch_get(monkeypatch, load_mock_response("dash_manifest.xml"))
 
         sorted_reps, auto_resolution, auto_base_url = NetworkManager.get_video_dash_manifest(
             "test-video-id", "test-in-key"
         )
-
-        assert sorted_reps == [
-            [480, "https://vod-example.invalid/chzzk/video_480p.mp4"],
-            [720, "https://vod-example.invalid/chzzk/video_720p.mp4"],
-            [1080, "https://vod-example.invalid/chzzk/video_1080p.mp4"],
-        ]
-        # auto는 목록 중 가장 높은 해상도
-        assert auto_resolution == 1080
-        assert auto_base_url == "https://vod-example.invalid/chzzk/video_1080p.mp4"
 
         # 요청 URL·헤더 구성도 현재 동작 그대로 고정 (실호출 없음)
         assert calls == [
@@ -106,39 +101,5 @@ class TestGetVideoDashManifest:
                 {"headers": {"Accept": "application/dash+xml"}},
             )
         ]
-
-    def test_skips_audio_only_representation(self, monkeypatch, load_mock_response):
-        """width/height 없는 오디오 전용 Representation은 건너뛰어야 한다 (#38).
-
-        픽스처는 videoNo 14158884의 실제 매니페스트 박제본이다: video/mp4 3종(1080/720/144)
-        + video/mp2t 3종(BaseURL이 '/hls/'로 끝나 기존 로직이 스킵) + audio/mp4 1종
-        (width/height 없음 — 기존에는 여기서 TypeError로 전체 파싱이 실패했다).
-        """
-        self._patch_get(
-            monkeypatch, load_mock_response("dash_manifest_audio_only_14158884.xml")
-        )
-
-        sorted_reps, auto_resolution, auto_base_url = NetworkManager.get_video_dash_manifest(
-            "test-video-id", "test-in-key"
-        )
-
-        # 영상 3종만 남는다: 오디오 전용(m4a)·hls 항목은 제외, 해상도 오름차순
-        assert [rep[0] for rep in sorted_reps] == [144, 720, 1080]
-        assert auto_resolution == 1080
-        for _, base_url in sorted_reps:
-            assert base_url.endswith(".mp4?_lsu_sa_=REDACTED")
-            assert "/hls/" not in base_url
-            assert ".m4a" not in base_url
-        assert auto_base_url == sorted_reps[-1][1]
-
-    def test_portrait_single_representation(self, monkeypatch, load_mock_response):
-        """세로 영상(720x1280) 단일 항목: 해상도는 min(width, height)=720으로 계산된다."""
-        self._patch_get(monkeypatch, load_mock_response("dash_manifest_portrait.xml"))
-
-        sorted_reps, auto_resolution, auto_base_url = NetworkManager.get_video_dash_manifest(
-            "portrait-video-id", "portrait-in-key"
-        )
-
-        assert sorted_reps == [[720, "https://vod-example.invalid/chzzk/portrait_720.mp4"]]
-        assert auto_resolution == 720
-        assert auto_base_url == "https://vod-example.invalid/chzzk/portrait_720.mp4"
+        # 반환값은 core 파서에 응답 본문을 그대로 넘긴 결과와 일치해야 한다
+        assert (sorted_reps, auto_resolution, auto_base_url) == parse_dash_manifest(xml_text)


### PR DESCRIPTION
## 관련 이슈

Closes #51

## 변경 내용

- `core/api/dash.py` 신규: `parse_dash_manifest(xml_text: str)` 순수 함수. 해상도 정렬, min(width, height) 계산, `/hls/` 스킵, 해상도 없는 항목 스킵(#38 오디오 전용), auto 선택 로직을 **식 그대로 이동** — 동작 완전 동일. 이동하면서 주석 처리된 디버그 print 2줄과 실제 동작과 다른 주석("중복 제거") 1줄만 제거
- `NetworkManager.get_video_dash_manifest`: HTTP(요청 URL·헤더) 담당으로 남고 core 파서에 위임 — 시그니처·반환 형식 무변경. `xml.etree.ElementTree` import는 network.py에서 더 이상 쓰이지 않아 제거
- 테스트 재구성:
  - 픽스처 파싱 테스트 3건(기본/오디오 전용 #38/세로 영상)을 `tests/unit/core/test_dash.py`로 이전 — core 파서 직접 호출로 전환, HTTP mock 불필요. 기대값 무변경
  - `test_network.py`에는 HTTP 경로 테스트 1건 유지: 요청 URL·헤더 구성 고정 + 응답 본문이 core 파서 결과로 반환되는지(위임) 확인

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (62 passed, 기대값 무변경)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — 이전한 픽스처 3건이 core 파서를 직접 커버, #50의 PySide6 금지 가드 테스트도 dash.py를 자동 커버
- [x] `core/api/dash.py`에 requests·PySide6 import 없음 (표준 라이브러리 `xml.etree.ElementTree`만 사용)
- [x] 앱 스모크: `uv run python main.py` 기동 정상 (import 오류·크래시 없음)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — view 변경 없음, 호출부는 종전대로 `NetworkManager` 경유
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: core 내 파일 추가는 #51 (`approved` 라벨)

## 리뷰어에게

- 완료 조건의 "DASH 경로 VOD 1건 다운로드" 스모크는 실 VOD 접근이 필요해 에이전트가 수행하지 않았습니다. 기동 스모크까지 확인했으니 머지 전 DASH 경로 다운로드 1회 확인 부탁드립니다.
- 이슈 본문의 "#39 오디오 트랙 픽스처"는 코드·픽스처 주석 기준 #38을 가리키는 것으로 판단해 #38 회귀 테스트(videoNo 14158884 박제본)를 이전했습니다. 다른 의도였다면 알려주세요.
- `parse_dash_manifest`는 기존 로직 그대로이므로 빈 매니페스트에서 IndexError, BaseURL 누락 시 AttributeError가 나는 기존 결함(#38 관련 메모)도 그대로입니다 — 해당 수정은 이 PR 범위 밖(별도 이슈 소관)입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
