### PR TITLE
refactor: 다운로드 상태 머신을 core/models로 이주 (#60)

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,0 +1,6 @@
+"""core 도메인 모델 패키지 — UI와 무관한 순수 데이터·상태 모델 (#60)."""
+
+from core.models.download_state import DownloadState
+from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
+
+__all__ = ["DownloadState", "DownloadTaskModel", "InvalidStateTransitionError"]

--- a/core/models/download_state.py
+++ b/core/models/download_state.py
@@ -1,0 +1,17 @@
+"""다운로드 상태 정의 — UI와 무관한 순수 도메인 열거형 (#60, SPEC §4.2).
+
+기존 download/state.py에서 이주했다. 값과 의미는 그대로 유지한다.
+기존 호출부는 download/state.py의 re-export를 통해 무변경으로 동작한다.
+"""
+
+from enum import Enum
+
+
+class DownloadState(Enum):
+    """다운로드 태스크의 생명주기 상태."""
+
+    WAITING = 0  # 다운로드 대기
+    RUNNING = 1  # 다운로드 실행
+    PAUSED = 2  # 다운로드 중지(일시정지)
+    FINISHED = 3  # 다운로드 완료
+    FAILED = 4  # 다운로드 실패

--- a/core/models/download_task.py
+++ b/core/models/download_task.py
@@ -1,0 +1,169 @@
+"""다운로드 태스크 도메인 모델 — 상태·진행률 보유와 전이 (#60, SPEC §4.2).
+
+Qt 등 UI 프레임워크에 의존하지 않는 순수 상태 머신이다.
+상태 전이는 반드시 start/pause/resume/stop/finish/fail 메서드를 통해서만 일어나고
+락으로 동기화된다. UI 계층에는 on_state_change 콜백으로만 변경을 알린다
+(app → core 단방향 의존 유지).
+
+기존 download/task.py의 DownloadTask에서 순수 부분만 분리했다. Qt 계층 연결
+(ContentItem 상태 반영, 다운로드 로깅)은 기존 위치의 어댑터가 담당한다.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+
+from core.models.download_state import DownloadState
+
+
+class InvalidStateTransitionError(RuntimeError):
+    """허용되지 않는 상태 전이를 시도했을 때 발생한다."""
+
+
+# 전이 메서드별 허용 출발 상태. 현재 상태가 목표 상태와 같으면 전이 전에
+# 멱등 no-op으로 처리되므로, 여기에는 "실제로 상태가 바뀌는" 출발 상태만 적는다.
+_ALLOWED_SOURCES: dict[str, frozenset[DownloadState]] = {
+    "start": frozenset({DownloadState.WAITING}),
+    "pause": frozenset({DownloadState.RUNNING}),
+    "resume": frozenset({DownloadState.PAUSED}),
+    "stop": frozenset({DownloadState.RUNNING, DownloadState.PAUSED}),
+    "finish": frozenset({DownloadState.RUNNING, DownloadState.PAUSED}),
+    "fail": frozenset({DownloadState.WAITING, DownloadState.RUNNING, DownloadState.PAUSED}),
+}
+
+
+class DownloadTaskModel:
+    """다운로드 한 건의 상태·진행률을 보유하고 전이 규칙을 강제하는 모델.
+
+    - 상태는 `state` 프로퍼티로만 읽고, 전이 메서드로만 바꾼다.
+    - `pause_event`는 다운로드 스레드가 일시정지를 대기(wait)하는 Event다.
+      set 상태가 "진행 가능"을 뜻한다. 기존 엔진(DownloadData._pause_event)과
+      같은 Event를 공유할 수 있도록 외부 주입을 허용한다.
+    """
+
+    def __init__(
+        self,
+        pause_event: threading.Event | None = None,
+        on_state_change: Callable[[DownloadState], None] | None = None,
+    ):
+        """모델을 초기 상태(WAITING)로 생성한다.
+
+        Args:
+            pause_event: 일시정지 대기용 Event. 생략하면 새로 만든다.
+            on_state_change: 상태가 실제로 바뀔 때 새 상태를 받는 콜백.
+        """
+        self._lock = threading.Lock()
+        self._state = DownloadState.WAITING
+        self._on_state_change = on_state_change
+
+        self.pause_event = pause_event if pause_event is not None else threading.Event()
+        self.pause_event.set()  # set 상태 = 진행 가능
+
+        # 진행률 관련 필드. 값 갱신은 엔진(Phase 3에서 이주 예정)이 담당한다.
+        self.total_size = 0
+        self.threads_progress: list[int] = []
+        self.start_time = 0.0
+        self.end_time = 0.0
+
+    @property
+    def state(self) -> DownloadState:
+        """현재 다운로드 상태."""
+        return self._state
+
+    def _transition(self, method: str, new_state: DownloadState) -> bool:
+        """전이 공통 처리. 이미 목표 상태면 no-op(False), 전이 성공 시 True.
+
+        허용되지 않는 출발 상태면 InvalidStateTransitionError를 던진다.
+        콜백은 락 밖에서 호출한다 — 콜백이 다시 모델을 만져도 교착이 없게 하기 위함.
+        """
+        with self._lock:
+            if self._state is new_state:
+                return False
+            if self._state not in _ALLOWED_SOURCES[method]:
+                raise InvalidStateTransitionError(
+                    f"{method}() 불가: {self._state.name} → {new_state.name} 전이는 허용되지 않는다"
+                )
+            self._state = new_state
+        if self._on_state_change is not None:
+            self._on_state_change(new_state)
+        return True
+
+    # ============ 상태 전이 ============
+
+    def start(self) -> bool:
+        """WAITING → RUNNING. 시작 시각을 기록한다."""
+        changed = self._transition("start", DownloadState.RUNNING)
+        if changed:
+            self.start_time = time.time()
+        return changed
+
+    def pause(self) -> bool:
+        """RUNNING → PAUSED. 다운로드 스레드를 대기 상태로 보낸다."""
+        changed = self._transition("pause", DownloadState.PAUSED)
+        if changed:
+            self.pause_event.clear()
+        return changed
+
+    def resume(self) -> bool:
+        """PAUSED → RUNNING. 대기 중인 다운로드 스레드를 깨운다."""
+        changed = self._transition("resume", DownloadState.RUNNING)
+        if changed:
+            self.pause_event.set()
+        return changed
+
+    def stop(self) -> bool:
+        """RUNNING/PAUSED → WAITING (취소). 이미 WAITING이면 no-op.
+
+        일시정지 대기 중인 스레드가 있으면 깨워서 종료 경로로 보내야 하므로
+        no-op 여부와 무관하게 Event는 항상 set한다.
+        """
+        changed = self._transition("stop", DownloadState.WAITING)
+        self.pause_event.set()
+        return changed
+
+    def finish(self) -> bool:
+        """RUNNING/PAUSED → FINISHED. 종료 시각을 기록한다."""
+        changed = self._transition("finish", DownloadState.FINISHED)
+        if changed:
+            self.end_time = time.time()
+            self.pause_event.set()
+        return changed
+
+    def fail(self) -> bool:
+        """WAITING/RUNNING/PAUSED → FAILED. 종료 시각을 기록한다."""
+        changed = self._transition("fail", DownloadState.FAILED)
+        if changed:
+            self.end_time = time.time()
+            self.pause_event.set()
+        return changed
+
+    def is_running(self) -> bool:
+        """현재 상태가 RUNNING인지 여부."""
+        return self._state is DownloadState.RUNNING
+
+    # ============ 진행률 집계 ============
+
+    def init_threads_progress(self, thread_count: int) -> None:
+        """스레드별 진행 바이트 배열을 0으로 초기화한다."""
+        with self._lock:
+            self.threads_progress = [0] * thread_count
+
+    def set_thread_progress(self, index: int, downloaded: int) -> None:
+        """index번 스레드의 누적 다운로드 바이트를 갱신한다."""
+        with self._lock:
+            self.threads_progress[index] = downloaded
+
+    @property
+    def downloaded_size(self) -> int:
+        """스레드별 진행 바이트의 합 = 전체 다운로드된 크기."""
+        with self._lock:
+            return sum(self.threads_progress)
+
+    @property
+    def progress(self) -> float:
+        """전체 진행률(0.0~100.0). total_size를 모르면(0 이하) 0.0."""
+        total = self.total_size
+        if total <= 0:
+            return 0.0
+        # 재시도로 total_size보다 많이 받은 경우에도 100을 넘기지 않는다
+        return min(self.downloaded_size / total * 100.0, 100.0)

--- a/download/state.py
+++ b/download/state.py
@@ -1,8 +1,9 @@
-from enum import Enum
+"""하위 호환 re-export — DownloadState 정의는 core/models/download_state.py로 이주 (#60).
 
-class DownloadState(Enum):
-    WAITING = 0     # 다운로드 대기
-    RUNNING = 1     # 다운로드 실행
-    PAUSED = 2      # 다운로드 중지
-    FINISHED = 3    # 다운로드 완료
-    FAILED = 4      # 다운로드 실패
+기존 호출부(application, content, download 모듈)의 import 경로를 유지하기 위한 파일이다.
+새 코드는 core.models.download_state에서 직접 import할 것.
+"""
+
+from core.models.download_state import DownloadState
+
+__all__ = ["DownloadState"]

--- a/download/task.py
+++ b/download/task.py
@@ -1,45 +1,74 @@
-from download.data import DownloadData
-from content.data import ContentItem
-from download.logger import DownloadLogger
-from download.state import DownloadState
+"""DownloadTask 어댑터 — 순수 상태 머신은 core/models/download_task.py로 이주 (#60).
+
+기존 호출부(download manager·worker·monitor)의 인터페이스(state 속성, lock,
+start/pause/resume/stop/finish/isRunning)를 그대로 유지하면서, 상태 보유·전이는
+core의 DownloadTaskModel에 위임한다. Qt 계층과의 연결(ContentItem 상태 반영,
+다운로드 로깅)은 이 어댑터에 남는다.
+"""
+
 import threading
 
+from content.data import ContentItem
+from core.models.download_state import DownloadState
+from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
+from download.data import DownloadData
+from download.logger import DownloadLogger
+
+
 class DownloadTask:
+    """core 상태 머신을 감싸 기존 다운로드 엔진과 UI 계층을 연결하는 어댑터."""
+
     def __init__(self, data: DownloadData, item: ContentItem, logger: DownloadLogger):
         self.data = data
         self.item = item
-        self.state = DownloadState.WAITING  # 초기 상태로 설정
         self.logger = logger
-        self.lock = threading.Lock()  # 상태 변경 시 동기화용 락
+        # 엔진(worker/monitor)이 future_count 등 공유 변수 동기화에 쓰는 락.
+        # 모델 내부의 상태 전이 락과는 별개다 (엔진 무변경 유지 — Phase 3에서 정리).
+        self.lock = threading.Lock()
+        # 엔진이 data._pause_event로 일시정지를 대기하므로 모델과 같은 Event를 공유한다
+        self.model = DownloadTaskModel(
+            pause_event=data._pause_event,
+            on_state_change=item.setDownloadState,
+        )
+
+    @property
+    def state(self) -> DownloadState:
+        """현재 다운로드 상태 (core 모델에 위임)."""
+        return self.model.state
+
+    def _try_transition(self, transition_name: str) -> bool:
+        """모델의 전이 메서드를 호출하되, 허용되지 않는 전이는 크래시 대신 경고 로그로 남긴다.
+
+        기존 코드는 어떤 상태에서든 전이를 허용했으므로, UI 이벤트 타이밍 문제로
+        어긋난 호출이 와도 앱이 죽지 않도록 어댑터에서 흡수한다.
+        """
+        try:
+            return getattr(self.model, transition_name)()
+        except InvalidStateTransitionError as e:
+            self.logger.warning(f"상태 전이 무시: {e}")
+            return False
 
     def start(self):
-        self.state = DownloadState.RUNNING
-        self.item.setDownloadState(self.state)
-        self.logger.log_download_info(self.item)
-        # 필요 시, ContentItem에 상태를 전달하여 업데이트
+        """다운로드 시작. 성공 시 다운로드 정보를 로그로 남긴다."""
+        if self._try_transition("start"):
+            self.logger.log_download_info(self.item)
 
     def pause(self):
-        self.state = DownloadState.PAUSED
-        self.data._pause_event.clear() # 대기 상태로 들어감
-        self.item.setDownloadState(self.state)
-        # ContentItem에 상태 전달
+        """다운로드 일시정지."""
+        self._try_transition("pause")
 
     def resume(self):
-        self.state = DownloadState.RUNNING
-        self.data._pause_event.set()
-        self.item.setDownloadState(self.state)
-        # 상태 업데이트 전달
+        """다운로드 재개."""
+        self._try_transition("resume")
 
     def stop(self):
-        self.state = DownloadState.WAITING
-        self.data._pause_event.set()
-        self.item.setDownloadState(self.state)
-        # 상태 업데이트 전달
+        """다운로드 취소(대기 상태로 복귀)."""
+        self._try_transition("stop")
 
     def finish(self):
-        self.state = DownloadState.FINISHED
-        self.item.setDownloadState(self.state)
-        # 상태 업데이트 전달
+        """다운로드 완료 처리."""
+        self._try_transition("finish")
 
-    def isRunning(self):
-        return self.state == DownloadState.RUNNING
+    def isRunning(self) -> bool:
+        """현재 다운로드가 실행 중인지 여부 (기존 메서드명 유지)."""
+        return self.model.is_running()

--- a/tests/unit/core/test_download_task_model.py
+++ b/tests/unit/core/test_download_task_model.py
@@ -1,0 +1,192 @@
+"""core/models/download_task.py 상태 머신 단위 테스트 (#60).
+
+검증 범위: 정상 전이 경로, 허용되지 않는 전이, 일시정지/재개 시 Event 동작,
+진행률 집계, 상태 변경 콜백.
+"""
+
+import threading
+
+import pytest
+
+from core.models.download_state import DownloadState
+from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
+
+
+def test_initial_state_is_waiting():
+    """생성 직후 상태는 WAITING이고 pause_event는 진행 가능(set) 상태다."""
+    model = DownloadTaskModel()
+    assert model.state is DownloadState.WAITING
+    assert model.pause_event.is_set()
+    assert not model.is_running()
+
+
+def test_normal_transition_path():
+    """정상 경로: 시작 → 일시정지 → 재개 → 완료."""
+    model = DownloadTaskModel()
+
+    assert model.start() is True
+    assert model.state is DownloadState.RUNNING
+    assert model.is_running()
+    assert model.start_time > 0
+
+    assert model.pause() is True
+    assert model.state is DownloadState.PAUSED
+
+    assert model.resume() is True
+    assert model.state is DownloadState.RUNNING
+
+    assert model.finish() is True
+    assert model.state is DownloadState.FINISHED
+    assert model.end_time >= model.start_time
+
+
+def test_stop_from_running_returns_to_waiting():
+    """실행 중 취소하면 WAITING으로 복귀한다."""
+    model = DownloadTaskModel()
+    model.start()
+    assert model.stop() is True
+    assert model.state is DownloadState.WAITING
+
+
+def test_stop_from_paused_wakes_waiting_threads():
+    """일시정지 상태에서 취소해도 WAITING으로 가고, 대기 중 스레드를 깨운다."""
+    model = DownloadTaskModel()
+    model.start()
+    model.pause()
+    assert model.stop() is True
+    assert model.state is DownloadState.WAITING
+    # 일시정지 대기(wait) 중인 스레드가 종료 경로로 빠져나가야 하므로 set이어야 한다
+    assert model.pause_event.is_set()
+
+
+def test_fail_transition():
+    """실행 중 실패 처리하면 FAILED가 되고 종료 시각이 기록된다."""
+    model = DownloadTaskModel()
+    model.start()
+    assert model.fail() is True
+    assert model.state is DownloadState.FAILED
+    assert model.end_time > 0
+
+
+@pytest.mark.parametrize(
+    ("setup", "invalid"),
+    [
+        # WAITING에서 pause/resume/finish 불가
+        ([], "pause"),
+        ([], "resume"),
+        ([], "finish"),
+        # FINISHED는 종료 상태 — 어떤 전이도 불가
+        (["start", "finish"], "start"),
+        (["start", "finish"], "pause"),
+        (["start", "finish"], "resume"),
+        (["start", "finish"], "stop"),
+        (["start", "finish"], "fail"),
+        # FAILED도 종료 상태 — 어떤 전이도 불가
+        (["start", "fail"], "start"),
+        (["start", "fail"], "resume"),
+        (["start", "fail"], "finish"),
+    ],
+)
+def test_invalid_transitions_raise(setup: list[str], invalid: str):
+    """허용되지 않는 전이는 InvalidStateTransitionError를 던진다."""
+    model = DownloadTaskModel()
+    for name in setup:
+        getattr(model, name)()
+    with pytest.raises(InvalidStateTransitionError):
+        getattr(model, invalid)()
+
+
+def test_same_state_transition_is_idempotent_noop():
+    """이미 목표 상태면 예외 없이 False를 반환하는 멱등 no-op이다."""
+    model = DownloadTaskModel()
+    model.start()
+    assert model.start() is False
+    assert model.resume() is False  # 이미 RUNNING
+    model.pause()
+    assert model.pause() is False
+    # WAITING에서 stop도 no-op — 엔진의 중복 stop 호출을 허용한다
+    model.stop()
+    assert model.stop() is False
+
+
+def test_pause_resume_event_behavior():
+    """pause는 Event를 clear해 스레드를 재우고, resume은 set해 깨운다."""
+    model = DownloadTaskModel()
+    model.start()
+    assert model.pause_event.is_set()
+
+    model.pause()
+    assert not model.pause_event.is_set()
+
+    model.resume()
+    assert model.pause_event.is_set()
+
+
+def test_injected_pause_event_is_shared():
+    """외부에서 주입한 Event를 그대로 공유한다 (기존 엔진과의 연결용)."""
+    shared = threading.Event()
+    model = DownloadTaskModel(pause_event=shared)
+    assert shared.is_set()  # 생성 시 진행 가능 상태로 초기화
+    model.start()
+    model.pause()
+    assert not shared.is_set()
+
+
+def test_on_state_change_fires_only_on_real_transition():
+    """콜백은 상태가 실제로 바뀔 때만, 새 상태를 인자로 호출된다."""
+    changes: list[DownloadState] = []
+    model = DownloadTaskModel(on_state_change=changes.append)
+
+    model.start()
+    model.pause()
+    model.pause()  # 멱등 no-op — 콜백 없음
+    model.resume()
+    model.finish()
+
+    assert changes == [
+        DownloadState.RUNNING,
+        DownloadState.PAUSED,
+        DownloadState.RUNNING,
+        DownloadState.FINISHED,
+    ]
+
+
+def test_progress_aggregation():
+    """스레드별 진행 바이트의 합과 백분율 진행률을 집계한다."""
+    model = DownloadTaskModel()
+    model.total_size = 1000
+    model.init_threads_progress(4)
+    assert model.downloaded_size == 0
+    assert model.progress == 0.0
+
+    model.set_thread_progress(0, 100)
+    model.set_thread_progress(1, 200)
+    model.set_thread_progress(3, 200)
+    assert model.downloaded_size == 500
+    assert model.progress == 50.0
+
+
+def test_progress_is_zero_without_total_size():
+    """total_size가 확정되지 않았으면(0) 진행률은 0.0이다."""
+    model = DownloadTaskModel()
+    model.init_threads_progress(2)
+    model.set_thread_progress(0, 100)
+    assert model.progress == 0.0
+
+
+def test_progress_is_capped_at_100():
+    """재시도 등으로 total_size보다 많이 받아도 진행률은 100.0으로 캡한다."""
+    model = DownloadTaskModel()
+    model.total_size = 100
+    model.init_threads_progress(1)
+    model.set_thread_progress(0, 150)
+    assert model.progress == 100.0
+
+
+def test_state_enum_values_preserved():
+    """이주 후에도 상태 값·의미가 기존 download/state.py와 동일해야 한다."""
+    assert DownloadState.WAITING.value == 0
+    assert DownloadState.RUNNING.value == 1
+    assert DownloadState.PAUSED.value == 2
+    assert DownloadState.FINISHED.value == 3
+    assert DownloadState.FAILED.value == 4

--- a/tests/unit/test_download_task_adapter.py
+++ b/tests/unit/test_download_task_adapter.py
@@ -1,0 +1,98 @@
+"""download/task.py 어댑터·download/state.py re-export 검증 (#60).
+
+상태 머신을 core/models로 이주한 뒤에도 기존 호출부 인터페이스
+(state 속성, lock, start/pause/resume/stop/finish/isRunning)가 유지되고,
+ContentItem 상태 반영과 pause_event 공유가 동작하는지 확인한다.
+"""
+
+import threading
+
+from core.models.download_state import DownloadState as CoreDownloadState
+from download.data import DownloadData
+from download.state import DownloadState
+from download.task import DownloadTask
+
+
+class _FakeLogger:
+    """DownloadLogger 대역 — 파일 핸들러 생성 없이 호출 기록만 남긴다."""
+
+    def __init__(self):
+        self.warnings: list[str] = []
+        self.logged_items: list[object] = []
+
+    def warning(self, message: str):
+        self.warnings.append(message)
+
+    def log_download_info(self, item):
+        self.logged_items.append(item)
+
+
+class _FakeItem:
+    """ContentItem 대역 — setDownloadState 수신 상태만 기록한다."""
+
+    def __init__(self):
+        self.downloadState = DownloadState.WAITING
+
+    def setDownloadState(self, state: DownloadState):
+        self.downloadState = state
+
+
+def _make_task() -> tuple[DownloadTask, DownloadData, _FakeItem, _FakeLogger]:
+    data = DownloadData("base", "vod", "out.mp4", "1080p", "zip")
+    item = _FakeItem()
+    logger = _FakeLogger()
+    return DownloadTask(data, item, logger), data, item, logger
+
+
+def test_state_reexport_is_same_class():
+    """download.state의 DownloadState는 core 정의와 동일 객체여야 한다."""
+    assert DownloadState is CoreDownloadState
+
+
+def test_adapter_keeps_engine_interface():
+    """엔진(worker/monitor)이 쓰는 state·lock 인터페이스가 유지된다."""
+    task, _, _, _ = _make_task()
+    assert task.state is DownloadState.WAITING
+    assert isinstance(task.lock, type(threading.Lock()))
+    assert not task.isRunning()
+
+
+def test_transitions_update_item_state():
+    """전이 시 ContentItem에 상태가 반영된다 (기존 setDownloadState 경로 유지)."""
+    task, _, item, logger = _make_task()
+
+    task.start()
+    assert task.state is DownloadState.RUNNING
+    assert item.downloadState is DownloadState.RUNNING
+    assert logger.logged_items  # 시작 시 다운로드 정보 로깅 유지
+
+    task.pause()
+    assert item.downloadState is DownloadState.PAUSED
+
+    task.resume()
+    assert item.downloadState is DownloadState.RUNNING
+
+    task.finish()
+    assert item.downloadState is DownloadState.FINISHED
+
+
+def test_pause_event_is_shared_with_download_data():
+    """어댑터는 DownloadData._pause_event를 core 모델과 공유한다 (엔진 무변경)."""
+    task, data, _, _ = _make_task()
+    task.start()
+
+    task.pause()
+    assert not data._pause_event.is_set()
+
+    task.resume()
+    assert data._pause_event.is_set()
+
+
+def test_invalid_transition_is_absorbed_not_raised():
+    """허용되지 않는 전이는 예외로 앱을 죽이지 않고 경고 로그로 흡수한다."""
+    task, _, item, logger = _make_task()
+
+    task.resume()  # WAITING에서 resume은 허용되지 않는 전이
+    assert task.state is DownloadState.WAITING
+    assert item.downloadState is DownloadState.WAITING
+    assert logger.warnings


### PR DESCRIPTION
## 관련 이슈

Closes #60

## 변경 내용

다운로드 상태 머신을 Qt 계층에서 core로 이주했다 (Phase 2, SPEC §4.2).

- **`core/models/download_state.py` (신규)**: `DownloadState` 열거형 이주. 표준 `enum.Enum` 기반이며 값(0~4)과 의미는 기존과 동일.
- **`core/models/download_task.py` (신규)**: `DownloadTaskModel` — 순수 상태·진행률 모델.
  - 필드: state, total_size, threads_progress(스레드별 진행 배열), start/end time, 일시정지용 `threading.Event`
  - 전이는 start/pause/resume/stop/finish/fail 메서드로만 일어나고 락으로 동기화. 허용되지 않는 전이는 `InvalidStateTransitionError`, 같은 상태로의 재호출은 멱등 no-op.
  - 진행률 집계: `downloaded_size`(스레드 합), `progress`(0~100, total 미확정 시 0, 100 캡)
  - UI 통지는 `on_state_change` 콜백으로만 (app → core 단방향 유지)
- **`download/state.py`**: re-export로 전환 — 기존 import 경로 무변경.
- **`download/task.py`**: 어댑터로 전환 — `state`/`lock`/`isRunning()` 등 기존 인터페이스를 유지하며 core 모델에 위임. `ContentItem.setDownloadState` 반영·다운로드 로깅은 어댑터에 잔류. `pause_event`는 `DownloadData._pause_event`와 공유해 **다운로드 엔진(worker/monitor)은 한 줄도 수정하지 않음** (Phase 3 소관).
- **테스트**: `tests/unit/core/test_download_task_model.py` (정상 전이 경로·허용되지 않는 전이·pause/resume Event 동작·진행률 집계·콜백·enum 값 보존), `tests/unit/test_download_task_adapter.py` (re-export 동일성·엔진 인터페이스 유지·ContentItem 반영·Event 공유·비정상 전이 흡수).

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (102 passed, Windows 로컬 — core 순수성 가드 `test_no_qt_import` 포함)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시)
- [x] `uv run python scripts/headless_download.py` 임포트 체인·인자 처리 정상 (DownloadManager → task 어댑터 → core 모델 로드 확인)
- [x] 앱 스모크(다운로드 1회 + 일시정지·재개), 공개 VOD 헤드리스 실다운로드 — 실제 VOD URL·GUI 조작이 필요해 소유자 확인 요청드립니다

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — `core/models`는 표준 라이브러리만 import
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 호출부는 기존 어댑터 경유로 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — `core/models/` 신규 파일 추가는 이슈 #60에서 `approved`로 승인된 범위

## 리뷰어에게

판단이 필요했던 지점:

1. **허용되지 않는 전이의 처리** — core 모델은 예외(`InvalidStateTransitionError`)를 던지지만, 어댑터는 이를 경고 로그로 흡수한다. 기존 코드는 어떤 상태에서든 전이를 허용했으므로(예: FINISHED 직후 pause 클릭 레이스), UI 타이밍 문제로 어긋난 호출이 와도 앱이 죽지 않게 하기 위함이다. core를 직접 쓰는 새 코드(Phase 3~)는 엄격한 규칙을 적용받는다.
2. **stop()의 멱등 처리** — 엔진이 이미 WAITING인 상태에서 `stopped` 시그널로 stop()을 재호출하는 경로(download.py:257)가 있어, WAITING→stop은 예외가 아닌 no-op으로 정의했다. 이때도 일시정지 대기 스레드를 깨워야 하므로 Event는 항상 set한다.
3. **진행률 필드의 위치** — 이슈 명세대로 진행률 필드·집계를 core 모델에 두었지만, 엔진은 아직 `DownloadData`의 기존 필드를 갱신한다(엔진 무변경 원칙). 모델의 진행률 API는 현재 단위 테스트로만 검증되며, 엔진 연결은 Phase 3에서 이주 예정.
4. `task.lock`은 엔진이 future_count 등 공유 변수 동기화에 쓰고 있어(monitor.py:50 등) 어댑터에 별도 Lock으로 유지했다. 모델 내부 상태 전이 락과는 분리되어 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)