### PR TITLE
refactor: 다운로드 데이터 모델 통합 - Content·VideoInfo 신설, DownloadData 위임화 (#61)

### DIFF
--- a/content/network.py
+++ b/content/network.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 
 from core.api.dash import parse_dash_manifest
 from core.api.url_parser import extract_content_no
+from core.models.content import VideoInfo
 
 NAVER_API = "https://apis.naver.com"
 CHZZK_API = "https://api.chzzk.naver.com"
@@ -65,14 +66,16 @@ class NetworkManager:
         return extract_content_no(vod_url)
 
     @staticmethod
-    def get_video_info(video_no: str, cookies: dict):
+    def get_video_info(video_no: str, cookies: dict) -> VideoInfo:
         """
         API를 통해 video_no에 대응하는 video_id, in_key, 메타데이터를 가져온다.
 
-        membershipBenefitType·encryptionType도 함께 반환한다 (#55).
+        기존 8-tuple 대신 VideoInfo 데이터 객체를 반환한다 (#61). 값·의미는 무변경.
+
+        membership_benefit_type·encryption_type도 함께 반환한다 (#55).
         - 멤버십(구독자) 전용 VOD는 권한이 없으면 inKey가 null로 내려오므로,
-          호출부에서 membershipBenefitType으로 "멤버십 필요" 안내를 구분할 수 있다.
-        - encryptionType이 null이 아니면(AES 등) 세그먼트가 암호화되어 있어
+          호출부에서 membership_benefit_type으로 "멤버십 필요" 안내를 구분할 수 있다.
+        - encryption_type이 null이 아니면(AES 등) 세그먼트가 암호화되어 있어
           현재 다운로더로는 조립할 수 없으므로 호출부에서 조기에 안내한다.
         """
         api_url = f"{CHZZK_API}/service/v2/videos/{video_no}"
@@ -81,14 +84,6 @@ class NetworkManager:
         response.raise_for_status()
 
         content = response.json().get('content', {})
-        video_id = content.get('videoId')
-        in_key = content.get('inKey')
-        adult = content.get('adult')
-        vodStatus = content.get('vodStatus')
-        liveRewindPlaybackJson = content.get('liveRewindPlaybackJson')
-        membershipBenefitType = content.get('membershipBenefitType')
-        encryptionType = content.get('encryptionType')
-
         metadata = {
             'title': re.sub(r'[\\/:\*\?"<>|\n]', '', content.get('videoTitle', 'Unknown Title')), # 정규식으로 특수문자 제거
             'thumbnailImageUrl': content.get('thumbnailImageUrl', ''),
@@ -98,7 +93,16 @@ class NetworkManager:
             'createdDate': content.get('liveOpenDate', 'Unknown Date'),
             'duration': content.get('duration', 0),
         }
-        return video_id, in_key, adult, vodStatus, liveRewindPlaybackJson, membershipBenefitType, encryptionType, metadata
+        return VideoInfo(
+            video_id=content.get('videoId'),
+            in_key=content.get('inKey'),
+            adult=content.get('adult'),
+            vod_status=content.get('vodStatus'),
+            live_rewind_playback_json=content.get('liveRewindPlaybackJson'),
+            membership_benefit_type=content.get('membershipBenefitType'),
+            encryption_type=content.get('encryptionType'),
+            metadata=metadata,
+        )
 
     @staticmethod
     def get_video_dash_manifest(video_id: str, in_key: str, cookies: dict | None = None):

--- a/content/worker.py
+++ b/content/worker.py
@@ -41,30 +41,30 @@ class ContentWorker(QObject):
             self.error.emit(str(e))
 
     def fetchVideo(self, video_no: str):
-        video_id, in_key, adult, vodStatus, liveRewindPlaybackJson, membershipBenefitType, encryptionType, metadata = NetworkManager.get_video_info(video_no, self.cookies)
-        if adult and not video_id:
+        info = NetworkManager.get_video_info(video_no, self.cookies)
+        if info.adult and not info.video_id:
             errorMessage = self.tr("Invalid cookies value")
             raise ValueError(f"{self.vod_url}\n{errorMessage}")
-        elif encryptionType:
+        elif info.encryption_type:
             # 암호화(AES/SEA) VOD는 세그먼트를 복호화할 수 없어 다운로드 불가.
             # 권한(멤버십) 유무와 무관하므로 매니페스트 요청 전에 조기 안내한다 (#55)
             errorMessage = self.tr("Encrypted content is not supported")
             raise ValueError(f"{self.vod_url}\n{errorMessage}")
-        elif liveRewindPlaybackJson:
-            unique_reps, resolution, base_url = NetworkManager.get_video_m3u8_manifest(liveRewindPlaybackJson)
+        elif info.live_rewind_playback_json:
+            unique_reps, resolution, base_url = NetworkManager.get_video_m3u8_manifest(info.live_rewind_playback_json)
         else:
             # 멤버십 전용 VOD는 권한이 없으면 inKey가 null로 내려온다.
             # 이대로 매니페스트를 요청하면 원인을 알 수 없는 401이 노출되므로 먼저 안내한다 (#55)
-            if not in_key and membershipBenefitType == "MEMBER_ONLY":
+            if not info.in_key and info.membership_benefit_type == "MEMBER_ONLY":
                 errorMessage = self.tr("Channel membership required")
                 raise ValueError(f"{self.vod_url}\n{errorMessage}")
-            unique_reps, resolution, base_url = NetworkManager.get_video_dash_manifest(video_id, in_key, self.cookies)
+            unique_reps, resolution, base_url = NetworkManager.get_video_dash_manifest(info.video_id, info.in_key, self.cookies)
         if not unique_reps:
             errorMessage = self.tr("Failed to get DASH manifest")
             raise ValueError(f"{self.vod_url}\n{errorMessage}")
-        
+
         # 네트워크 작업 결과를 tuple 형태로 묶어서 전달
-        return (self.vod_url, metadata, unique_reps, resolution, base_url, self.downloadPath, liveRewindPlaybackJson)
+        return (self.vod_url, info.metadata, unique_reps, resolution, base_url, self.downloadPath, info.live_rewind_playback_json)
             
 
     def fetchClip(self, clip_no: str):

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,6 +1,14 @@
-"""core 도메인 모델 패키지 — UI와 무관한 순수 데이터·상태 모델 (#60)."""
+"""core 도메인 모델 패키지 — UI와 무관한 순수 데이터·상태 모델 (#60, #61)."""
 
+from core.models.content import Content, ContentType, VideoInfo
 from core.models.download_state import DownloadState
 from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
 
-__all__ = ["DownloadState", "DownloadTaskModel", "InvalidStateTransitionError"]
+__all__ = [
+    "Content",
+    "ContentType",
+    "VideoInfo",
+    "DownloadState",
+    "DownloadTaskModel",
+    "InvalidStateTransitionError",
+]

--- a/core/models/content.py
+++ b/core/models/content.py
@@ -1,0 +1,63 @@
+"""컨텐츠 도메인 모델 — 메타데이터 데이터클래스와 컨텐츠 타입 (#61, SPEC §4.1).
+
+서브클래스 없는 단일 데이터클래스로 정의한다 — 타입 간 차이는 도메인 행동이
+아니라 전달 방식이므로, 타입별 분기는 다운로더가 담당한다.
+ERROR는 컨텐츠 타입이 아니다 — 파싱·조회 실패는 예외로 다루고, 실패를 가짜
+Content로 만들지 않는다.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from uuid import uuid4
+
+
+class ContentType(Enum):
+    """컨텐츠 타입 (SPEC §4.1). 값은 현행 코드가 쓰는 문자열과 동일하다."""
+
+    CHZZK_VIDEO = "video"
+    CHZZK_VIDEO_M3U8 = "m3u8"
+    CHZZK_CLIP = "clip"
+    CHZZK_LIVE = "live"
+
+
+@dataclass
+class Content:
+    """컨텐츠 메타데이터 (SPEC §4.1). 서브클래스 없는 단일 데이터클래스.
+
+    필드는 현행 코드가 실제로 사용하는 것만 둔다. created_at·completed_at 등
+    SPEC의 미사용 필드는 실제 소비처가 생길 때 추가한다.
+    """
+
+    content_type: ContentType
+    url: str
+    id: str = field(default_factory=lambda: uuid4().hex)
+    download_path: str = ""
+    output_path: str = ""
+    channel_name: str | None = None
+    title: str | None = None
+    resolution: int | None = None
+    # 재생·암호화 관련 필드
+    base_url: str | None = None
+    video_id: str | None = None
+    in_key: str | None = None
+    encryption_type: str | None = None
+    live_rewind_playback_json: str | None = None
+
+
+@dataclass(frozen=True)
+class VideoInfo:
+    """get_video_info의 결과 객체 (#61).
+
+    기존 8-tuple 반환을 대체한다 — tuple은 항목이 늘어날 때마다 모든 호출부가
+    위치 기반으로 깨질 위험이 있고 필드 의미가 코드에 드러나지 않는다.
+    필드의 값·의미는 기존 tuple 항목과 1:1 대응한다.
+    """
+
+    video_id: str | None
+    in_key: str | None
+    adult: bool | None
+    vod_status: str | None
+    live_rewind_playback_json: str | None
+    membership_benefit_type: str | None
+    encryption_type: str | None
+    metadata: dict

--- a/core/models/download_task.py
+++ b/core/models/download_task.py
@@ -70,6 +70,14 @@ class DownloadTaskModel:
         """현재 다운로드 상태."""
         return self._state
 
+    def set_on_state_change(self, callback: Callable[[DownloadState], None] | None) -> None:
+        """상태 변경 콜백을 등록한다.
+
+        모델을 먼저 만들고(예: DownloadData 소유) 나중에 UI 연결이 결정되는
+        경우를 위해 생성자 주입과 별도로 제공한다 (#61).
+        """
+        self._on_state_change = callback
+
     def _transition(self, method: str, new_state: DownloadState) -> bool:
         """전이 공통 처리. 이미 목표 상태면 no-op(False), 전이 성공 시 True.
 

--- a/download/data.py
+++ b/download/data.py
@@ -1,38 +1,50 @@
-import threading
+"""다운로드 한 건의 공유 데이터 — core 모델로 통합 중인 어댑터 (#61).
+
+기존에는 컨텐츠 정보·상태·진행률 필드가 이 클래스에 평면적으로 흩어져 있었다.
+이제 소유는 core 모델이 한다:
+
+- 컨텐츠 식별·재생 정보(vod_url, base_url, output_path, resolution, content_type)
+  → core/models/content.py의 Content
+- 상태·진행률(total_size, threads_progress, start/end_time, _pause_event)
+  → core/models/download_task.py의 DownloadTaskModel (#60에서 신설, 단일 소유처)
+
+다운로드 엔진(worker/monitor)은 무변경 유지가 원칙이므로(Phase 3 소관),
+기존 속성 이름을 위임 프로퍼티로 제공한다. 엔진 내부 구현 변수
+(future_count, remaining_ranges 등)는 도메인 데이터가 아니므로 이곳에 남는다.
+"""
+
+from core.models.content import Content, ContentType
+from core.models.download_task import DownloadTaskModel
+
 
 class DownloadData:
+    """다운로드 스레드·모니터가 공유하는 데이터 홀더 (core 모델 위임 어댑터)."""
+
     def __init__(self, base_url, vod_url, output_path, resolution, content_type):
+        # 컨텐츠 식별·재생 정보의 소유처 (#61)
+        self.content = Content(
+            content_type=ContentType(content_type),
+            url=vod_url,
+            output_path=output_path,
+            resolution=resolution,
+            base_url=base_url,
+        )
+        # 상태·진행률의 소유처. DownloadTask 어댑터가 이 모델로 상태 전이를 수행한다
+        self.model = DownloadTaskModel()
+
         self.total_downloaded_size = 0
-        self.total_size = 0
-        
-        # 공유 변수
-        self._pause_event = threading.Event()
-        self._pause_event.set()
-        #TODO: Task로 옮길지에 대해 논의
 
         # CPU 개수를 바탕으로 초깃값 지정
         self.adjust_threads = 4
         self.max_threads = self.adjust_threads
 
-        self.start_time = 0
-        self.end_time = 0
         self.future_count = 0
-
         self.total_ranges = 0
-        self.threads_progress = []
-
         self.remaining_ranges = []
 
         self.speed_mb = 0
         self.merged_segments = 0
 
-        # DownloadThread 내부 변수
-        self.base_url = base_url
-        self.vod_url = vod_url
-        self.output_path = output_path
-        self.resolution = resolution
-        self.content_type = content_type
-        
         # 진행도/실패/재시작/스레드 관련 변수
         self.completed_threads = 0
         self.failed_threads = 0
@@ -41,3 +53,84 @@ class DownloadData:
 
         # MonitorThread 내부 변수
         self.prev_size = 0
+
+    # ============ 컨텐츠 필드 위임 (Content 소유) ============
+
+    @property
+    def base_url(self):
+        return self.content.base_url
+
+    @base_url.setter
+    def base_url(self, value):
+        self.content.base_url = value
+
+    @property
+    def vod_url(self):
+        return self.content.url
+
+    @vod_url.setter
+    def vod_url(self, value):
+        self.content.url = value
+
+    @property
+    def output_path(self):
+        return self.content.output_path
+
+    @output_path.setter
+    def output_path(self, value):
+        self.content.output_path = value
+
+    @property
+    def resolution(self):
+        return self.content.resolution
+
+    @resolution.setter
+    def resolution(self, value):
+        self.content.resolution = value
+
+    @property
+    def content_type(self) -> str:
+        # 엔진은 기존 문자열('video'/'m3u8'/'clip')과 비교하므로 값을 그대로 돌려준다
+        return self.content.content_type.value
+
+    @content_type.setter
+    def content_type(self, value: str):
+        self.content.content_type = ContentType(value)
+
+    # ============ 상태·진행률 필드 위임 (DownloadTaskModel 소유) ============
+
+    @property
+    def total_size(self):
+        return self.model.total_size
+
+    @total_size.setter
+    def total_size(self, value):
+        self.model.total_size = value
+
+    @property
+    def threads_progress(self):
+        return self.model.threads_progress
+
+    @threads_progress.setter
+    def threads_progress(self, value):
+        self.model.threads_progress = value
+
+    @property
+    def start_time(self):
+        return self.model.start_time
+
+    @start_time.setter
+    def start_time(self, value):
+        self.model.start_time = value
+
+    @property
+    def end_time(self):
+        return self.model.end_time
+
+    @end_time.setter
+    def end_time(self, value):
+        self.model.end_time = value
+
+    @property
+    def _pause_event(self):
+        return self.model.pause_event

--- a/download/download_m3u8.py
+++ b/download/download_m3u8.py
@@ -39,8 +39,8 @@ class DownloadM3U8Thread(QThread):
                 'NID_SES': data.get("NID_SES", "")
             }
             content_type, content_no = NetworkManager.extract_content_no(self.s.vod_url)
-            video_id, in_key, adult, vodStatus, liveRewindPlaybackJson, membershipBenefitType, encryptionType, metadata = NetworkManager.get_video_info(content_no, cookies)
-            self.s.base_url = NetworkManager.get_video_m3u8_base_url(liveRewindPlaybackJson, self.s.resolution, cookies)
+            info = NetworkManager.get_video_info(content_no, cookies)
+            self.s.base_url = NetworkManager.get_video_m3u8_base_url(info.live_rewind_playback_json, self.s.resolution, cookies)
             threading.current_thread().name = "DownloadM3U8Thread"  # 스레드 시작 시 이름 재설정
             self.s.start_time = tm.time()
 

--- a/download/task.py
+++ b/download/task.py
@@ -10,7 +10,7 @@ import threading
 
 from content.data import ContentItem
 from core.models.download_state import DownloadState
-from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
+from core.models.download_task import InvalidStateTransitionError
 from download.data import DownloadData
 from download.logger import DownloadLogger
 
@@ -25,11 +25,10 @@ class DownloadTask:
         # 엔진(worker/monitor)이 future_count 등 공유 변수 동기화에 쓰는 락.
         # 모델 내부의 상태 전이 락과는 별개다 (엔진 무변경 유지 — Phase 3에서 정리).
         self.lock = threading.Lock()
-        # 엔진이 data._pause_event로 일시정지를 대기하므로 모델과 같은 Event를 공유한다
-        self.model = DownloadTaskModel(
-            pause_event=data._pause_event,
-            on_state_change=item.setDownloadState,
-        )
+        # 상태·진행률의 소유처는 DownloadData가 가진 core 모델 하나다 (#61).
+        # 별도 모델을 만들지 않고 같은 모델에 UI 반영 콜백만 연결한다
+        self.model = data.model
+        self.model.set_on_state_change(item.setDownloadState)
 
     @property
     def state(self) -> DownloadState:

--- a/tests/unit/core/test_content_model.py
+++ b/tests/unit/core/test_content_model.py
@@ -1,0 +1,80 @@
+"""core/models/content.py 컨텐츠 모델 단위 테스트 (#61).
+
+ContentType 값 매핑, Content 기본값·id 생성, VideoInfo 불변성을 검증한다.
+"""
+
+import dataclasses
+
+import pytest
+
+from core.models.content import Content, ContentType, VideoInfo
+
+
+class TestContentType:
+    def test_values_match_current_strings(self):
+        """열거형 값은 현행 코드가 쓰는 문자열('video'/'m3u8'/'clip'/'live')과 같아야 한다."""
+        assert ContentType.CHZZK_VIDEO.value == "video"
+        assert ContentType.CHZZK_VIDEO_M3U8.value == "m3u8"
+        assert ContentType.CHZZK_CLIP.value == "clip"
+        assert ContentType.CHZZK_LIVE.value == "live"
+
+    def test_lookup_by_value(self):
+        """기존 문자열로 역변환(ContentType(value))이 가능해야 한다."""
+        assert ContentType("video") is ContentType.CHZZK_VIDEO
+        assert ContentType("m3u8") is ContentType.CHZZK_VIDEO_M3U8
+        assert ContentType("clip") is ContentType.CHZZK_CLIP
+
+    def test_unknown_value_raises(self):
+        """정의되지 않은 타입 문자열은 ValueError — 에러를 타입 값으로 표현하지 않는다."""
+        with pytest.raises(ValueError):
+            ContentType("error")
+
+
+class TestContent:
+    def test_minimal_construction_with_defaults(self):
+        """필수 필드만으로 생성되고 나머지는 기본값이어야 한다."""
+        content = Content(content_type=ContentType.CHZZK_VIDEO, url="https://chzzk.naver.com/video/1")
+        assert content.content_type is ContentType.CHZZK_VIDEO
+        assert content.url == "https://chzzk.naver.com/video/1"
+        assert content.title is None
+        assert content.resolution is None
+        assert content.encryption_type is None
+
+    def test_id_is_unique_per_instance(self):
+        """id는 인스턴스마다 자동 생성되는 고유값이어야 한다."""
+        a = Content(content_type=ContentType.CHZZK_CLIP, url="u")
+        b = Content(content_type=ContentType.CHZZK_CLIP, url="u")
+        assert a.id and b.id
+        assert a.id != b.id
+
+    def test_is_single_dataclass_without_subclasses(self):
+        """SPEC §4.1: 서브클래스 없는 단일 데이터클래스여야 한다."""
+        assert dataclasses.is_dataclass(Content)
+        assert Content.__subclasses__() == []
+
+
+class TestVideoInfo:
+    def _make(self) -> VideoInfo:
+        return VideoInfo(
+            video_id="vid",
+            in_key="key",
+            adult=False,
+            vod_status="ABR_HLS",
+            live_rewind_playback_json=None,
+            membership_benefit_type=None,
+            encryption_type=None,
+            metadata={"duration": 1},
+        )
+
+    def test_field_access(self):
+        """tuple 위치가 아닌 이름으로 필드에 접근할 수 있어야 한다."""
+        info = self._make()
+        assert info.video_id == "vid"
+        assert info.in_key == "key"
+        assert info.metadata["duration"] == 1
+
+    def test_result_object_is_immutable(self):
+        """조회 결과는 값 객체이므로 필드 재할당이 금지된다(frozen)."""
+        info = self._make()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.video_id = "other"

--- a/tests/unit/test_download_data.py
+++ b/tests/unit/test_download_data.py
@@ -1,0 +1,63 @@
+"""download/data.py의 core 모델 위임 검증 (#61).
+
+DownloadData가 컨텐츠 필드는 Content로, 상태·진행률 필드는 DownloadTaskModel로
+위임하면서 기존 속성 이름(엔진 인터페이스)을 그대로 유지하는지 확인한다.
+"""
+
+import pytest
+
+from download.data import DownloadData
+
+
+def _make_data() -> DownloadData:
+    return DownloadData(
+        "https://cdn.example/base", "https://chzzk.naver.com/video/1", "out.mp4", 1080, "video"
+    )
+
+
+def test_content_fields_are_delegated_to_content_model():
+    """컨텐츠 필드는 Content가 소유하고, 기존 속성 이름으로 읽고 쓸 수 있어야 한다."""
+    data = _make_data()
+
+    assert data.vod_url == "https://chzzk.naver.com/video/1"
+    assert data.base_url == "https://cdn.example/base"
+    assert data.output_path == "out.mp4"
+    assert data.resolution == 1080
+    # 엔진은 문자열 비교를 하므로 content_type은 기존 문자열 값을 돌려줘야 한다
+    assert data.content_type == "video"
+
+    # 엔진이 하는 쓰기(예: m3u8 스레드의 base_url 해석)가 Content에 반영돼야 한다
+    data.base_url = "https://cdn.example/1080"
+    assert data.content.base_url == "https://cdn.example/1080"
+
+
+def test_state_progress_fields_are_delegated_to_task_model():
+    """상태·진행률 필드는 DownloadTaskModel이 단일 소유처여야 한다."""
+    data = _make_data()
+
+    data.total_size = 1000
+    assert data.model.total_size == 1000
+
+    # 엔진의 배열 초기화·개별 갱신 패턴이 모델에 그대로 반영돼야 한다
+    data.threads_progress = [0] * 4
+    data.threads_progress[1] = 250
+    assert data.model.threads_progress == [0, 250, 0, 0]
+    assert data.model.downloaded_size == 250
+
+    data.start_time = 1.0
+    data.end_time = 3.5
+    assert data.model.start_time == 1.0
+    assert data.model.end_time == 3.5
+
+
+def test_pause_event_is_the_models_event():
+    """_pause_event는 모델의 pause_event와 같은 객체여야 한다 (일시정지 연동)."""
+    data = _make_data()
+    assert data._pause_event is data.model.pause_event
+    assert data._pause_event.is_set()  # 초기 상태는 진행 가능
+
+
+def test_unknown_content_type_raises():
+    """정의되지 않은 content_type 문자열은 생성 시점에 ValueError로 실패해야 한다."""
+    with pytest.raises(ValueError):
+        DownloadData("b", "u", "o", 720, "unknown-type")

--- a/tests/unit/test_download_task_adapter.py
+++ b/tests/unit/test_download_task_adapter.py
@@ -38,7 +38,7 @@ class _FakeItem:
 
 
 def _make_task() -> tuple[DownloadTask, DownloadData, _FakeItem, _FakeLogger]:
-    data = DownloadData("base", "vod", "out.mp4", "1080p", "zip")
+    data = DownloadData("base", "vod", "out.mp4", 1080, "video")
     item = _FakeItem()
     logger = _FakeLogger()
     return DownloadTask(data, item, logger), data, item, logger

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -143,16 +143,7 @@ class TestGetVideoInfo:
 
         monkeypatch.setattr(network._session, "get", fake_get)
 
-        (
-            video_id,
-            in_key,
-            adult,
-            vodStatus,
-            liveRewindPlaybackJson,
-            membershipBenefitType,
-            encryptionType,
-            metadata,
-        ) = NetworkManager.get_video_info("13714380", cookies)
+        info = NetworkManager.get_video_info("13714380", cookies)
 
         # 요청 구성: URL과 쿠키가 그대로 실려야 한다
         assert calls == [
@@ -161,15 +152,16 @@ class TestGetVideoInfo:
                 {"cookies": cookies, "headers": {"User-Agent": "Mozilla/5.0"}},
             )
         ]
+        # 반환은 tuple이 아닌 VideoInfo 필드 접근 (#61). 기대값 자체는 무변경.
         # 멤버십 전용 VOD: videoId는 있으나 권한이 없으면 inKey가 null이다
-        assert video_id == "54D1729900196FDCEC43D70891951FE9FA3C"
-        assert in_key is None
-        assert adult is False
-        assert vodStatus == "ABR_HLS"
-        assert liveRewindPlaybackJson is None
-        assert membershipBenefitType == "MEMBER_ONLY"
-        assert encryptionType == "AES"
-        assert metadata["duration"] == 10925
+        assert info.video_id == "54D1729900196FDCEC43D70891951FE9FA3C"
+        assert info.in_key is None
+        assert info.adult is False
+        assert info.vod_status == "ABR_HLS"
+        assert info.live_rewind_playback_json is None
+        assert info.membership_benefit_type == "MEMBER_ONLY"
+        assert info.encryption_type == "AES"
+        assert info.metadata["duration"] == 10925
 
 
 class TestGetVideoM3u8BaseUrl:

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -12,6 +12,7 @@ import pytest
 import content.network as network
 from content.network import NetworkManager
 from content.worker import ContentWorker
+from core.models.content import VideoInfo
 from tests.mocks.mock_http import MockResponse
 
 COOKIES = {"NID_AUT": "REDACTED", "NID_SES": "REDACTED"}
@@ -60,7 +61,16 @@ def test_member_only_without_in_key_raises_membership_error(monkeypatch):
     """비암호화 멤버십 전용 VOD(inKey null)이면 멤버십 안내 에러가 발생해야 한다."""
 
     def fake_get_video_info(video_no, cookies):
-        return "video-id", None, False, "ABR_HLS", None, "MEMBER_ONLY", None, {}
+        return VideoInfo(
+            video_id="video-id",
+            in_key=None,
+            adult=False,
+            vod_status="ABR_HLS",
+            live_rewind_playback_json=None,
+            membership_benefit_type="MEMBER_ONLY",
+            encryption_type=None,
+            metadata={},
+        )
 
     monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
 
@@ -74,7 +84,16 @@ def test_adult_without_video_id_keeps_invalid_cookies_error(monkeypatch):
     """성인 VOD(adult=True, videoId 없음)의 기존 에러 동작이 유지돼야 한다 (회귀 방지)."""
 
     def fake_get_video_info(video_no, cookies):
-        return None, None, True, "ABR_HLS", None, None, None, {}
+        return VideoInfo(
+            video_id=None,
+            in_key=None,
+            adult=True,
+            vod_status="ABR_HLS",
+            live_rewind_playback_json=None,
+            membership_benefit_type=None,
+            encryption_type=None,
+            metadata={},
+        )
 
     monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
 
@@ -89,8 +108,16 @@ def test_dash_path_passes_cookies_to_manifest_request(monkeypatch):
     manifest_calls = []
 
     def fake_get_video_info(video_no, cookies):
-        metadata = {"title": "t", "duration": 1}
-        return "video-id", "in-key", False, "ABR_HLS", None, "MEMBER_ONLY", None, metadata
+        return VideoInfo(
+            video_id="video-id",
+            in_key="in-key",
+            adult=False,
+            vod_status="ABR_HLS",
+            live_rewind_playback_json=None,
+            membership_benefit_type="MEMBER_ONLY",
+            encryption_type=None,
+            metadata={"title": "t", "duration": 1},
+        )
 
     def fake_get_dash_manifest(video_id, in_key, cookies=None):
         manifest_calls.append((video_id, in_key, cookies))


### PR DESCRIPTION
## 관련 이슈

Closes #61

## 변경 내용

다운로드 한 건의 정보를 core 도메인 모델로 통합했다 (Phase 2, SPEC §4.1). `2.8.0-dev` 브랜치는 베이스로 쓰지 않았고, 현재 main 기준으로 재적용했다.

- **`core/models/content.py` (신규)**
  - `ContentType` 열거형: `CHZZK_VIDEO | CHZZK_VIDEO_M3U8 | CHZZK_CLIP | CHZZK_LIVE` (SPEC §4.1). 값은 현행 코드의 문자열(`'video'/'m3u8'/'clip'/'live'`)과 동일해 `ContentType(value)` 역변환으로 기존 문자열과 호환된다. 정의되지 않은 값은 `ValueError` — 에러를 타입 값으로 표현하지 않는다.
  - `Content` 단일 데이터클래스 (서브클래스 없음): id(uuid hex 자동), content_type, url, download_path, output_path, channel_name, title, resolution + 재생·암호화 필드(base_url, video_id, in_key, encryption_type, live_rewind_playback_json). 현행 코드가 실제 사용하는 필드만 두고 created_at 등 미사용 SPEC 필드는 소비처가 생길 때 추가.
  - `VideoInfo` (frozen): `get_video_info` 전용 결과 객체. 기존 8-tuple 항목과 1:1 대응.
- **`get_video_info` tuple 반환 제거**: `VideoInfo` 반환으로 교체하고 두 호출부(`content/worker.py` fetchVideo, `download/download_m3u8.py`의 재해석 경로)를 필드 접근으로 수정. 값·동작·에러 분기(#55의 암호화/멤버십 안내) 무변경.
- **DownloadData 중복 필드 통합** (`download/data.py`): 컨텐츠 식별·재생 필드(vod_url, base_url, output_path, resolution, content_type)는 `Content`가, 상태·진행률 필드(total_size, threads_progress, start/end_time, _pause_event)는 #60의 `DownloadTaskModel`이 소유한다. 기존 속성 이름은 위임 프로퍼티로 유지해 **다운로드 엔진(worker/monitor)은 무변경**.
- **`download/task.py` 어댑터**: 별도 모델을 만들지 않고 `data.model`을 공유, `set_on_state_change`(core에 신규 추가)로 UI 반영 콜백만 연결. #60에서 pause_event만 공유하던 구조가 모델 전체 공유로 정리됨.
- **테스트**: `tests/unit/core/test_content_model.py`, `tests/unit/test_download_data.py` 신규. tuple 인덱스·언패킹에 의존하던 `test_network.py`·`test_worker.py`를 필드 접근으로 갱신 — **기대값 자체는 무변경**.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (114 passed, Windows 로컬 — core 순수성 가드 포함)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시)
- [x] `uv run python scripts/headless_download.py` 임포트 체인·인자 처리 정상
- [ ] 앱 스모크(일반 VOD 1회 + 암호화 VOD 안내 문구(#56 회귀) + 클립 1회), 공개 VOD 헤드리스 실다운로드 — 실제 VOD URL·GUI 조작이 필요해 소유자 확인 요청드립니다. 암호화 VOD 분기는 실응답 픽스처 테스트(test_worker.py)로는 통과 확인됨.

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — core/models는 표준 라이브러리만 import
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — `core/models/content.py` 추가는 이슈 #61에서 `approved`로 승인된 범위

## 리뷰어에게

**통합 방향 선택과 근거 (이슈 항목 3)**: 중복 필드는 **core `DownloadTaskModel` 쪽으로** 모았다. 근거: (1) SPEC §4.2가 상태·진행률의 소유처를 DownloadTask로 규정하고, #60에서 이미 그 필드들이 core 모델에 정의됨 — DownloadData 쪽으로 모으면 #60과 역행한다. (2) DownloadData는 Qt 계층(download/)에 있어 core로 모아야 단위 테스트가 Qt 없이 가능하다. (3) 엔진 무변경 제약은 DownloadData를 위임 프로퍼티 어댑터로 만들어 충족했다 — Phase 3에서 엔진이 core 모델을 직접 쓰게 되면 이 어댑터는 제거 대상이다.

판단이 필요했던 지점:

1. **`ContentType` 값을 SPEC 이름(CHZZK_VIDEO 등) + 현행 문자열 값('video' 등)으로 정의** — 엔진과 UI가 문자열 비교(`content_type == "m3u8"`)를 하므로, 값 호환을 유지하면서 이름은 SPEC을 따랐다. ContentItem 등 app 계층의 문자열 사용처 전환은 이 이슈 범위 밖이라 두지 않았다.
2. **`Content`에 base_url·output_path 포함** — 이슈의 필드 목록에는 없지만 "현행 코드가 실제로 사용하는 것만"이라는 원칙에 따라, DownloadData가 실제 보유하던 재생·저장 필드를 포함했다. 과하다고 판단되면 DownloadData의 평면 속성으로 되돌릴 수 있다.
3. **에러를 컨텐츠 타입으로 표현하는 코드(이슈 항목 4)는 현재 코드에 없음을 확인** — content_type 대입은 worker의 'm3u8'/'clip' 전환 두 곳뿐이다. 다만 `get_clip_manifest`가 에러를 4번째 tuple 항목으로 반환하는 패턴이 남아 있는데, 클립 API 반환 형태는 이 이슈의 작업 범위 밖이라 손대지 않았다. 원하시면 후속 이슈로 제안하겠다.
4. **worker → manager의 7-tuple 결과는 유지** — 이슈 범위가 get_video_info 반환 형태와 그 호출부로 한정되어 있어, 워커 시그널 페이로드 교체는 범위 밖으로 판단했다 (Phase 2 후속에서 Content로 대체 가능).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
