### PR TITLE
refactor: Session 헬퍼·로깅 설정 모듈 core 이주 (#62)

### DIFF
--- a/config/log_setup.py
+++ b/config/log_setup.py
@@ -1,64 +1,28 @@
-"""공통 logging 설정 모듈 (#30).
+"""공통 logging 설정 진입점 — 구현은 core/utils/logging_setup.py로 이주 (#62, 원본 #30).
 
-앱 전역에서 사용할 표준 logging 핸들러(콘솔 + 회전 파일)를 루트 로거에 연결한다.
-각 모듈은 `logging.getLogger(__name__)`로 로거를 얻어 쓰기만 하면 되고,
-핸들러·포맷 구성은 이 모듈에서만 관리한다.
+로그 저장 위치(CONFIG_DIR/logs)는 app 영역 지식이므로 core에 두지 않고 여기서 주입한다.
+기존 호출부(main.py, scripts/headless_download.py)의 import 경로와 시그니처는 그대로다.
 """
 
 import logging
-import logging.handlers
 import os
 
 import config.config as config
-
-# 포맷: 시간·레벨·모듈·메시지
-LOG_FORMAT = "%(asctime)s - %(levelname)s - [%(name)s] - %(message)s"
-LOG_FILE_NAME = "app.log"
-
-# 파일 회전 설정: 1MB × 5개 백업
-MAX_BYTES = 1024 * 1024
-BACKUP_COUNT = 5
-
-# 중복 초기화 방지 플래그
-_configured = False
+from core.utils import logging_setup as _logging_setup
+from core.utils.logging_setup import (  # noqa: F401 — 하위 호환 re-export
+    BACKUP_COUNT,
+    LOG_FILE_NAME,
+    LOG_FORMAT,
+    MAX_BYTES,
+)
 
 
 def setup_logging(log_level: int = logging.DEBUG) -> None:
-    """루트 로거에 콘솔·회전 파일 핸들러를 설정한다.
+    """루트 로거 설정을 core 구현에 위임한다.
 
-    앱 시작 시 한 번만 호출한다. 재호출은 무시된다(핸들러 중복 방지).
+    로그 파일 위치는 기존 규칙(CONFIG_DIR/logs)을 그대로 따른다.
 
     Args:
         log_level: 루트 로거에 적용할 로깅 레벨 (기본값: DEBUG)
     """
-    global _configured
-    if _configured:
-        return
-
-    # 로그 파일 위치는 기존 규칙(CONFIG_DIR/logs)을 그대로 따른다
-    log_dir = os.path.join(config.CONFIG_DIR, "logs")
-    os.makedirs(log_dir, exist_ok=True)
-
-    formatter = logging.Formatter(LOG_FORMAT)
-
-    file_handler = logging.handlers.RotatingFileHandler(
-        os.path.join(log_dir, LOG_FILE_NAME),
-        maxBytes=MAX_BYTES,
-        backupCount=BACKUP_COUNT,
-        encoding="utf-8",
-    )
-    file_handler.setFormatter(formatter)
-
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
-
-    root_logger = logging.getLogger()
-    root_logger.setLevel(log_level)
-    root_logger.addHandler(file_handler)
-    root_logger.addHandler(console_handler)
-
-    # 서드파티 라이브러리의 과도한 DEBUG 출력은 억제한다
-    # (다운로드 시 요청 1건마다 urllib3 로그가 쌓여 로그가 불어나는 것 방지)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
-
-    _configured = True
+    _logging_setup.setup_logging(os.path.join(config.CONFIG_DIR, "logs"), log_level)

--- a/content/network.py
+++ b/content/network.py
@@ -1,50 +1,19 @@
 import re
-import requests
 import json
-import threading
-from http.cookiejar import DefaultCookiePolicy
 from urllib.parse import urljoin
 
 from core.api.dash import parse_dash_manifest
 from core.api.url_parser import extract_content_no
 from core.models.content import VideoInfo
 
+# Session 관리는 core/api/session.py로 이주했다 (#62, 원본 #31).
+# _session은 아래 NetworkManager가 계속 사용하고, 나머지는 기존 호출부 호환용 re-export다.
+from core.api.session import _session
+from core.api.session import _make_session, get_thread_session  # noqa: F401
+
 NAVER_API = "https://apis.naver.com"
 CHZZK_API = "https://api.chzzk.naver.com"
 VIDEOHUB_API = "https://api-videohub.naver.com"
-
-
-def _make_session() -> requests.Session:
-    """연결 재사용용 Session을 만든다 (#31).
-
-    기존에는 매 호출 requests.get()이 독립적이라 응답의 Set-Cookie가 다음 요청으로
-    이어지지 않았다. 이 이슈는 연결 재사용만 도입하므로, 응답 쿠키 저장을 차단해
-    쿠키 동작을 기존과 동일하게 유지한다. 요청별 cookies= 인자는 그대로 전송된다.
-    """
-    session = requests.Session()
-    session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
-    return session
-
-
-# NetworkManager API 호출용 모듈 수준 공유 세션.
-# 응답 쿠키를 저장하지 않으므로 여러 스레드에서 호출해도 상태 공유 문제가 없다.
-_session = _make_session()
-
-# 다운로드 워커용 스레드로컬 세션 저장소
-_thread_local = threading.local()
-
-
-def get_thread_session() -> requests.Session:
-    """호출한 스레드 전용 Session을 반환한다 (없으면 생성).
-
-    requests.Session은 스레드 간 완전한 안전이 보장되지 않으므로, 다운로드 워커처럼
-    동시 요청이 많은 경로는 스레드마다 별도 Session을 사용해 연결 재사용만 취한다.
-    """
-    session = getattr(_thread_local, "session", None)
-    if session is None:
-        session = _make_session()
-        _thread_local.session = session
-    return session
 
 
 class NetworkManager:

--- a/core/api/session.py
+++ b/core/api/session.py
@@ -1,0 +1,43 @@
+"""requests.Session 관리 모듈 (#62, 원본 #31).
+
+공유 세션과 스레드로컬 세션 헬퍼는 Qt와 무관한 인프라 코드이므로 core로 이주했다.
+쿠키 저장 차단 정책과 스레드로컬 방식은 #35에서 검증된 동작을 그대로 유지한다.
+"""
+
+import threading
+from http.cookiejar import DefaultCookiePolicy
+
+import requests
+
+
+def _make_session() -> requests.Session:
+    """연결 재사용용 Session을 만든다 (#31).
+
+    기존에는 매 호출 requests.get()이 독립적이라 응답의 Set-Cookie가 다음 요청으로
+    이어지지 않았다. 이 이슈는 연결 재사용만 도입하므로, 응답 쿠키 저장을 차단해
+    쿠키 동작을 기존과 동일하게 유지한다. 요청별 cookies= 인자는 그대로 전송된다.
+    """
+    session = requests.Session()
+    session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
+    return session
+
+
+# API 호출용 모듈 수준 공유 세션.
+# 응답 쿠키를 저장하지 않으므로 여러 스레드에서 호출해도 상태 공유 문제가 없다.
+_session = _make_session()
+
+# 다운로드 워커용 스레드로컬 세션 저장소
+_thread_local = threading.local()
+
+
+def get_thread_session() -> requests.Session:
+    """호출한 스레드 전용 Session을 반환한다 (없으면 생성).
+
+    requests.Session은 스레드 간 완전한 안전이 보장되지 않으므로, 다운로드 워커처럼
+    동시 요청이 많은 경로는 스레드마다 별도 Session을 사용해 연결 재사용만 취한다.
+    """
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = _make_session()
+        _thread_local.session = session
+    return session

--- a/core/utils/logging_setup.py
+++ b/core/utils/logging_setup.py
@@ -1,0 +1,64 @@
+"""공통 logging 설정 모듈 (#62, 원본 #30).
+
+앱 전역에서 사용할 표준 logging 핸들러(콘솔 + 회전 파일)를 루트 로거에 연결한다.
+각 모듈은 `logging.getLogger(__name__)`로 로거를 얻어 쓰기만 하면 되고,
+핸들러·포맷 구성은 이 모듈에서만 관리한다.
+
+로그 저장 위치(CONFIG_DIR/logs)는 app 영역 지식이므로 core는 경로를 정하지 않고
+log_dir 인자로 주입받는다 — 기존 진입점인 config/log_setup.py가 주입한다.
+"""
+
+import logging
+import logging.handlers
+import os
+
+# 포맷: 시간·레벨·모듈·메시지
+LOG_FORMAT = "%(asctime)s - %(levelname)s - [%(name)s] - %(message)s"
+LOG_FILE_NAME = "app.log"
+
+# 파일 회전 설정: 1MB × 5개 백업
+MAX_BYTES = 1024 * 1024
+BACKUP_COUNT = 5
+
+# 중복 초기화 방지 플래그
+_configured = False
+
+
+def setup_logging(log_dir: str, log_level: int = logging.DEBUG) -> None:
+    """루트 로거에 콘솔·회전 파일 핸들러를 설정한다.
+
+    앱 시작 시 한 번만 호출한다. 재호출은 무시된다(핸들러 중복 방지).
+
+    Args:
+        log_dir: 로그 파일을 저장할 디렉토리 (없으면 생성)
+        log_level: 루트 로거에 적용할 로깅 레벨 (기본값: DEBUG)
+    """
+    global _configured
+    if _configured:
+        return
+
+    os.makedirs(log_dir, exist_ok=True)
+
+    formatter = logging.Formatter(LOG_FORMAT)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        os.path.join(log_dir, LOG_FILE_NAME),
+        maxBytes=MAX_BYTES,
+        backupCount=BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+    # 서드파티 라이브러리의 과도한 DEBUG 출력은 억제한다
+    # (다운로드 시 요청 1건마다 urllib3 로그가 쌓여 로그가 불어나는 것 방지)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    _configured = True

--- a/download/download.py
+++ b/download/download.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import QThread, Signal
 from concurrent.futures import ThreadPoolExecutor
 from download.task import DownloadTask
 from download.state import DownloadState
-from content.network import get_thread_session
+from core.api.session import get_thread_session
 
 # 구현은 core/downloaders/ranges.py로 이동했다 (#50). 기존 호출부 호환용 re-export.
 from core.downloaders.ranges import decide_part_size, split_ranges

--- a/download/download_m3u8.py
+++ b/download/download_m3u8.py
@@ -10,7 +10,8 @@ from PySide6.QtCore import QThread, Signal
 from concurrent.futures import ThreadPoolExecutor
 from download.task import DownloadTask
 from download.state import DownloadState
-from content.network import NetworkManager, get_thread_session
+from content.network import NetworkManager
+from core.api.session import get_thread_session
 
 class DownloadM3U8Thread(QThread):
     """

--- a/download/logger.py
+++ b/download/logger.py
@@ -50,7 +50,7 @@ class DownloadLogger:
         file_handler.setFormatter(formatter)
 
         # 핸들러 추가 — 콘솔 출력은 자체 핸들러 대신 공통 로깅 설정(루트 로거,
-        # config/log_setup.py)으로 전파되어 처리된다 (#30)
+        # core/utils/logging_setup.py)으로 전파되어 처리된다 (#30, #62)
         self.logger.addHandler(file_handler)
 
     def save_and_close(self):

--- a/tests/unit/core/test_logging_setup.py
+++ b/tests/unit/core/test_logging_setup.py
@@ -1,0 +1,75 @@
+"""core.utils.logging_setup 공통 로깅 설정 단위 테스트 (#62, 원본 #30).
+
+tests/unit/test_log_setup.py에서 이주했다. 핸들러 구성·기대 동작 무변경.
+로그 위치 주입(CONFIG_DIR/logs)은 config/log_setup.py 진입점 테스트에서 검증한다.
+"""
+
+import logging
+import logging.handlers
+
+import pytest
+
+import core.utils.logging_setup as logging_setup
+
+
+@pytest.fixture
+def isolated_logging(monkeypatch, tmp_path):
+    """임시 로그 디렉토리를 제공하고, 테스트 후 루트 로거 상태를 복원한다."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+
+    monkeypatch.setattr(logging_setup, "_configured", False)
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    yield tmp_path
+
+    # setup_logging이 추가한 핸들러를 닫고 원래 핸들러·레벨을 복원한다
+    for handler in root.handlers[:]:
+        handler.close()
+        root.removeHandler(handler)
+    for handler in saved_handlers:
+        root.addHandler(handler)
+    root.setLevel(saved_level)
+
+
+def test_setup_adds_console_and_rotating_file_handlers(isolated_logging):
+    """루트 로거에 콘솔 핸들러와 회전 파일 핸들러가 각각 1개씩 연결된다."""
+    # pytest 로깅 플러그인이 끼워 넣는 캡처 핸들러를 제외하기 위해 전후 차집합으로 비교한다
+    before = set(logging.getLogger().handlers)
+
+    logging_setup.setup_logging(str(isolated_logging / "logs"))
+
+    added = [h for h in logging.getLogger().handlers if h not in before]
+    rotating = [
+        h for h in added if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    consoles = [
+        h
+        for h in added
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    ]
+    assert len(rotating) == 1
+    assert len(consoles) == 1
+
+
+def test_log_message_is_written_to_logs_file(isolated_logging):
+    """모듈 로거로 남긴 메시지가 log_dir의 app.log 파일에 기록된다."""
+    logging_setup.setup_logging(str(isolated_logging / "logs"))
+
+    logging.getLogger("smoke.test").info("hello log file")
+
+    log_file = isolated_logging / "logs" / logging_setup.LOG_FILE_NAME
+    assert log_file.exists()
+    assert "hello log file" in log_file.read_text(encoding="utf-8")
+
+
+def test_setup_logging_is_idempotent(isolated_logging):
+    """setup_logging을 여러 번 호출해도 핸들러가 중복 추가되지 않는다."""
+    logging_setup.setup_logging(str(isolated_logging / "logs"))
+    handler_count = len(logging.getLogger().handlers)
+
+    logging_setup.setup_logging(str(isolated_logging / "logs"))
+
+    assert len(logging.getLogger().handlers) == handler_count

--- a/tests/unit/core/test_session.py
+++ b/tests/unit/core/test_session.py
@@ -1,21 +1,25 @@
-"""content.network의 Session 도입(연결 재사용) 단위 테스트 (#31)."""
+"""core.api.session의 Session 관리(연결 재사용·쿠키 차단) 단위 테스트 (#62, 원본 #31).
+
+tests/unit/test_network_session.py에서 이주했다. 검증 내용·기대 동작 무변경.
+"""
 
 import threading
 
 import requests
 
 import content.network as network
+import core.api.session as session
 
 
 def test_module_session_is_a_requests_session():
     """API 호출용 모듈 수준 공유 세션이 requests.Session이어야 한다."""
-    assert isinstance(network._session, requests.Session)
+    assert isinstance(session._session, requests.Session)
 
 
 def test_thread_session_is_reused_within_same_thread():
     """같은 스레드에서 get_thread_session은 항상 같은 Session을 돌려준다."""
-    first = network.get_thread_session()
-    second = network.get_thread_session()
+    first = session.get_thread_session()
+    second = session.get_thread_session()
 
     assert isinstance(first, requests.Session)
     assert first is second
@@ -23,11 +27,11 @@ def test_thread_session_is_reused_within_same_thread():
 
 def test_thread_session_is_distinct_across_threads():
     """다른 스레드에서는 별도의 Session이 생성된다 (스레드 안전성 확보 방식)."""
-    main_session = network.get_thread_session()
+    main_session = session.get_thread_session()
     other_sessions = []
 
     def worker():
-        other_sessions.append(network.get_thread_session())
+        other_sessions.append(session.get_thread_session())
 
     thread = threading.Thread(target=worker)
     thread.start()
@@ -46,7 +50,7 @@ def test_session_does_not_store_response_cookies():
     from http.cookiejar import Cookie
     from urllib.request import Request
 
-    policy = network._make_session().cookies.get_policy()
+    policy = session._make_session().cookies.get_policy()
 
     cookie = Cookie(
         version=0,
@@ -69,3 +73,14 @@ def test_session_does_not_store_response_cookies():
     request = Request("https://api.chzzk.naver.com/service")
 
     assert policy.set_ok(cookie, request) is False
+
+
+def test_content_network_reexports_core_session():
+    """content.network의 하위 호환 re-export가 core 구현과 동일 객체여야 한다 (#62).
+
+    기존 테스트·호출부는 network._session 객체의 get을 monkeypatch하므로,
+    두 모듈이 같은 세션 객체를 공유해야 목킹·동작이 기존과 동일하게 유지된다.
+    """
+    assert network._session is session._session
+    assert network.get_thread_session is session.get_thread_session
+    assert network._make_session is session._make_session

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -1,12 +1,16 @@
-"""config.log_setup 공통 로깅 설정 단위 테스트 (#30)."""
+"""config.log_setup 진입점(로그 위치 주입) 단위 테스트 (#62, 원본 #30).
+
+핸들러 구성 자체의 테스트는 tests/unit/core/test_logging_setup.py로 이주했다.
+여기서는 기존 시그니처 유지와 로그 위치(CONFIG_DIR/logs) 주입만 검증한다.
+"""
 
 import logging
-import logging.handlers
 
 import pytest
 
 import config.config
 import config.log_setup as log_setup
+import core.utils.logging_setup as core_logging_setup
 
 
 @pytest.fixture
@@ -17,7 +21,7 @@ def isolated_logging(monkeypatch, tmp_path):
     saved_level = root.level
 
     monkeypatch.setattr(config.config, "CONFIG_DIR", str(tmp_path))
-    monkeypatch.setattr(log_setup, "_configured", False)
+    monkeypatch.setattr(core_logging_setup, "_configured", False)
     for handler in root.handlers[:]:
         root.removeHandler(handler)
 
@@ -32,42 +36,12 @@ def isolated_logging(monkeypatch, tmp_path):
     root.setLevel(saved_level)
 
 
-def test_setup_adds_console_and_rotating_file_handlers(isolated_logging):
-    """루트 로거에 콘솔 핸들러와 회전 파일 핸들러가 각각 1개씩 연결된다."""
-    # pytest 로깅 플러그인이 끼워 넣는 캡처 핸들러를 제외하기 위해 전후 차집합으로 비교한다
-    before = set(logging.getLogger().handlers)
-
+def test_setup_logging_writes_to_config_dir_logs(isolated_logging):
+    """기존 진입점 호출 시 CONFIG_DIR/logs/app.log에 기록된다 (동작 무변경)."""
     log_setup.setup_logging()
 
-    added = [h for h in logging.getLogger().handlers if h not in before]
-    rotating = [
-        h for h in added if isinstance(h, logging.handlers.RotatingFileHandler)
-    ]
-    consoles = [
-        h
-        for h in added
-        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
-    ]
-    assert len(rotating) == 1
-    assert len(consoles) == 1
+    logging.getLogger("smoke.test").info("hello via entrypoint")
 
-
-def test_log_message_is_written_to_logs_file(isolated_logging):
-    """모듈 로거로 남긴 메시지가 logs/app.log 파일에 기록된다."""
-    log_setup.setup_logging()
-
-    logging.getLogger("smoke.test").info("hello log file")
-
-    log_file = isolated_logging / "logs" / log_setup.LOG_FILE_NAME
+    log_file = isolated_logging / "logs" / core_logging_setup.LOG_FILE_NAME
     assert log_file.exists()
-    assert "hello log file" in log_file.read_text(encoding="utf-8")
-
-
-def test_setup_logging_is_idempotent(isolated_logging):
-    """setup_logging을 여러 번 호출해도 핸들러가 중복 추가되지 않는다."""
-    log_setup.setup_logging()
-    handler_count = len(logging.getLogger().handlers)
-
-    log_setup.setup_logging()
-
-    assert len(logging.getLogger().handlers) == handler_count
+    assert "hello via entrypoint" in log_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## 관련 이슈

Closes #62

## 변경 내용

Session 관리와 로깅 설정 모듈을 Qt와 무관한 core로 이주했다 (Phase 2). **정책·구성 변경 없음.**

- **`core/api/session.py` 신설** — `content/network.py`의 공유 세션(`_session`), `get_thread_session()`(스레드로컬), 쿠키 저장 차단 정책(`DefaultCookiePolicy(allowed_domains=[])`)을 코드 그대로 이주. #35에서 검증된 동작 유지.
- **`core/utils/logging_setup.py` 신설** — 콘솔+회전 파일(1MB×5) 핸들러 구성, urllib3 WARNING 억제, 중복 초기화 가드를 그대로 이주. 단, 로그 위치(`CONFIG_DIR/logs`)는 SPEC상 app 영역 지식이므로 core는 `log_dir`을 인자로 받는다.
- **원 위치 re-export/진입점 유지** — `content/network.py`는 `_make_session`/`_session`/`get_thread_session`을 re-export(동일 객체 공유, 기존 monkeypatch 패턴 유지). `config/log_setup.py`는 기존 시그니처 `setup_logging(log_level)`을 유지한 채 `CONFIG_DIR/logs`를 core에 주입하는 진입점으로 남김 → `main.py`, `scripts/headless_download.py` 무수정.
- **호출부 정리** — `download/download.py`, `download/download_m3u8.py`가 `get_thread_session`을 core에서 직접 import. `download/logger.py`는 주석 경로만 갱신.
- **테스트 이주** — `tests/unit/core/test_session.py`(구 test_network_session.py, re-export 동일 객체 검증 1건 추가), `tests/unit/core/test_logging_setup.py`(구 test_log_setup.py). 기존 `tests/unit/test_log_setup.py`에는 진입점의 CONFIG_DIR/logs 주입 검증만 남김.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (116 passed, Windows 로컬 — xvfb는 Linux CI에서 수행)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시)
- [x] 다운로드 스모크 1회 정상: 공개 VOD 14158884 144p, 265,706 bytes, exit 0
- [x] `logs/app.log`가 기존 파일에 동일 포맷으로 이어서 기록되고 이벤트별 1회 출력(이중 출력 없음), core 순수성 가드(test_no_qt_import) 통과

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #62 (approved, core 하위 모듈 신설)

## 리뷰어에게

판단이 필요했던 지점 하나: 이슈 2항의 로깅 이주에서 원본 `config/log_setup.py`는 `config.config`의 `CONFIG_DIR`를 직접 import하는데, 이를 core로 그대로 옮기면 core→config(app 영역, SPEC §7) 역방향 의존이 생깁니다. 그래서 core 함수는 `setup_logging(log_dir, log_level)`로 경로를 주입받고, 기존 진입점 `config/log_setup.py`가 `CONFIG_DIR/logs`를 계산해 위임하는 형태로 나눴습니다. 호출부 시그니처·로그 위치·핸들러 구성은 모두 기존과 동일합니다. 다른 형태를 원하시면 반영하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
