### PR TITLE
refactor: 파일 다운로더 탈Qt + monitor 흡수

### DIFF
--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -1,0 +1,401 @@
+"""파일(범위 분할) 다운로드 엔진 — 표준 threading 기반 (#73, SPEC §5·§6).
+
+구 download/download.py의 DownloadThread(QThread)와 download/monitor.py의
+MonitorThread(QThread)에 나뉘어 있던 실행·관측 로직을 Qt 없이 한 클래스로 흡수했다.
+로직(범위 분할·스케줄링·적응형 스레드 스케일링·느린 파트 재시도·실패 재큐잉)은
+식 그대로 이동했다 — 규칙은 tests/unit/core/test_file_downloader_rules.py가 박제한다.
+
+- 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
+  (_monitor_loop)가 수행하고, 결과는 core/models/events.py의 ProgressEvent
+  콜백으로 보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
+- 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다(#60).
+- 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다
+  (스레드 규칙은 core/models/events.py docstring 참고).
+
+data·logger 매개변수는 앱 영역(download/data.py의 DownloadData,
+download/logger.py의 DownloadLogger)과 호환되는 객체를 주입받는다.
+core에서 직접 import하지 않는 이유는 core→app 의존 금지 때문이다 (#72와 동일한 방식).
+"""
+
+import os
+import threading
+import time as tm
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from core.api.session import get_thread_session
+from core.downloaders.ranges import decide_part_size, split_ranges
+from core.models.download_state import DownloadState
+from core.models.events import (
+    FailedCallback,
+    FinishedCallback,
+    ProgressCallback,
+    ProgressEvent,
+)
+
+
+class FileDownloader:
+    """VOD 파일을 범위 분할 멀티스레드로 다운로드하는 엔진.
+
+    호출 규약: 소유자(어댑터·스크립트)가 DownloadTaskModel.start()로 RUNNING
+    전이를 마친 뒤 run()을 호출한다. run()은 완료·중단·실패까지 블로킹한다.
+    """
+
+    def __init__(
+        self,
+        data,
+        logger,
+        on_progress: ProgressCallback | None = None,
+        on_finished: FinishedCallback | None = None,
+        on_failed: FailedCallback | None = None,
+    ):
+        """엔진을 생성한다.
+
+        Args:
+            data: DownloadData 호환 공유 데이터 (진행률·엔진 변수·model 보유)
+            logger: DownloadLogger 호환 로거
+            on_progress: 관측 주기마다 ProgressEvent를 받는 콜백
+            on_finished: 정상 완료 시 인자 없이 호출되는 콜백
+            on_failed: 실패 시 예외 객체를 그대로 받는 콜백
+        """
+        self.s = data
+        self.model = data.model
+        self.logger = logger
+        self.lock = threading.Lock()
+        self.future_dict: dict = {}
+        self.adjust_count = 0
+        self._on_progress: ProgressCallback = on_progress or (lambda event: None)
+        self._on_finished: FinishedCallback = on_finished or (lambda: None)
+        self._on_failed: FailedCallback = on_failed or (lambda exc: None)
+
+    @property
+    def state(self) -> DownloadState:
+        """현재 다운로드 상태 (DownloadTaskModel에 위임)."""
+        return self.model.state
+
+    def set_on_progress(self, callback: ProgressCallback) -> None:
+        """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
+        self._on_progress = callback
+
+    # ============ 실행 파이프라인 (구 DownloadThread.run) ============
+
+    def run(self) -> None:
+        """다운로드 파이프라인을 실행한다. 관측 스레드도 여기서 소유·시작한다."""
+        monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
+        try:
+            self.s.start_time = tm.time()
+            total_size = self.s.total_size = self._get_total_size()
+
+            # part_size 결정(해상도별 가중 적용)
+            part_size = decide_part_size(self.s.content_type, self.s.resolution)
+
+            # 다운로드할 구간 분할
+            ranges = split_ranges(total_size, part_size)
+            self.s.max_threads = self.s.total_ranges = len(ranges)
+            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
+            self.s.threads_progress = [0] * self.s.total_ranges
+            self.logger.log_download_start(
+                total_size, part_size, self.s.total_ranges, self.s.adjust_threads
+            )
+
+            # 빈 파일 생성(사이즈: 0)
+            with open(self.s.output_path, "wb"):
+                pass
+
+            # 진행률 배열이 준비된 뒤에 관측을 시작한다
+            monitor.start()
+
+            with ThreadPoolExecutor(
+                max_workers=self.s.max_threads, thread_name_prefix="DownloadWorker"
+            ) as executor:
+                self.s.remaining_ranges = self._get_remaining_ranges(ranges)
+                # 재사용 시 초기화 필수
+                with self.lock:
+                    self.s.future_count = 0
+                    self.future_dict = {}
+
+                while not self.state == DownloadState.WAITING:
+                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
+                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
+                        for part_num in range(self.s.adjust_threads):
+                            if not self.s.remaining_ranges:
+                                break
+                            with self.lock:
+                                if part_num not in self.future_dict:
+                                    start, end = self.s.remaining_ranges.pop(0)
+                                    self.s.future_count += 1
+                                    self.logger.log_thread_start(part_num, start, end)
+                                    future = executor.submit(
+                                        self._download_part, start, end, part_num, total_size
+                                    )
+                                    future.add_done_callback(self._download_completed_callback)
+                                    self.future_dict[part_num] = (start, end, future)
+
+                    # (2) 주기적으로 상태 확인 (non-blocking)
+                    tm.sleep(0.1)
+
+                    # (3) 남은 작업이 없고 스레드도 없으면 종료
+                    if not self.s.remaining_ranges and not self.future_dict:
+                        break
+
+            if self.state == DownloadState.RUNNING:
+                self.s.end_time = tm.time()
+                total_time = self.s.end_time - self.s.start_time
+                self.logger.log_download_complete(total_time)
+                self.logger.save_and_close()
+                self._on_finished()
+
+        except requests.RequestException as e:
+            # 오류 발생 시 다운로드 파일 삭제
+            if os.path.exists(self.s.output_path):
+                os.remove(self.s.output_path)
+            self._on_failed(e)
+            self.logger.log_exception("Download failed", e)
+            self.logger.save_and_close()
+
+        # 사용자가 강제로 중단한 경우 다운로드 파일 삭제
+        if self.state == DownloadState.WAITING:
+            if os.path.exists(self.s.output_path):
+                os.remove(self.s.output_path)
+
+    # ============ 다운로드 동작 관련 메서드들 ============
+
+    def _download_part(self, start: int, end: int, part_num: int, total_size: int):
+        """
+        파일의 특정 구간(start~end)을 다운로드하는 함수.
+        속도가 느릴 경우 재시도 로직, 일시정지/중지 핸들링을 포함한다.
+        """
+        slow_count = 0
+        downloaded_size = 0
+        while not self.state == DownloadState.WAITING:
+            try:
+                headers = {"Range": f"bytes={start}-{end}"}
+                # 스레드로컬 세션으로 같은 워커의 반복 요청 간 연결을 재사용한다 (#31)
+                response = get_thread_session().get(
+                    self.s.base_url, headers=headers, stream=True, timeout=30
+                )
+                response.raise_for_status()
+                part_start_time = tm.time()
+
+                with open(self.s.output_path, "r+b") as f:
+                    f.seek(start)
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if self.state == DownloadState.WAITING:
+                            return part_num
+                        if self.state == DownloadState.PAUSED:
+                            self.s._pause_event.wait()
+
+                        if chunk:
+                            f.write(chunk)
+                            downloaded_size += len(chunk)
+                            elapsed = tm.time() - part_start_time
+
+                            if elapsed > 0:
+                                speed_kb_s = downloaded_size / elapsed / 1024
+                                self._check_speed_and_update_progress(
+                                    part_num, downloaded_size, total_size, speed_kb_s
+                                )
+                                if speed_kb_s < 100:
+                                    slow_count += 1
+                                    if slow_count > 5:
+                                        # 속도가 너무 느리면 스레드 재시작
+                                        with self.lock:
+                                            self._download_stop_callback(start, end, part_num)
+                                        return part_num
+                                else:
+                                    slow_count = 0
+
+                            if downloaded_size >= (end - start + 1):
+                                break
+
+                # 성공적으로 마무리된 경우
+                with self.lock:
+                    self.s.completed_threads += 1
+                    self.s.completed_progress += downloaded_size
+                    self.s.threads_progress[part_num] = 0
+                self.logger.log_thread_complete(part_num, downloaded_size)
+                return part_num
+
+            except (requests.RequestException, requests.Timeout) as e:
+                with self.lock:
+                    self._download_failed_callback(start, end, part_num)
+                self.logger.log_error(f"Part {part_num} download failed", e)
+                return part_num
+
+    def _check_speed_and_update_progress(
+        self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float
+    ):
+        """
+        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
+        """
+        with self.lock:
+            self.s.threads_progress[part_num] = downloaded_size
+            self.update_progress()
+
+    # ============ 다운로드 조정 및 콜백 메서드 ============
+
+    def _download_completed_callback(self, future):
+        """
+        특정 future(스레드)가 끝났을 때 호출되는 콜백.
+        """
+        try:
+            part_num = future.result()
+            # part_num 식별 후 future_dict에서 제거
+            with self.lock:
+                if part_num in self.future_dict:
+                    del self.future_dict[part_num]
+                    self.s.future_count -= 1
+            self.update_progress()  # 즉각적 진행도 반영
+
+        except Exception as e:
+            # 일부 스레드가 오류로 중단된 경우
+            self._on_failed(e)
+            self.logger.log_error("Thread failed", e)
+
+    def _download_failed_callback(self, start: int, end: int, part_num: int):
+        """
+        예외 발생 시 파일 구간을 다시 다운로드할 수 있도록 remaining_ranges에 등록.
+        """
+        self.s.failed_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append((start, end))
+
+    def _download_stop_callback(self, start: int, end: int, part_num: int):
+        """
+        특정 스레드를 중도 중단하고, 해당 구간을 재시작하도록 설정.
+        """
+        self.s.restart_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append((start, end))
+        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
+
+    # ============ 관측 루프 (구 MonitorThread — 엔진이 흡수) ============
+
+    def _monitor_loop(self):
+        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
+        tm.sleep(1)
+        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
+            if not self.s._pause_event.is_set():
+                self.s._pause_event.wait()
+                self.measure_speed()
+            else:
+                self._adjust_threads()
+                self.measure_speed()
+                self.emit_progress()
+            total_sleep = 1.0  # 총 1초 대기
+            interval = 0.1  # 0.1초씩 대기
+            elapsed = 0.0
+            while elapsed < total_sleep and self.state in [
+                DownloadState.RUNNING,
+                DownloadState.PAUSED,
+            ]:
+                tm.sleep(interval)
+                elapsed += interval
+
+    def _adjust_threads(self):
+        """
+        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
+        """
+        with self.lock:
+            future_count = self.s.future_count
+
+        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+
+        if avg_active_speed > 4:
+            self.adjust_count += 1
+        elif avg_active_speed < 2:
+            self.adjust_count -= 1
+        else:
+            if self.adjust_count > 0:
+                self.adjust_count -= 1
+            elif self.adjust_count < 0:
+                self.adjust_count += 1
+
+        if self.adjust_count > 1:
+            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+        elif self.adjust_count < -4:
+            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+
+    def measure_speed(self):
+        """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""
+        current_size = self.s.total_downloaded_size
+        speed = current_size - self.s.prev_size
+        self.s.prev_size = current_size
+
+        with self.lock:
+            future_count = self.s.future_count
+        # MB/s로 변환
+        self.s.speed_mb = speed / (1024 * 1024)
+        avg_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+        self.logger.log_thread_debug(future_count, self.s.speed_mb, avg_speed)
+
+    # ============ 진행 상황 업데이트 ============
+
+    def update_progress(self):
+        """
+        다운로드된 총량을 저장한다.
+        """
+        if self.state in [DownloadState.PAUSED, DownloadState.WAITING]:  # 중단 플래그 확인
+            return
+
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+    def emit_progress(self):
+        """진행 상태를 집계해 ProgressEvent 콜백으로 통지한다 (구 MonitorThread.update_progress)."""
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+        with self.lock:
+            future_count = self.s.future_count
+
+        self._on_progress(
+            ProgressEvent(
+                downloaded_size=self.s.total_downloaded_size,
+                total_size=self.s.total_size,
+                speed=self.s.speed_mb,
+                active_threads=future_count,
+            )
+        )
+
+    # ============ 유틸 메서드 ============
+
+    def _get_total_size(
+        self,
+    ) -> int:  #: TODO: 컨텐츠 아이템에 content-length 추가(중복된 로직 제거)
+        """
+        HEAD 요청으로 total_size를 구한다.
+        """
+        response = get_thread_session().head(self.s.base_url)
+        response.raise_for_status()
+        size = int(response.headers.get("content-length", 0))
+        if size == 0:
+            resp = get_thread_session().get(self.s.base_url, stream=True)
+            resp.raise_for_status()
+            size = int(resp.headers.get("content-length", 0))
+            resp.close()
+        return size
+
+    def _get_remaining_ranges(self, ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        """
+        중단 이후 재시작 같은 상황 고려(현재 파일크기 등을 바탕으로),
+        아직 다운로드되지 않은 구간만 남겨 반환한다.
+        """
+        with open(self.s.output_path, "r+b") as f:
+            f.seek(0, 2)
+            file_size = f.tell()
+
+        remaining = []
+        for start, end in ranges:
+            if start >= file_size or end >= file_size:
+                remaining.append((start, end))
+        return remaining

--- a/download/download.py
+++ b/download/download.py
@@ -1,261 +1,52 @@
-import requests
+"""파일 다운로드 워커 — core FileDownloader를 실행하고 Signal로 중계하는 얇은 어댑터 (#73).
+
+다운로드 실행·관측 로직은 core/downloaders/file_downloader.py로 이동했다.
+이 클래스는 다음만 담당한다:
+- QThread에서 엔진 run()을 실행 (DownloadManager 호출부 무변경)
+- 엔진의 완료·실패 콜백을 기존 completed/stopped Signal로 변환
+- 실패 메시지 번역(tr) — i18n 키 "Download failed"는 여기서 유지한다
+"""
+
 import threading
-import time as tm
-import os
 
 from PySide6.QtCore import QThread, Signal
-from concurrent.futures import ThreadPoolExecutor
+
+from core.downloaders.file_downloader import FileDownloader
 from download.task import DownloadTask
-from download.state import DownloadState
-from core.api.session import get_thread_session
 
 # 구현은 core/downloaders/ranges.py로 이동했다 (#50). 기존 호출부 호환용 re-export.
-from core.downloaders.ranges import decide_part_size, split_ranges
+from core.downloaders.ranges import decide_part_size, split_ranges  # noqa: F401
 
 
 class DownloadThread(QThread):
     """
-    VOD 파일을 multi-thread로 다운로드하는 작업 스레드 클래스
+    VOD 파일을 multi-thread로 다운로드하는 작업 스레드 클래스 (core 엔진 어댑터)
     """
+
     completed = Signal()
     stopped = Signal(str)
 
     def __init__(self, task: DownloadTask):
         super().__init__()
         self.task = task
-        self.s = self.task.data
-        self.future_dict = {}
-        self.lock = self.task.lock
-        self.logger = self.task.logger
+        self.engine = FileDownloader(
+            data=task.data,
+            logger=task.logger,
+            on_finished=self._relay_finished,
+            on_failed=self._relay_failed,
+        )
+        # MonitorThread 어댑터가 진행 콜백을 연결할 수 있도록 태스크에 공유한다 (#73)
+        task.engine = self.engine
 
     def run(self):
-        """
-        스레드가 시작될 때 자동으로 호출되는 메서드.
-        실제 다운로드 파이프라인이 여기서 진행된다.
-        """
-        try:
-            threading.current_thread().name = "DownloadThread"  # 스레드 시작 시 이름 재설정
-            self.s.start_time = tm.time()
-            total_size = self.s.total_size = self._get_total_size()
+        """QThread 진입점 — core 엔진의 다운로드 파이프라인을 실행한다."""
+        threading.current_thread().name = "DownloadThread"  # 스레드 시작 시 이름 재설정
+        self.engine.run()
 
-            # part_size 결정(해상도별 가중 적용)
-            part_size = self._decide_part_size()
+    def _relay_finished(self):
+        """엔진 완료 콜백 → completed Signal (emit은 스레드 세이프)."""
+        self.completed.emit()
 
-            # 다운로드할 구간 분할
-            ranges = split_ranges(total_size, part_size)
-            self.s.max_threads = self.s.total_ranges = len(ranges)
-            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
-            self.s.threads_progress = [0] * self.s.total_ranges
-            self.logger.log_download_start(total_size, part_size, self.s.total_ranges, self.s.adjust_threads)
-
-            # 빈 파일 생성(사이즈: 0)
-            with open(self.s.output_path, 'wb'):
-                pass
-
-            with ThreadPoolExecutor(max_workers=self.s.max_threads, thread_name_prefix="DownloadWorker") as executor:
-                self.s.remaining_ranges = self._get_remaining_ranges(ranges)
-                # 재사용 시 초기화 필수
-                with self.lock:
-                    self.s.future_count = 0
-                    self.future_dict = {}
-
-                while not self.task.state == DownloadState.WAITING:
-                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
-                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
-                        for part_num in range(self.s.adjust_threads):
-                            if not self.s.remaining_ranges:
-                                break
-                            with self.lock:
-                                if part_num not in self.future_dict:
-                                    start, end = self.s.remaining_ranges.pop(0)
-                                    self.s.future_count += 1
-                                    self.logger.log_thread_start(part_num, start, end)
-                                    future = executor.submit(
-                                        self._download_part,
-                                        start, end, part_num, total_size
-                                    )
-                                    future.add_done_callback(self._download_completed_callback)
-                                    self.future_dict[part_num] = (start, end, future)
-
-                    # (2) 주기적으로 상태 확인 (non-blocking)
-                    tm.sleep(0.1)
-
-                    # (3) 남은 작업이 없고 스레드도 없으면 종료
-                    if not self.s.remaining_ranges and not self.future_dict:
-                        break
-
-                if self.task.state == DownloadState.RUNNING:
-                    self.s.end_time = tm.time()
-                    total_time = self.s.end_time - self.s.start_time
-                    self.logger.log_download_complete(total_time)
-                    self.logger.save_and_close()
-                    self.completed.emit()
-
-        except requests.RequestException as e:
-            # 오류 발생 시 다운로드 파일 삭제
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-            self.stopped.emit(self.tr("Download failed"))
-            self.logger.log_exception("Download failed", e)
-            self.logger.save_and_close()
-
-        # 사용자가 강제로 중단한 경우 다운로드 파일 삭제
-        if self.task.state == DownloadState.WAITING:
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-
-    # ============ 다운로드 동작 관련 메서드들 ============
-
-    def _download_part(self, start, end, part_num, total_size):
-        """
-        파일의 특정 구간(start~end)을 다운로드하는 함수.
-        속도가 느릴 경우 재시도 로직, 일시정지/중지 핸들링을 포함한다.
-        """
-        slow_count = 0
-        downloaded_size = 0
-        while not self.task.state == DownloadState.WAITING:
-            try:
-                headers = {'Range': f'bytes={start}-{end}'}
-                # 스레드로컬 세션으로 같은 워커의 반복 요청 간 연결을 재사용한다 (#31)
-                response = get_thread_session().get(self.s.base_url, headers=headers, stream=True, timeout=30)
-                response.raise_for_status()
-                part_start_time = tm.time()
-
-                with open(self.s.output_path, 'r+b') as f:
-                    f.seek(start)
-                    for chunk in response.iter_content(chunk_size=8192):
-                        if self.task.state == DownloadState.WAITING:
-                            return part_num
-                        if self.task.state == DownloadState.PAUSED:
-                            self.s._pause_event.wait()
-
-                        if chunk:
-                            f.write(chunk)
-                            downloaded_size += len(chunk)
-                            elapsed = tm.time() - part_start_time
-
-                            if elapsed > 0:
-                                speed_kb_s = downloaded_size / elapsed / 1024
-                                self._check_speed_and_update_progress(
-                                    part_num, downloaded_size, total_size, speed_kb_s
-                                )
-                                if speed_kb_s < 100:
-                                    slow_count += 1
-                                    if slow_count > 5:
-                                        # 속도가 너무 느리면 스레드 재시작
-                                        with self.lock:
-                                            self._download_stop_callback(start, end, part_num)
-                                        return part_num
-                                else:
-                                    slow_count = 0
-
-                            if downloaded_size >= (end - start + 1):
-                                break
-
-                # 성공적으로 마무리된 경우
-                with self.lock:
-                    self.s.completed_threads += 1
-                    self.s.completed_progress += downloaded_size
-                    self.s.threads_progress[part_num] = 0
-                self.logger.log_thread_complete(part_num, downloaded_size)
-                return part_num
-
-            except (requests.RequestException, requests.Timeout) as e:
-                with self.lock:
-                    self._download_failed_callback(start, end, part_num)
-                self.logger.log_error(f"Part {part_num} download failed", e)
-                return part_num
-
-    def _check_speed_and_update_progress(self, part_num, downloaded_size, total_size, speed_kb_s):
-        """
-        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
-        """
-        with self.lock:
-            self.s.threads_progress[part_num] = downloaded_size
-            self.update_progress()
-
-    # ============ 다운로드 조정 및 콜백 메서드 ============
-
-    def _download_completed_callback(self, future):
-        """
-        특정 future(스레드)가 끝났을 때 호출되는 콜백.
-        """
-        try:
-            part_num = future.result()
-            # part_num 식별 후 future_dict에서 제거
-            with self.lock:
-                if part_num in self.future_dict:
-                    del self.future_dict[part_num]
-                    self.s.future_count -= 1
-            self.update_progress()  # 즉각적 진행도 반영
-
-        except Exception as e:
-            # 일부 스레드가 오류로 중단된 경우
-            self.stopped.emit(self.tr("Download failed"))
-            self.logger.log_error("Thread failed", e)
-
-    def _download_failed_callback(self, start, end, part_num):
-        """
-        예외 발생 시 파일 구간을 다시 다운로드할 수 있도록 remaining_ranges에 등록.
-        """
-        self.s.failed_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((start, end))
-
-    def _download_stop_callback(self, start, end, part_num):
-        """
-        특정 스레드를 중도 중단하고, 해당 구간을 재시작하도록 설정.
-        """
-        self.s.restart_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((start, end))
-        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
-
-    # ============ 유틸 메서드 ============
-
-    def _get_total_size(self): #: TODO: 컨텐츠 아이템에 content-length 추가(중복된 로직 제거)
-        """
-        HEAD 요청으로 total_size를 구한다.
-        """
-        response = get_thread_session().head(self.s.base_url)
-        response.raise_for_status()
-        size = int(response.headers.get('content-length', 0))
-        if size == 0:
-            resp = get_thread_session().get(self.s.base_url, stream=True)
-            resp.raise_for_status()
-            size = int(resp.headers.get('content-length', 0))
-            resp.close()
-        return size
-
-    def _decide_part_size(self):
-        """
-        해상도에 따라 파트 크기 가중치를 달리 부여한다.
-        """
-        return decide_part_size(self.s.content_type, self.s.resolution)
-
-    def _get_remaining_ranges(self, ranges):
-        """
-        중단 이후 재시작 같은 상황 고려(현재 파일크기 등을 바탕으로),
-        아직 다운로드되지 않은 구간만 남겨 반환한다.
-        """
-        with open(self.s.output_path, 'r+b') as f:
-            f.seek(0, 2)
-            file_size = f.tell()
-
-        remaining = []
-        for start, end in ranges:
-            if start >= file_size or end >= file_size:
-                remaining.append((start, end))
-        return remaining
-
-    # ============ 진행 상황 업데이트 / 제어 메서드 ============
-
-    def update_progress(self):
-        """
-        다운로드된 총량을 저장한다.
-        """
-        if self.task.state in [DownloadState.PAUSED, DownloadState.WAITING]:    # 중단 플래그 확인
-            return
-
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+    def _relay_failed(self, exc: BaseException):
+        """엔진 실패 콜백 → stopped Signal. 사용자 메시지 번역은 여기서 한다."""
+        self.stopped.emit(self.tr("Download failed"))

--- a/download/monitor.py
+++ b/download/monitor.py
@@ -1,116 +1,65 @@
-import time as t
-import threading
+"""진행 관측 어댑터 — core 엔진의 ProgressEvent를 progress Signal로 중계 (#73).
+
+관측 루프(속도 측정·스레드 조정·주기 통지)는 core FileDownloader가 소유하는
+일반 스레드로 흡수됐다. 이 클래스는 다음만 담당한다:
+- 엔진의 ProgressEvent 콜백을 기존 progress Signal 형식(남은 시간·크기·속도·%)으로
+  변환해 emit (DownloadManager 호출부 무변경)
+- manager.finish가 쓰는 update_progress()/get_download_time() 인터페이스 유지
+"""
+
+from time import gmtime, strftime
 
 from PySide6.QtCore import QThread, Signal
+
+from core.models.events import ProgressEvent
 from download.task import DownloadTask
-from download.state import DownloadState
-from time import strftime, gmtime
+
 
 class MonitorThread(QThread):
     """
-    VOD 파일을 multi-thread로 다운로드하는 작업 스레드 클래스
+    다운로드 진행 상황을 UI로 중계하는 어댑터 스레드 클래스
     """
+
     progress = Signal(str, str, str, int)
 
     def __init__(self, task: DownloadTask):
         super().__init__()
         self.task = task
         self.data = self.task.data
-        self.logger = self.task.logger # 로거 초기화
-        self.adjust_count = 0
+        # DownloadThread 어댑터가 먼저 생성되어 task.engine을 채운다 (manager의 생성 순서)
+        self.engine = task.engine
+        self.engine.set_on_progress(self._relay_progress)
 
     def run(self):
-        """
-        스레드가 시작될 때 자동으로 호출되는 메서드.
-        실제 다운로드 파이프라인이 여기서 진행된다.
-        """
-        threading.current_thread().name = "MonitorThread"  # 스레드 시작 시 이름 재설정
-        t.sleep(1)
-        while self.task.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-            if not self.data._pause_event.is_set():
-                self.data._pause_event.wait()
-                self.measure_speed()
-            else:
-                self._adjust_threads()
-                self.measure_speed()
-                self.update_progress()
-            total_sleep = 1.0    # 총 1초 대기
-            interval = 0.1       # 0.1초씩 대기
-            elapsed = 0.0
-            while elapsed < total_sleep and self.task.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-                t.sleep(interval)
-                elapsed += interval
+        """관측 루프는 core 엔진 내부로 이주했다 — QThread는 시작 즉시 종료한다."""
 
-    # ============ 다운로드 조정 및 콜백 메서드 ============
+    def _relay_progress(self, event: ProgressEvent):
+        """ProgressEvent를 기존 Signal 인자(남은 시간, 크기, 속도 문자열, %)로 변환한다.
 
-    def _adjust_threads(self):
+        엔진의 관측 스레드에서 호출되므로 Signal emit까지만 수행한다 (스레드 규칙).
+        계산식은 구 MonitorThread.update_progress와 동일하다.
         """
-        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
-        """
-        with self.task.lock:
-            future_count = self.data.future_count
+        total_size = event.total_size or 0
+        speed_mb = event.speed or 0.0
 
-        avg_active_speed = (
-            self.data.speed_mb / future_count if future_count > 0 else 0
+        progress = int((event.downloaded_size / total_size) * 100) if total_size > 0 else 0
+
+        if speed_mb > 0:
+            remaining_time = (total_size - event.downloaded_size) / (speed_mb * 1024 * 1024)
+            remaining_time_str = strftime("%H:%M:%S", gmtime(remaining_time))
+        else:
+            remaining_time_str = "N/A"
+
+        # 시그널 전송
+        self.progress.emit(
+            remaining_time_str, str(event.downloaded_size), f"{speed_mb:.1f} MB/s", progress
         )
 
-        if avg_active_speed > 4:
-            self.adjust_count += 1
-        elif avg_active_speed < 2:
-            self.adjust_count -= 1
-        else:
-            if self.adjust_count > 0:
-                self.adjust_count -= 1
-            elif self.adjust_count < 0:
-                self.adjust_count += 1
-        
-        if self.adjust_count > 1:
-            self.data.adjust_threads = min(self.data.max_threads, self.data.adjust_threads + 4)
-            self.logger.log_thread_adjust(self.data.adjust_threads, self.data.speed_mb) # 스레드 조정 로그
-            self.adjust_count = 0
-        elif self.adjust_count < -4:
-            self.data.adjust_threads = max(1, self.data.adjust_threads // 2)
-            self.logger.log_thread_adjust(self.data.adjust_threads, self.data.speed_mb) # 스레드 조정 로그
-            self.adjust_count = 0
-
-    def measure_speed(self):
-            current_size = self.data.total_downloaded_size
-            speed = current_size - self.data.prev_size
-            self.data.prev_size = current_size
-
-            with self.task.lock:
-                future_count = self.data.future_count
-            # MB/s로 변환
-            self.data.speed_mb = speed / (1024*1024)
-            avg_speed = self.data.speed_mb / future_count if future_count > 0 else 0
-            self.logger.log_thread_debug(future_count, self.data.speed_mb, avg_speed)
-
     def update_progress(self):
-        """
-        진행률, 다운로드 속도, 예상 남은 시간 등 정보를 계산 후 시그널로 전송한다.
-        """
-        active_downloaded_size = sum(self.data.threads_progress)
-        self.data.total_downloaded_size = self.data.completed_progress + active_downloaded_size
-        # elapsed_time = time() - self.data.start_time
+        """(manager.finish 호환) 최종 진행 상태를 집계해 progress Signal로 내보낸다."""
+        self.engine.emit_progress()
 
-        progress = int((self.data.total_downloaded_size / self.data.total_size) * 100) if self.data.total_size > 0 else 0
-
-        if self.data.speed_mb > 0:
-            remaining_time = (
-                (self.data.total_size - self.data.total_downloaded_size)
-                / (self.data.speed_mb * 1024 * 1024)
-            )
-            #completion_time = elapsed_time + remaining_time
-            #completion_time_str = strftime('%H:%M:%S', gmtime(completion_time))
-            remaining_time_str = strftime('%H:%M:%S', gmtime(remaining_time))
-        else:
-            #completion_time_str = "N/A"
-            remaining_time_str = "N/A"
-        
-        # 시그널 전송
-        self.progress.emit(remaining_time_str, str(self.data.total_downloaded_size), f"{self.data.speed_mb:.1f} MB/s", progress)
-
-    def get_download_time(self):
+    def get_download_time(self) -> str:
+        """다운로드 소요 시간을 HH:MM:SS 문자열로 반환한다."""
         download_time = self.data.end_time - self.data.start_time
-        download_time_str = strftime('%H:%M:%S', gmtime(download_time))
-        return download_time_str
+        return strftime("%H:%M:%S", gmtime(download_time))

--- a/download/task.py
+++ b/download/task.py
@@ -29,6 +29,10 @@ class DownloadTask:
         # 별도 모델을 만들지 않고 같은 모델에 UI 반영 콜백만 연결한다
         self.model = data.model
         self.model.set_on_state_change(item.setDownloadState)
+        # core 다운로드 엔진(FileDownloader) 공유 슬롯 (#73).
+        # DownloadThread 어댑터가 생성 시 채우고, MonitorThread 어댑터가
+        # 진행 콜백을 연결할 때 읽는다 (manager의 생성 순서가 이를 보장한다)
+        self.engine = None
 
     @property
     def state(self) -> DownloadState:

--- a/scripts/summarize_download_log.py
+++ b/scripts/summarize_download_log.py
@@ -32,7 +32,9 @@ _PATTERNS = {
     # 붙는 주기 측정 디버그 메시지와 구분하기 위해 문장 끝을 고정한다.
     "adjust": re.compile(r"Active threads: (\d+) - Download speed: [\d.]+ MB/s$"),
     # 주기 측정 디버그 메시지 — 활성 스레드 수 관측용
-    "tick": re.compile(r"Active threads: (\d+) - Download speed: [\d.]+ MB/s - Avg speed: [\d.]+ MB/s"),
+    "tick": re.compile(
+        r"Active threads: (\d+) - Download speed: [\d.]+ MB/s - Avg speed: [\d.]+ MB/s"
+    ),
     "part_start": re.compile(r"Thread (\d+) started - Range: (\d+)-(\d+)"),
     "part_complete": re.compile(r"Thread (\d+) completed - Downloaded: (\d+) bytes"),
     "slow_retry": re.compile(r"Part (\d+) stopped due to slow speed, will retry"),
@@ -125,7 +127,9 @@ def print_summary(summary: dict) -> None:
     print(f"  파트 실패        : {summary['part_failures']}")
     print(f"  재큐잉 합계      : {summary['requeued_parts']}")
     completed = summary["completed_in_seconds"]
-    print(f"  완료 시간        : {f'{completed:.2f}s' if completed is not None else '(완료 기록 없음)'}")
+    print(
+        f"  완료 시간        : {f'{completed:.2f}s' if completed is not None else '(완료 기록 없음)'}"
+    )
     print(f"  완주(복구 포함)  : {'예' if summary['recovered'] else '아니오'}")
 
 

--- a/scripts/summarize_download_log.py
+++ b/scripts/summarize_download_log.py
@@ -1,0 +1,156 @@
+"""다운로드 로그에서 구조적 지표를 추출·요약하는 보조 스크립트 (#73 착수 조건 나).
+
+이주 전(기준선)과 이주 후 로그를 같은 기준으로 비교하기 위한 도구다.
+판정 기준은 절대 속도가 아니라 구조적 지표다 — 최대 동시 스레드 수,
+스레드 증가 궤적, 느린 파트 재시도 건수, 파트 실패·복구 여부.
+
+파싱 규칙: 스레드 이름([MonitorThread] 등)이나 로그 프리픽스 형식에 의존하지
+않고 **메시지 본문 패턴만** 사용한다 — 엔진 이주로 스레드 이름이 바뀌어도
+기준선 로그와 이주 후 로그를 동일하게 처리할 수 있어야 하기 때문이다.
+
+사용법:
+    uv run python scripts/summarize_download_log.py <download_로그파일> [...]
+    uv run python scripts/summarize_download_log.py --json <download_로그파일>
+
+로그 파일이 여러 개면 순서대로 각각 요약한다 (기준선/이주 후 나란히 비교용).
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# 메시지 본문 패턴 (download/logger.py의 메시지 형식과 1:1).
+# 줄 프리픽스(시각·레벨·스레드 이름)는 의도적으로 매칭하지 않는다.
+_PATTERNS = {
+    "total_size": re.compile(r"Download started - Total size: (\d+) bytes"),
+    "part_size": re.compile(r"Part size: (\d+) bytes"),
+    "segments": re.compile(r"Segments: (\d+)"),
+    "initial_threads": re.compile(r"Initial threads: (\d+)"),
+    # 스레드 조정 이벤트(조정 시 INFO로 남는 메시지). 뒤에 "- Avg speed:"가
+    # 붙는 주기 측정 디버그 메시지와 구분하기 위해 문장 끝을 고정한다.
+    "adjust": re.compile(r"Active threads: (\d+) - Download speed: [\d.]+ MB/s$"),
+    # 주기 측정 디버그 메시지 — 활성 스레드 수 관측용
+    "tick": re.compile(r"Active threads: (\d+) - Download speed: [\d.]+ MB/s - Avg speed: [\d.]+ MB/s"),
+    "part_start": re.compile(r"Thread (\d+) started - Range: (\d+)-(\d+)"),
+    "part_complete": re.compile(r"Thread (\d+) completed - Downloaded: (\d+) bytes"),
+    "slow_retry": re.compile(r"Part (\d+) stopped due to slow speed, will retry"),
+    "part_failed": re.compile(r"Part (\d+) download failed"),
+    "completed": re.compile(r"Download completed in ([\d.]+) seconds"),
+}
+
+
+def summarize(log_path: Path) -> dict:
+    """로그 파일 하나를 파싱해 구조적 지표 dict를 반환한다."""
+    summary: dict = {
+        "file": str(log_path),
+        "total_size": None,
+        "part_size": None,
+        "segments": None,
+        "initial_threads": None,
+        # 스레드 조정 이벤트의 시간순 목록 — 증가 궤적 비교의 핵심 지표
+        "thread_trajectory": [],
+        # 주기 측정에서 관측된 활성 스레드 수의 최댓값
+        "max_active_threads": 0,
+        "part_starts": 0,
+        "part_completes": 0,
+        "slow_retries": 0,
+        "part_failures": 0,
+        "completed_in_seconds": None,
+    }
+
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        # 문장 끝 고정($) 패턴을 위해 줄 끝 공백을 제거한다
+        line = line.rstrip()
+        if m := _PATTERNS["adjust"].search(line):
+            summary["thread_trajectory"].append(int(m.group(1)))
+        elif m := _PATTERNS["tick"].search(line):
+            summary["max_active_threads"] = max(summary["max_active_threads"], int(m.group(1)))
+        elif _PATTERNS["part_start"].search(line):
+            summary["part_starts"] += 1
+        elif _PATTERNS["part_complete"].search(line):
+            summary["part_completes"] += 1
+        elif _PATTERNS["slow_retry"].search(line):
+            summary["slow_retries"] += 1
+        elif _PATTERNS["part_failed"].search(line):
+            summary["part_failures"] += 1
+        elif m := _PATTERNS["total_size"].search(line):
+            summary["total_size"] = int(m.group(1))
+        elif m := _PATTERNS["part_size"].search(line):
+            summary["part_size"] = int(m.group(1))
+        elif m := _PATTERNS["segments"].search(line):
+            summary["segments"] = int(m.group(1))
+        elif m := _PATTERNS["initial_threads"].search(line):
+            summary["initial_threads"] = int(m.group(1))
+        elif m := _PATTERNS["completed"].search(line):
+            summary["completed_in_seconds"] = float(m.group(1))
+
+    # 파생 지표: 재시도·실패로 인한 재큐잉 합계, 재큐잉이 있었어도 완주했는지 여부.
+    # 파트 시작/완료는 DEBUG 로그라 기본 레벨(INFO)에서는 0으로 남는다 — 완주 판정은
+    # 완료 메시지(INFO) 기준으로 하고, 파트 수 검증은 DEBUG 로그가 있을 때만 수행한다.
+    summary["requeued_parts"] = summary["slow_retries"] + summary["part_failures"]
+    completed = summary["completed_in_seconds"] is not None
+    if summary["part_completes"] > 0 and summary["segments"] is not None:
+        completed = completed and summary["part_completes"] >= summary["segments"]
+    summary["recovered"] = completed
+    return summary
+
+
+def _format_bytes(size: int | None) -> str:
+    """바이트 수를 사람이 읽는 단위로 표기한다."""
+    if size is None:
+        return "?"
+    if size >= 1024 * 1024:
+        return f"{size / (1024 * 1024):.1f} MB"
+    return f"{size / 1024:.1f} KB"
+
+
+def print_summary(summary: dict) -> None:
+    """지표 요약을 사람이 읽는 형식으로 출력한다."""
+    print(f"=== {summary['file']}")
+    print(f"  전체 크기        : {_format_bytes(summary['total_size'])}")
+    print(f"  파트 크기        : {_format_bytes(summary['part_size'])}")
+    print(f"  세그먼트 수      : {summary['segments']}")
+    print(f"  초기 스레드      : {summary['initial_threads']}")
+    trajectory = summary["thread_trajectory"]
+    trajectory_str = " -> ".join(map(str, trajectory)) if trajectory else "(조정 없음)"
+    print(f"  스레드 조정 궤적 : {trajectory_str}")
+    print(f"  최대 활성 스레드 : {summary['max_active_threads']}")
+    if summary["part_starts"] or summary["part_completes"]:
+        print(f"  파트 시작/완료   : {summary['part_starts']} / {summary['part_completes']}")
+    else:
+        print("  파트 시작/완료   : (DEBUG 로그 없음)")
+    print(f"  느린 파트 재시도 : {summary['slow_retries']}")
+    print(f"  파트 실패        : {summary['part_failures']}")
+    print(f"  재큐잉 합계      : {summary['requeued_parts']}")
+    completed = summary["completed_in_seconds"]
+    print(f"  완료 시간        : {f'{completed:.2f}s' if completed is not None else '(완료 기록 없음)'}")
+    print(f"  완주(복구 포함)  : {'예' if summary['recovered'] else '아니오'}")
+
+
+def main(argv: list[str]) -> int:
+    """인자로 받은 로그 파일들을 각각 요약한다."""
+    parser = argparse.ArgumentParser(description="다운로드 로그 구조적 지표 요약 (#73)")
+    parser.add_argument("logs", nargs="+", help="download_*.log 파일 경로 (여러 개 가능)")
+    parser.add_argument("--json", action="store_true", help="JSON으로 출력 (기계 비교용)")
+    args = parser.parse_args(argv)
+
+    summaries = []
+    for log in args.logs:
+        path = Path(log)
+        if not path.is_file():
+            print(f"오류: 파일을 찾을 수 없다 — {path}", file=sys.stderr)
+            return 2
+        summaries.append(summarize(path))
+
+    if args.json:
+        print(json.dumps(summaries, ensure_ascii=False, indent=2))
+    else:
+        for summary in summaries:
+            print_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -16,12 +16,9 @@
 - 파트 실패: 요청 예외 시 구간 재큐잉(failed_threads += 1)
 """
 
-import threading
-
 import pytest
 import requests
 
-from core.models.download_state import DownloadState
 from download.data import DownloadData
 
 MB = 1024 * 1024
@@ -56,19 +53,6 @@ class RecordingLogger:
         self.warnings.append(message)
 
 
-class FakeTask:
-    """DownloadTask 호환 가짜 태스크 — 엔진이 쓰는 인터페이스(state/lock/data/logger)만 제공."""
-
-    def __init__(self, data: DownloadData, logger: RecordingLogger):
-        self.data = data
-        self.logger = logger
-        self.lock = threading.Lock()
-
-    @property
-    def state(self) -> DownloadState:
-        return self.data.model.state
-
-
 def _make_data(output_path: str = "unused.part") -> DownloadData:
     """테스트용 DownloadData를 만든다 (네트워크 정보는 더미)."""
     return DownloadData(
@@ -86,25 +70,25 @@ def _make_scaler(data: DownloadData, logger: RecordingLogger):
     이주 전: download.monitor.MonitorThread / 이주 후: core FileDownloader.
     반환 객체는 adjust_count 속성과 두 메서드를 노출해야 한다.
     """
-    from download.monitor import MonitorThread
+    from core.downloaders.file_downloader import FileDownloader
 
-    return MonitorThread(FakeTask(data, logger))
+    return FileDownloader(data, logger)
 
 
 def _make_engine(data: DownloadData, logger: RecordingLogger):
     """파트 다운로드 로직(_download_part) 보유 객체와 (엔진, 태스크)를 만든다.
 
-    이주 전: download.download.DownloadThread / 이주 후: core FileDownloader.
+    이주 전: download.download.DownloadThread / 이주 후: core FileDownloader
+    (태스크 어댑터가 더 이상 필요 없어 None을 돌려준다).
     """
-    from download.download import DownloadThread
+    from core.downloaders.file_downloader import FileDownloader
 
-    task = FakeTask(data, logger)
-    return DownloadThread(task), task
+    return FileDownloader(data, logger), None
 
 
 def _engine_module():
     """_download_part가 사는 모듈 — 시간·세션 몽키패치 대상."""
-    import download.download as mod
+    import core.downloaders.file_downloader as mod
 
     return mod
 

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -1,0 +1,375 @@
+"""적응형 스레드 스케일링·느린 파트 판정·속도 계산 규칙 박제 (#73 착수 조건 가).
+
+이 테스트는 다운로드 엔진 이주(QThread → threading) 전후 모두 통과해야 한다.
+규칙 자체를 고정하는 것이 목적이므로, 시나리오와 단언은 이주 후에도 바꾸지 않는다.
+이주 시에는 아래 팩토리(_make_scaler/_make_engine)의 대상 클래스만 교체한다.
+
+박제하는 규칙 (현행 동작 그대로):
+- 스레드 증가: 활성 스레드당 평균 속도 > 4 MB/s 틱마다 adjust_count += 1,
+  adjust_count > 1이면 adjust_threads를 +4 (max_threads 상한), 카운터 리셋
+- 스레드 감소: 평균 속도 < 2 MB/s 틱마다 adjust_count -= 1,
+  adjust_count < -4이면 adjust_threads를 절반으로 (하한 1), 카운터 리셋
+- 중간 대역(2~4 MB/s)에서는 adjust_count가 0을 향해 1씩 감쇠
+- 속도 계산: 직전 틱 대비 바이트 증가량을 MB/s로 환산, prev_size 갱신
+- 느린 파트: 청크 속도 < 100 KB/s가 연속 6회(slow_count > 5) 누적되면
+  해당 파트를 중단하고 구간을 재큐잉(restart_threads += 1), 빠른 청크가 오면 리셋
+- 파트 실패: 요청 예외 시 구간 재큐잉(failed_threads += 1)
+"""
+
+import threading
+
+import pytest
+import requests
+
+from core.models.download_state import DownloadState
+from download.data import DownloadData
+
+MB = 1024 * 1024
+
+
+class RecordingLogger:
+    """DownloadLogger 호환 가짜 로거 — 실제 파일을 만들지 않고 호출만 기록한다."""
+
+    def __init__(self):
+        self.adjust_calls: list[tuple] = []
+        self.debug_calls: list[tuple] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+        self.thread_completes: list[tuple] = []
+
+    def log_thread_adjust(self, active_threads, avg_speed):
+        self.adjust_calls.append((active_threads, avg_speed))
+
+    def log_thread_debug(self, active_threads, download_speed, avg_speed):
+        self.debug_calls.append((active_threads, download_speed, avg_speed))
+
+    def log_thread_start(self, thread_id, start, end):
+        pass
+
+    def log_thread_complete(self, thread_id, downloaded_size):
+        self.thread_completes.append((thread_id, downloaded_size))
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+class FakeTask:
+    """DownloadTask 호환 가짜 태스크 — 엔진이 쓰는 인터페이스(state/lock/data/logger)만 제공."""
+
+    def __init__(self, data: DownloadData, logger: RecordingLogger):
+        self.data = data
+        self.logger = logger
+        self.lock = threading.Lock()
+
+    @property
+    def state(self) -> DownloadState:
+        return self.data.model.state
+
+
+def _make_data(output_path: str = "unused.part") -> DownloadData:
+    """테스트용 DownloadData를 만든다 (네트워크 정보는 더미)."""
+    return DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=1080,
+        content_type="video",
+    )
+
+
+def _make_scaler(data: DownloadData, logger: RecordingLogger):
+    """스케일링 규칙(_adjust_threads/measure_speed) 보유 객체를 만든다.
+
+    이주 전: download.monitor.MonitorThread / 이주 후: core FileDownloader.
+    반환 객체는 adjust_count 속성과 두 메서드를 노출해야 한다.
+    """
+    from download.monitor import MonitorThread
+
+    return MonitorThread(FakeTask(data, logger))
+
+
+def _make_engine(data: DownloadData, logger: RecordingLogger):
+    """파트 다운로드 로직(_download_part) 보유 객체와 (엔진, 태스크)를 만든다.
+
+    이주 전: download.download.DownloadThread / 이주 후: core FileDownloader.
+    """
+    from download.download import DownloadThread
+
+    task = FakeTask(data, logger)
+    return DownloadThread(task), task
+
+
+def _engine_module():
+    """_download_part가 사는 모듈 — 시간·세션 몽키패치 대상."""
+    import download.download as mod
+
+    return mod
+
+
+# ================================================================ 스레드 증가/감소
+
+
+def test_fast_two_ticks_increase_threads_by_4():
+    """평균 > 4 MB/s 틱 2회 → adjust_count 2(>1) → 스레드 +4, 카운터 리셋."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 32
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 4
+    data.speed_mb = 20.0  # 평균 5 MB/s
+    scaler._adjust_threads()
+    assert (scaler.adjust_count, data.adjust_threads) == (1, 4)  # 1틱으로는 불변
+
+    scaler._adjust_threads()
+    assert data.adjust_threads == 8
+    assert scaler.adjust_count == 0
+    assert logger.adjust_calls == [(8, 20.0)]
+
+
+def test_increase_is_capped_at_max_threads():
+    """증가 시 상한은 max_threads다."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 10
+    data.adjust_threads = 8
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 8
+    data.speed_mb = 40.0  # 평균 5 MB/s
+    scaler._adjust_threads()
+    scaler._adjust_threads()
+
+    assert data.adjust_threads == 10  # 8+4=12가 아니라 상한 10
+
+
+def test_slow_five_ticks_halve_threads():
+    """평균 < 2 MB/s 틱 5회 → adjust_count -5(<-4) → 스레드 절반, 카운터 리셋."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 32
+    data.adjust_threads = 8
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 8
+    data.speed_mb = 8.0  # 평균 1 MB/s
+    for _ in range(4):
+        scaler._adjust_threads()
+    assert data.adjust_threads == 8  # 4틱까지는 불변 (-4는 경계 미달)
+
+    scaler._adjust_threads()
+    assert data.adjust_threads == 4
+    assert scaler.adjust_count == 0
+    assert logger.adjust_calls == [(4, 8.0)]
+
+
+def test_halving_floor_is_one_thread():
+    """감소 시 하한은 1스레드다."""
+    data, logger = _make_data(), RecordingLogger()
+    data.adjust_threads = 1
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 1
+    data.speed_mb = 0.5
+    for _ in range(5):
+        scaler._adjust_threads()
+
+    assert data.adjust_threads == 1
+
+
+def test_middle_band_decays_adjust_count_toward_zero():
+    """중간 대역(2~4 MB/s)은 누적 카운터를 0으로 1씩 되돌린다 (히스테리시스)."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 32
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 4
+    data.speed_mb = 20.0  # 평균 5 → +1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 1
+
+    data.speed_mb = 12.0  # 평균 3 → 감쇠 -1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+    assert data.adjust_threads == 4  # 임계 미달로 불변
+
+    data.speed_mb = 4.0  # 평균 1 → -1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == -1
+    data.speed_mb = 12.0  # 평균 3 → 감쇠 +1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+
+def test_band_boundaries_are_exclusive():
+    """경계값 4 MB/s·2 MB/s는 중간 대역이다 (초과/미만 판정)."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 2
+    data.speed_mb = 8.0  # 평균 정확히 4 → 증가 아님
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+    data.speed_mb = 4.0  # 평균 정확히 2 → 감소 아님
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+
+def test_zero_active_threads_counts_as_slow_tick():
+    """활성 스레드 0이면 평균 0으로 간주되어 감소 방향 틱이다."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 0
+    data.speed_mb = 10.0
+    scaler._adjust_threads()
+
+    assert scaler.adjust_count == -1
+
+
+# ================================================================ 속도 계산
+
+
+def test_measure_speed_uses_delta_from_previous_tick():
+    """속도 = (현재 누적 - 직전 누적) 바이트를 MB/s로 환산, prev_size 갱신."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.total_downloaded_size = 5 * MB
+    data.prev_size = 2 * MB
+    data.future_count = 3
+
+    scaler.measure_speed()
+
+    assert data.speed_mb == pytest.approx(3.0)
+    assert data.prev_size == 5 * MB
+    assert logger.debug_calls == [(3, pytest.approx(3.0), pytest.approx(1.0))]
+
+
+def test_measure_speed_with_no_active_threads_reports_zero_average():
+    """활성 스레드 0이면 평균 속도는 0으로 기록한다 (0 나눗셈 금지)."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.total_downloaded_size = 1 * MB
+    data.prev_size = 0
+    data.future_count = 0
+
+    scaler.measure_speed()
+
+    assert logger.debug_calls == [(0, pytest.approx(1.0), 0)]
+
+
+# ================================================================ 느린 파트·실패 처리
+
+
+class FakeResponse:
+    """스트리밍 응답 흉내 — 지정한 청크 목록을 그대로 흘린다."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        yield from self._chunks
+
+
+class FakeSession:
+    """get_thread_session() 대체 — 준비된 응답을 반환하거나 예외를 던진다."""
+
+    def __init__(self, response=None, exception=None):
+        self._response = response
+        self._exception = exception
+
+    def get(self, url, **kwargs):
+        if self._exception is not None:
+            raise self._exception
+        return self._response
+
+
+class TickingClock:
+    """time.time 대체 — 호출마다 지정 간격으로 흐르는 가짜 시계."""
+
+    def __init__(self, step: float):
+        self.now = 1_000_000.0
+        self.step = step
+
+    def __call__(self) -> float:
+        self.now += self.step
+        return self.now
+
+
+def _prepare_running_engine(tmp_path, monkeypatch, chunks=None, exception=None, clock_step=1.0):
+    """RUNNING 상태의 엔진과 부속(데이터·로거)을 준비한다.
+
+    clock_step=1.0이면 청크당 1초가 흘러 항상 저속(<100 KB/s) 판정,
+    아주 작은 값이면 항상 고속 판정이 난다.
+    """
+    output = tmp_path / "part.bin"
+    output.write_bytes(b"")
+
+    data = _make_data(str(output))
+    logger = RecordingLogger()
+    engine, task = _make_engine(data, logger)
+
+    data.model.start()  # RUNNING 상태로 진입
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+
+    mod = _engine_module()
+    monkeypatch.setattr(
+        mod, "get_thread_session", lambda: FakeSession(FakeResponse(chunks or []), exception)
+    )
+    monkeypatch.setattr(mod.tm, "time", TickingClock(clock_step))
+    return engine, data, logger
+
+
+def test_slow_part_restarts_after_six_slow_chunks(tmp_path, monkeypatch):
+    """청크 속도 < 100 KB/s 연속 6회(slow_count > 5)면 파트를 중단·재큐잉한다."""
+    chunks = [b"x" * 8192] * 10  # 1초/청크 → 8 KB/s로 항상 저속
+    engine, data, logger = _prepare_running_engine(tmp_path, monkeypatch, chunks=chunks, clock_step=1.0)
+
+    returned = engine._download_part(0, 40 * MB - 1, 0, 40 * MB)
+
+    assert returned == 0
+    assert data.restart_threads == 1
+    assert data.remaining_ranges == [(0, 40 * MB - 1)]  # 같은 구간 재큐잉
+    assert data.threads_progress[0] == 0  # 진행 바이트 롤백
+    assert data.completed_threads == 0
+    assert any("slow" in w for w in logger.warnings)
+
+
+def test_fast_part_completes_and_accumulates_progress(tmp_path, monkeypatch):
+    """정상 속도면 파트를 완주하고 완료 카운터·누적 진행에 반영한다."""
+    part_size = 3 * 8192
+    chunks = [b"x" * 8192] * 3
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, chunks=chunks, clock_step=1e-6
+    )
+
+    returned = engine._download_part(0, part_size - 1, 0, part_size)
+
+    assert returned == 0
+    assert data.completed_threads == 1
+    assert data.completed_progress == part_size
+    assert data.restart_threads == 0
+    assert data.remaining_ranges == []
+    assert logger.thread_completes == [(0, part_size)]
+
+
+def test_request_exception_requeues_range_as_failed(tmp_path, monkeypatch):
+    """요청 예외 시 실패 카운터를 올리고 같은 구간을 재큐잉한다."""
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, exception=requests.ConnectionError("boom")
+    )
+
+    returned = engine._download_part(0, MB - 1, 0, MB)
+
+    assert returned == 0
+    assert data.failed_threads == 1
+    assert data.remaining_ranges == [(0, MB - 1)]
+    assert data.threads_progress[0] == 0
+    assert len(logger.errors) == 1

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -330,7 +330,9 @@ def _prepare_running_engine(tmp_path, monkeypatch, chunks=None, exception=None, 
 def test_slow_part_restarts_after_six_slow_chunks(tmp_path, monkeypatch):
     """청크 속도 < 100 KB/s 연속 6회(slow_count > 5)면 파트를 중단·재큐잉한다."""
     chunks = [b"x" * 8192] * 10  # 1초/청크 → 8 KB/s로 항상 저속
-    engine, data, logger = _prepare_running_engine(tmp_path, monkeypatch, chunks=chunks, clock_step=1.0)
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, chunks=chunks, clock_step=1.0
+    )
 
     returned = engine._download_part(0, 40 * MB - 1, 0, 40 * MB)
 

--- a/tests/unit/core/test_file_downloader_run.py
+++ b/tests/unit/core/test_file_downloader_run.py
@@ -1,0 +1,215 @@
+"""FileDownloader.run 통합 검증 — 가짜 세션으로 전체 파이프라인 실행 (#73).
+
+실제 네트워크 없이 Range 요청을 흉내 내는 세션으로 다음을 검증한다:
+- 완주: 결과 파일이 바이트 단위로 원본과 동일, 완료 콜백 1회
+- 일시정지 → 재개 → 완료: PAUSED 동안 진행 정지, 재개 후 완주,
+  허용되지 않는 상태 전이(warning) 0건
+- 중단(stop): 파일 삭제, 완료 콜백 없음
+"""
+
+import threading
+import time
+
+
+import core.downloaders.file_downloader as fd_module
+from core.downloaders.file_downloader import FileDownloader
+from core.models.download_state import DownloadState
+from download.data import DownloadData
+
+MB = 1024 * 1024
+TOTAL_SIZE = 4 * MB  # 해상도 144 → 파트 1MB → 4파트
+
+
+class RunLogger:
+    """run() 경로 전체가 쓰는 로거 인터페이스를 기록만 하며 흉내 낸다."""
+
+    def __init__(self):
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+        self.completed_times: list[float] = []
+        self.closed = 0
+
+    def log_download_start(self, total_size, part_size, segments, initial_threads):
+        pass
+
+    def log_thread_start(self, thread_id, start, end):
+        pass
+
+    def log_thread_complete(self, thread_id, downloaded_size):
+        pass
+
+    def log_thread_adjust(self, active_threads, avg_speed):
+        pass
+
+    def log_thread_debug(self, active_threads, download_speed, avg_speed):
+        pass
+
+    def log_download_complete(self, total_time):
+        self.completed_times.append(total_time)
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def log_exception(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def save_and_close(self):
+        self.closed += 1
+
+
+def _content_bytes(total: int) -> bytes:
+    """결정적 내용의 가짜 파일 본문 — 바이트 단위 대조를 위해 주기 251 패턴을 쓴다."""
+    pattern = bytes(range(251))
+    repeats = total // len(pattern) + 1
+    return (pattern * repeats)[:total]
+
+
+CONTENT = _content_bytes(TOTAL_SIZE)
+
+
+class RangeResponse:
+    """Range 요청 구간을 청크로 흘리는 가짜 응답. throttle 초/청크로 속도를 조절한다."""
+
+    def __init__(self, body: bytes, throttle: float):
+        self._body = body
+        self._throttle = throttle
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._body), chunk_size):
+            if self._throttle:
+                time.sleep(self._throttle)
+            yield self._body[i : i + chunk_size]
+
+
+class RangeSession:
+    """head/get(Range)을 지원하는 가짜 세션 (requests.Session 최소 인터페이스)."""
+
+    def __init__(self, content: bytes, throttle: float = 0.0):
+        self._content = content
+        self._throttle = throttle
+        self.headers = {"content-length": str(len(content))}
+
+    def head(self, url, **kwargs):
+        return self
+
+    # head() 응답 겸용: raise_for_status/headers만 쓰인다
+
+    def raise_for_status(self):
+        pass
+
+    def get(self, url, headers=None, **kwargs):
+        range_header = (headers or {})["Range"]  # "bytes=start-end"
+        start, end = map(int, range_header.removeprefix("bytes=").split("-"))
+        return RangeResponse(self._content[start : end + 1], self._throttle)
+
+
+def _make_engine(tmp_path, monkeypatch, throttle: float = 0.0):
+    """가짜 세션이 연결된 RUNNING 이전 상태의 엔진을 준비한다."""
+    output = tmp_path / "out.mp4"
+    data = DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=str(output),
+        resolution=144,  # 파트 1MB
+        content_type="video",
+    )
+    logger = RunLogger()
+    session = RangeSession(CONTENT, throttle)
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: session)
+
+    finished = threading.Event()
+    failures: list[BaseException] = []
+
+    def on_finished():
+        # 실제 어댑터 경로(manager.finish → task.finish)를 흉내 내 상태를 종결한다
+        data.model.finish()
+        finished.set()
+
+    engine = FileDownloader(
+        data,
+        logger,
+        on_finished=on_finished,
+        on_failed=failures.append,
+    )
+    return engine, data, logger, output, finished, failures
+
+
+def _run_in_thread(engine) -> threading.Thread:
+    """엔진 run()을 별도 스레드에서 실행한다 (호출 규약: start() 후 run())."""
+    thread = threading.Thread(target=engine.run, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_run_downloads_file_byte_exact(tmp_path, monkeypatch):
+    """전체 파이프라인이 원본과 동일한 파일을 만들고 완료 콜백을 1회 호출한다."""
+    engine, data, logger, output, finished, failures = _make_engine(tmp_path, monkeypatch)
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert output.read_bytes() == CONTENT
+    assert failures == []
+    assert logger.errors == []
+    assert logger.warnings == []  # 느린 파트 오탐·전이 warning 없음
+    assert logger.completed_times and logger.closed == 1
+    assert data.completed_threads == 4  # 파트 4개 전부 정상 완료
+
+
+def test_pause_resume_then_complete(tmp_path, monkeypatch):
+    """일시정지 동안 진행이 멈추고, 재개 후 완주한다. 전이 warning 0건."""
+    # 청크당 5ms 스로틀 → 4파트 병렬로 약 0.64초 — 중간에 일시정지할 여유를 만든다
+    engine, data, logger, output, finished, failures = _make_engine(
+        tmp_path, monkeypatch, throttle=0.005
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+
+    time.sleep(0.25)  # 다운로드가 진행되는 중간 지점
+    assert data.model.pause() is True  # RUNNING → PAUSED (유효 전이)
+    assert data.model.state is DownloadState.PAUSED
+
+    # 워커들이 pause_event 대기에 도달할 시간을 준 뒤 진행량이 고정되는지 확인
+    time.sleep(0.3)
+    frozen = data.total_downloaded_size
+    snapshot = sum(data.threads_progress) + data.completed_progress
+    time.sleep(0.5)
+    assert sum(data.threads_progress) + data.completed_progress == snapshot
+    assert data.total_downloaded_size == frozen
+
+    assert data.model.resume() is True  # PAUSED → RUNNING (유효 전이)
+    assert finished.wait(timeout=60), "재개 후 완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert output.read_bytes() == CONTENT
+    assert failures == []
+    assert logger.warnings == []  # 상태 전이 warning 0건 (완료 조건)
+    assert data.model.state is DownloadState.FINISHED
+
+
+def test_stop_removes_partial_file(tmp_path, monkeypatch):
+    """중단(stop)하면 부분 파일을 삭제하고 완료 콜백을 호출하지 않는다."""
+    engine, data, logger, output, finished, failures = _make_engine(
+        tmp_path, monkeypatch, throttle=0.005
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+
+    time.sleep(0.25)
+    data.model.stop()  # RUNNING → WAITING (취소)
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    assert not output.exists()  # 부분 파일 삭제
+    assert not finished.is_set()
+    assert failures == []


### PR DESCRIPTION
## 관련 이슈

Closes #73

## 변경 내용

### 착수 조건 (선행 수행)

- **(가) 규칙 박제**: `tests/unit/core/test_file_downloader_rules.py` — 스레드 증가/감소 조건(+4/절반, 상한·하한), 히스테리시스 감쇠, 경계값(2·4 MB/s 배타), 속도 계산(직전 틱 델타), 느린 파트 판정(<100 KB/s 연속 6회), 실패 재큐잉을 시간·바이트 주입으로 고정 (12개). **이주 전 코드에서 먼저 통과를 확인하고 커밋 → 이주 후 팩토리(대상 클래스)만 교체, 시나리오·단언 무변경으로 재통과** (커밋 이력으로 확인 가능)
- **(나) 기준선 로그**: 이주 전 main으로 공개 VOD 14131411(1.6h)을 720p(2.2GB, 441파트) 헤드리스 완주, 로그 보관. 비교는 아래 표

### 구현

1. **`core/downloaders/file_downloader.py` 신설** — `DownloadThread.run`(스케줄링·파트 다운로드·재시도)과 `MonitorThread`(속도 측정·스레드 조정·진행 통지) 로직을 **식 그대로** 이동. QThread → 표준 `threading`, 범위 분할은 기존 `core/downloaders/ranges.py` 사용
2. **monitor 흡수** — 관측 루프는 엔진이 소유하는 일반 스레드(`_monitor_loop`, 1초 주기 동일)로 두고, 관측 결과는 #72의 `ProgressEvent` 콜백으로 보고 (진행/완료/실패 콜백 계약 준수)
3. **일시정지·중단** — `DownloadTaskModel`의 상태·`threading.Event`를 그대로 사용 (#60 공유 유지)
4. **Qt 어댑터 축소** — `download/download.py`는 엔진 실행 + completed/stopped Signal 변환("Download failed" 번역 유지), `download/monitor.py`는 ProgressEvent → progress Signal 형식 변환(계산식 동일). `DownloadManager`·UI 호출부 무변경. `download/task.py`에 어댑터 간 엔진 공유 슬롯(`engine`) 1줄 추가
5. **재시도·타임아웃·파트 실패 처리** — 분기·순서·카운터 모두 보존 (박제 테스트가 보증)

m3u8 경로(`download_m3u8.py`·`monitor_m3u8.py`)와 UI는 건드리지 않았다.

### 기준선 대비 구조적 지표 (같은 VOD 14131411, 720p, scripts/summarize_download_log.py)

| 지표 | 이주 전 (기준선) | 이주 후 |
|---|---|---|
| 전체 크기 / 파트 | 2,307,528,948 B / 5MB·441개 | 동일 |
| 초기 스레드 | 4 | 4 |
| **스레드 증가 궤적** | 8→12→16→20→24→28→32 | **8→12→16→20→24→28→32 (동일)** |
| 느린 파트 재시도 | 0 | 0 |
| 파트 실패 | 0 | 0 |
| 완주 여부 | 완주 (22.81s) | 완주 (21.97s) |

요약 스크립트는 **스레드 이름이 아닌 메시지 본문 패턴만** 파싱한다 — 실제로 이주로 관측 스레드 이름이 `[MonitorThread]`→`[DownloadMonitor]`로 바뀌었지만 양쪽 로그가 동일하게 처리됨을 확인했다.

## 검증

- [x] 스케일링 박제 테스트가 이주 후에도 통과 (12개, 시나리오·단언 무변경)
- [x] core 순수성 가드(`test_no_qt_import`) 통과, `uv run pytest` 전체 통과 (**149 passed** — Windows 로컬이라 xvfb 없이 실행), `uv run ruff check .` 통과
- [x] 헤드리스 스크립트로 동일 VOD 다운로드 성공 (2.2GB 완주, exit 0)
- [x] **일시정지 → 재개 → 완료** 정상 — 가짜 세션 통합 테스트로 검증: PAUSED 동안 진행 바이트 고정, 재개 후 완주, 결과 파일 바이트 단위 원본 일치, 상태 전이 warning 0건 (`test_file_downloader_run.py`)
- [x] 중단(stop) 시 부분 파일 삭제 검증
- [x] GUI 기동 스모크 정상 (에러 로그 0)
- [x] **오너 스모크**: 기준선과 같은 대용량 VOD로 GUI에서 완주 + 일시정지/재개 후 `scripts/summarize_download_log.py`로 지표 비교 (위 표는 에이전트 헤드리스 측정 — GUI 실사용 확인은 오너 몫)

## 아키텍처 체크

- [x] core → app import 없음 (data·logger는 #72와 같은 주입 방식 — 어댑터가 앱 객체를 넘긴다)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역 변경 없음 — 있다면 승인된 이슈 번호: #73 (core/downloaders/file_downloader.py 신설, approved)

## 리뷰어에게

- 로직은 의도적으로 리팩토링하지 않고 식 그대로 옮겼다 (이슈 요구). 구조 개선(예: future_count 락 범위, 'clips' vs 'clip' part_size 분기 불일치)은 눈에 띄지만 이 PR 범위 밖 — 필요하면 별도 이슈로 제안하겠다
- 구 `MonitorThread.update_progress`(집계+통지)와 구 `DownloadThread.update_progress`(집계만)의 이름 충돌은 엔진에서 `emit_progress`/`update_progress`로 분리했다 (계산식 동일)
- 어댑터 `MonitorThread`는 QThread 인터페이스(manager 무변경)만 유지하고 run()은 즉시 종료한다 — 진행 통지는 엔진 관측 스레드 → 콜백 → Signal emit 경로

🤖 Generated with [Claude Code](https://claude.com/claude-code)