### PR TITLE
refactor: m3u8 다운로더 탈Qt + monitor 흡수 (#74)

### DIFF
--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -1,0 +1,456 @@
+"""m3u8(세그먼트 분할) 다운로드 엔진 — 표준 threading 기반 (#74, SPEC §5·§6).
+
+구 download/download_m3u8.py의 DownloadM3U8Thread(QThread)와
+download/monitor_m3u8.py의 MonitorM3U8Thread(QThread)에 나뉘어 있던
+실행·관측 로직을 Qt 없이 한 클래스로 흡수했다 — 이슈 #73(파일 다운로더)과
+같은 패턴이다. 로직(플레이리스트 파싱·세그먼트 스케줄링·해상도별 적응형
+스레드 스케일링·느린 세그먼트 재시도·실패 재큐잉·순서 보장 병합)은 식 그대로
+이동했다 — 규칙은 tests/unit/core/test_m3u8_downloader_rules.py가 박제한다.
+
+파일 경로 엔진(FileDownloader)과의 차이:
+- base_url은 m3u8 플레이리스트 URL이며 **호출 전에 해석이 끝나 있어야 한다**.
+  치지직 API 조회(쿠키·NetworkManager)는 아직 앱 영역이므로 어댑터가 수행한다.
+- 스레드 스케일링 기준 속도가 해상도별 테이블(_get_standard_speed)을 따른다.
+- 다운로드 완료 후 병합 단계가 있다. 병합 시작은 on_merge_start 콜백으로
+  알린다 — 앱 어댑터가 UI 플래그(item.post_process)로 변환한다.
+- 전체 크기를 미리 알 수 없어 ProgressEvent.total_size는 None이다.
+  진행률 계산(세그먼트 수 기반)은 어댑터의 몫이다.
+
+- 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
+  (_monitor_loop)가 수행하고, 결과는 core/models/events.py의 ProgressEvent
+  콜백으로 보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
+- 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다(#60).
+- 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다
+  (스레드 규칙은 core/models/events.py docstring 참고).
+
+data·logger 매개변수는 앱 영역(download/data.py의 DownloadData,
+download/logger.py의 DownloadLogger)과 호환되는 객체를 주입받는다.
+core에서 직접 import하지 않는 이유는 core→app 의존 금지 때문이다 (#72와 동일한 방식).
+"""
+
+import os
+import shutil
+import threading
+import time as tm
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import urljoin
+
+import requests
+
+from core.api.session import get_thread_session
+from core.models.download_state import DownloadState
+from core.models.events import (
+    FailedCallback,
+    FinishedCallback,
+    ProgressCallback,
+    ProgressEvent,
+)
+
+
+class M3U8Downloader:
+    """m3u8 VOD를 세그먼트 단위 멀티스레드로 다운로드·병합하는 엔진.
+
+    호출 규약: 소유자(어댑터·스크립트)가 data.base_url에 m3u8 플레이리스트 URL을
+    채우고 DownloadTaskModel.start()로 RUNNING 전이를 마친 뒤 run()을 호출한다.
+    run()은 완료·중단·실패까지 블로킹한다.
+    """
+
+    def __init__(
+        self,
+        data,
+        logger,
+        on_progress: ProgressCallback | None = None,
+        on_finished: FinishedCallback | None = None,
+        on_failed: FailedCallback | None = None,
+        on_merge_start: Callable[[], None] | None = None,
+    ):
+        """엔진을 생성한다.
+
+        Args:
+            data: DownloadData 호환 공유 데이터 (진행률·엔진 변수·model 보유)
+            logger: DownloadLogger 호환 로거
+            on_progress: 관측 주기마다 ProgressEvent를 받는 콜백
+            on_finished: 정상 완료 시 인자 없이 호출되는 콜백
+            on_failed: 실패 시 예외 객체를 그대로 받는 콜백
+            on_merge_start: 세그먼트 병합 단계 진입 시 인자 없이 호출되는 콜백
+        """
+        self.s = data
+        self.model = data.model
+        self.logger = logger
+        self.lock = threading.Lock()
+        self.future_dict: dict = {}
+        self.adjust_count = 0
+        self._on_progress: ProgressCallback = on_progress or (lambda event: None)
+        self._on_finished: FinishedCallback = on_finished or (lambda: None)
+        self._on_failed: FailedCallback = on_failed or (lambda exc: None)
+        self._on_merge_start: Callable[[], None] = on_merge_start or (lambda: None)
+
+    @property
+    def state(self) -> DownloadState:
+        """현재 다운로드 상태 (DownloadTaskModel에 위임)."""
+        return self.model.state
+
+    def set_on_progress(self, callback: ProgressCallback) -> None:
+        """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
+        self._on_progress = callback
+
+    # ============ 실행 파이프라인 (구 DownloadM3U8Thread.run) ============
+
+    def run(self) -> None:
+        """다운로드·병합 파이프라인을 실행한다. 관측 스레드도 여기서 소유·시작한다."""
+        monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
+        # 세그먼트 저장용 임시 폴더 경로 설정 (예외 정리 경로가 참조하므로 가장 먼저)
+        self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
+        try:
+            self.s.start_time = tm.time()
+
+            response = get_thread_session().get(self.s.base_url)
+            response.raise_for_status()
+            lines = response.text.splitlines()
+            segments = [line for line in lines if line and not line.startswith("#")]
+            init_segment = None
+            self.s.merged_segments = 0
+
+            self.s.max_threads = self.s.total_ranges = len(segments)
+            self.width = len(str(self.s.total_ranges))
+            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
+            self.s.threads_progress = [0] * self.s.total_ranges
+            self.logger.log_download_start(0, 0, self.s.total_ranges, self.s.adjust_threads)
+
+            # 세그먼트 저장용 임시 폴더가 있다면 내용 포함 삭제 후 재생성
+            if os.path.exists(self.temp_dir):
+                shutil.rmtree(self.temp_dir)
+            os.makedirs(self.temp_dir)
+
+            for line in lines:
+                if line.startswith("#EXT-X-MAP:"):
+                    init_segment = line.split("URI=")[1].strip('"')
+            init_url = urljoin(self.s.base_url, init_segment)
+            init_segment_path = os.path.join(self.temp_dir, f"{0:0{self.width}d}.m4s")
+            # 초기화 세그먼트 다운로드
+            with open(init_segment_path, "wb") as f:
+                f.write(get_thread_session().get(init_url).content)
+
+            # 진행률 배열이 준비된 뒤에 관측을 시작한다
+            monitor.start()
+
+            with ThreadPoolExecutor(
+                max_workers=self.s.max_threads, thread_name_prefix="DownloadM3U8Worker"
+            ) as executor:
+                self.s.remaining_ranges = list(enumerate(segments))
+                # 재사용 시 초기화 필수
+                with self.lock:
+                    self.s.future_count = 0
+                    self.future_dict = {}
+
+                while not self.state == DownloadState.WAITING:
+                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
+                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
+                        for part_num in range(self.s.adjust_threads):
+                            if not self.s.remaining_ranges:
+                                break
+                            with self.lock:
+                                if part_num not in self.future_dict:
+                                    segment_index, segment = self.s.remaining_ranges.pop(0)
+                                    self.s.future_count += 1
+                                    self.logger.log_m3u8_thread_start(part_num, segment)
+                                    future = executor.submit(
+                                        self._download_segment,
+                                        index=segment_index,
+                                        segment=segment,
+                                        part_num=part_num,
+                                        total_ranges=self.s.total_ranges,
+                                    )
+                                    future.add_done_callback(self._download_completed_callback)
+                                    self.future_dict[part_num] = (segment, future)
+
+                    # (2) 주기적으로 상태 확인 (non-blocking)
+                    tm.sleep(0.1)
+
+                    # (3) 남은 작업이 없고 스레드도 없으면 종료
+                    if not self.s.remaining_ranges and not self.future_dict:
+                        break
+
+                if self.state == DownloadState.RUNNING:
+                    # (4) 다운로드 완료 후 파일 합치기
+                    self._on_merge_start()
+                    with open(self.s.output_path, "wb") as final_f:
+                        segment_files = sorted(os.listdir(self.temp_dir))
+                        for seg_file in segment_files:
+                            # 다운로드 중지 상태라면 중단
+                            if self.state == DownloadState.RUNNING:
+                                seg_path = os.path.join(self.temp_dir, seg_file)
+                                with open(seg_path, "rb") as seg_f:
+                                    while True:
+                                        chunk = seg_f.read(8192)
+                                        if not chunk:
+                                            break
+                                        final_f.write(chunk)
+                                        # 일시정지 상태라면 대기
+                                        if self.state == DownloadState.PAUSED:
+                                            self.s._pause_event.wait()
+                                # 세그먼트 파일 합친 후 삭제
+                                self.safe_remove(seg_path)
+                                self.s.merged_segments += 1
+
+                    self.s.end_time = tm.time()
+                    total_time = self.s.end_time - self.s.start_time
+                    self.logger.log_download_complete(total_time)
+                    self.logger.save_and_close()
+                    self._on_finished()
+
+            # (5) 임시 폴더 삭제
+            shutil.rmtree(self.temp_dir)
+
+        except Exception as e:
+            # 오류 발생 시 임시 파일과 다운로드 파일 삭제
+            if os.path.exists(self.temp_dir):
+                shutil.rmtree(self.temp_dir)
+            if os.path.exists(self.s.output_path):
+                os.remove(self.s.output_path)
+            self._on_failed(e)
+            self.logger.log_exception("Download failed", e)
+            self.logger.save_and_close()
+
+        # 사용자가 강제로 중단한 경우 임시 파일과 다운로드 파일 삭제
+        if self.state == DownloadState.WAITING:
+            if os.path.exists(self.temp_dir):
+                shutil.rmtree(self.temp_dir)
+            if os.path.exists(self.s.output_path):
+                os.remove(self.s.output_path)
+
+    # ============ 다운로드 동작 관련 메서드들 ============
+
+    def _download_segment(self, index: int, segment: str, part_num: int, total_ranges: int):
+        """
+        개별 세그먼트 다운로드(재시도 포함)
+        """
+        slow_count = 0
+        downloaded_size = 0
+        segment_url = urljoin(self.s.base_url, segment)
+        while not self.state == DownloadState.WAITING:
+            try:
+                # 스레드로컬 세션으로 같은 워커의 세그먼트 요청 간 연결을 재사용한다 (#31)
+                response = get_thread_session().get(segment_url, stream=True, timeout=30)
+                response.raise_for_status()
+                part_start_time = tm.time()
+
+                temp_file = os.path.join(self.temp_dir, f"{index + 1:0{self.width}d}.m4v")
+                with open(temp_file, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if self.state == DownloadState.WAITING:
+                            return part_num
+                        if self.state == DownloadState.PAUSED:
+                            self.s._pause_event.wait()
+
+                        if chunk:
+                            f.write(chunk)
+                            downloaded_size += len(chunk)
+                            elapsed = tm.time() - part_start_time
+
+                            if elapsed > 0:
+                                speed_kb_s = downloaded_size / elapsed / 1024
+                                self._check_speed_and_update_progress(
+                                    part_num, downloaded_size, total_ranges, speed_kb_s
+                                )
+                                if speed_kb_s < 100:
+                                    slow_count += 1
+                                    if slow_count > 5:
+                                        # 속도가 너무 느리면 스레드 재시작
+                                        with self.lock:
+                                            self._download_stop_callback(index, segment, part_num)
+                                        return part_num
+                                else:
+                                    slow_count = 0
+
+                # 성공적으로 마무리된 경우
+                with self.lock:
+                    self.s.completed_threads += 1
+                    self.s.completed_progress += downloaded_size
+                    self.s.threads_progress[part_num] = 0
+                self.logger.log_thread_complete(part_num, downloaded_size)
+                return part_num
+
+            except (requests.RequestException, requests.Timeout) as e:
+                with self.lock:
+                    self._download_failed_callback(index, segment, part_num)
+                self.logger.log_error(f"Part {part_num} download failed", e)
+                return part_num
+
+    def _check_speed_and_update_progress(
+        self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float
+    ):
+        """
+        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
+        """
+        with self.lock:
+            self.s.threads_progress[part_num] = downloaded_size
+            self.update_progress()
+
+    # ============ 다운로드 조정 및 콜백 메서드 ============
+
+    def _download_completed_callback(self, future):
+        """
+        특정 future(스레드)가 끝났을 때 호출되는 콜백.
+        """
+        try:
+            part_num = future.result()
+            # part_num 식별 후 future_dict에서 제거
+            with self.lock:
+                if part_num in self.future_dict:
+                    del self.future_dict[part_num]
+                    self.s.future_count -= 1
+            self.update_progress()  # 즉각적 진행도 반영
+
+        except Exception as e:
+            # 일부 스레드가 오류로 중단된 경우
+            self._on_failed(e)
+            self.logger.log_error("Thread failed", e)
+
+    def _download_failed_callback(self, index: int, segment: str, part_num: int):
+        """
+        예외 발생 시 세그먼트를 다시 다운로드할 수 있도록 remaining_ranges에 등록.
+        """
+        self.s.failed_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append((index, segment))
+
+    def _download_stop_callback(self, index: int, segment: str, part_num: int):
+        """
+        특정 스레드를 중도 중단하고, 해당 세그먼트를 재시작하도록 설정.
+        """
+        self.s.restart_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append((index, segment))
+        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
+
+    # ============ 관측 루프 (구 MonitorM3U8Thread — 엔진이 흡수) ============
+
+    def _monitor_loop(self):
+        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
+        tm.sleep(1)
+        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
+            if not self.s._pause_event.is_set():
+                self.s._pause_event.wait()
+                self.measure_speed()
+            else:
+                self._adjust_threads()
+                self.measure_speed()
+                self.emit_progress()
+            total_sleep = 1.0  # 총 1초 대기
+            interval = 0.1  # 0.1초씩 대기
+            elapsed = 0.0
+            while elapsed < total_sleep and self.state in [
+                DownloadState.RUNNING,
+                DownloadState.PAUSED,
+            ]:
+                tm.sleep(interval)
+                elapsed += interval
+
+    def _adjust_threads(self):
+        """
+        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
+        """
+        with self.lock:
+            future_count = self.s.future_count
+
+        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+
+        standard_speed = self._get_standard_speed()
+
+        if avg_active_speed > standard_speed:
+            self.adjust_count += 1
+        elif avg_active_speed < standard_speed / 2:
+            self.adjust_count -= 1
+        else:
+            if self.adjust_count > 0:
+                self.adjust_count -= 1
+            elif self.adjust_count < 0:
+                self.adjust_count += 1
+
+        if self.adjust_count > 1:
+            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+        elif self.adjust_count < -4:
+            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+
+    def measure_speed(self):
+        """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""
+        current_size = self.s.total_downloaded_size
+        speed = current_size - self.s.prev_size
+        self.s.prev_size = current_size
+
+        with self.lock:
+            future_count = self.s.future_count
+        # MB/s로 변환
+        self.s.speed_mb = speed / (1024 * 1024)
+        avg_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+        self.logger.log_thread_debug(future_count, self.s.speed_mb, avg_speed)
+
+    def _get_standard_speed(self) -> float:
+        """
+        해상도에 따른 표준 속도 값을 반환합니다.
+        """
+        if self.s.resolution == 144:
+            return 0.2
+        elif self.s.resolution in [360, 480]:
+            return 0.5
+        elif self.s.resolution == 720:
+            return 1.2
+        else:
+            return 3
+
+    # ============ 진행 상황 업데이트 ============
+
+    def update_progress(self):
+        """
+        다운로드된 총량을 저장한다.
+        """
+        if self.state in [DownloadState.PAUSED, DownloadState.WAITING]:  # 중단 플래그 확인
+            return
+
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+    def emit_progress(self):
+        """진행 상태를 집계해 ProgressEvent 콜백으로 통지한다 (구 MonitorM3U8Thread.update_progress).
+
+        m3u8은 전체 바이트 크기를 미리 알 수 없으므로 total_size는 None이다.
+        세그먼트 수 기반 진행률 계산은 어댑터가 공유 데이터로 수행한다.
+        """
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+        with self.lock:
+            future_count = self.s.future_count
+
+        self._on_progress(
+            ProgressEvent(
+                downloaded_size=self.s.total_downloaded_size,
+                total_size=None,
+                speed=self.s.speed_mb,
+                active_threads=future_count,
+            )
+        )
+
+    # ============ 유틸 메서드 ============
+
+    def safe_remove(self, path: str, retries: int = 5, delay: float = 0.2) -> None:
+        """
+        파일 삭제 시도 (PermissionError 방지용 재시도 포함)
+        """
+        for _ in range(int(retries)):
+            try:
+                os.remove(path)
+                return
+            except PermissionError:  # [WinError 32]
+                tm.sleep(delay)
+        raise PermissionError(f"Failed to remove {path} after {retries} attempts")

--- a/download/download_m3u8.py
+++ b/download/download_m3u8.py
@@ -1,289 +1,86 @@
-import requests
+"""m3u8 다운로드 워커 — core M3U8Downloader를 실행하고 Signal로 중계하는 얇은 어댑터 (#74).
+
+다운로드·병합 실행 로직은 core/downloaders/m3u8_downloader.py로 이동했다.
+이 클래스는 다음만 담당한다:
+- base_url 해석: 쿠키 로드·치지직 API 조회(NetworkManager)는 네트워크 계층이
+  아직 앱 영역이므로 어댑터가 run() 시작 시 수행한다 (#72와 같은 이유)
+- QThread에서 엔진 run()을 실행 (DownloadManager 호출부 무변경)
+- 엔진의 완료·실패·병합 시작 콜백을 기존 completed/stopped Signal과
+  item.post_process 플래그로 변환
+- 실패 메시지 번역(tr) — i18n 키 "Download failed"는 여기서 유지한다
+"""
+
 import threading
-import time as tm
-import os
-import shutil
-import config.config as config
-from urllib.parse import urljoin
 
 from PySide6.QtCore import QThread, Signal
-from concurrent.futures import ThreadPoolExecutor
-from download.task import DownloadTask
-from download.state import DownloadState
+
+import config.config as config
 from content.network import NetworkManager
-from core.api.session import get_thread_session
+from core.downloaders.m3u8_downloader import M3U8Downloader
+from core.models.download_state import DownloadState
+from download.task import DownloadTask
+
 
 class DownloadM3U8Thread(QThread):
     """
-    m3u8 파일을 multi-thread로 다운로드하는 작업 스레드 클래스
+    m3u8 파일을 multi-thread로 다운로드하는 작업 스레드 클래스 (core 엔진 어댑터)
     """
+
     completed = Signal()
     stopped = Signal(str)
 
     def __init__(self, task: DownloadTask):
         super().__init__()
         self.task = task
-        self.s = self.task.data
-        self.future_dict = {}
-        self.lock = self.task.lock
-        self.logger = self.task.logger
+        self.engine = M3U8Downloader(
+            data=task.data,
+            logger=task.logger,
+            on_finished=self._relay_finished,
+            on_failed=self._relay_failed,
+            on_merge_start=self._relay_merge_start,
+        )
+        # MonitorM3U8Thread 어댑터가 진행 콜백을 연결할 수 있도록 태스크에 공유한다 (#73)
+        task.engine = self.engine
 
     def run(self):
-        """
-        스레드가 시작될 때 자동으로 호출되는 메서드.
-        실제 다운로드 파이프라인이 여기서 진행된다.
-        """
+        """QThread 진입점 — base_url을 해석한 뒤 core 엔진의 파이프라인을 실행한다."""
+        threading.current_thread().name = "DownloadM3U8Thread"  # 스레드 시작 시 이름 재설정
         try:
-            data = config.load_config().get("cookies", {})
-            cookies = {
-                'NID_AUT': data.get("NID_AUT", ""),
-                'NID_SES': data.get("NID_SES", "")
-            }
-            content_type, content_no = NetworkManager.extract_content_no(self.s.vod_url)
-            info = NetworkManager.get_video_info(content_no, cookies)
-            self.s.base_url = NetworkManager.get_video_m3u8_base_url(info.live_rewind_playback_json, self.s.resolution, cookies)
-            threading.current_thread().name = "DownloadM3U8Thread"  # 스레드 시작 시 이름 재설정
-            self.s.start_time = tm.time()
-
-            response = get_thread_session().get(self.s.base_url)
-            response.raise_for_status()
-            lines = response.text.splitlines()
-            segments = [line for line in lines if line and not line.startswith("#")]
-            init_segment = None
-            self.s.merged_segments = 0
-            
-            self.s.max_threads = self.s.total_ranges = len(segments)
-            self.width = len(str(self.s.total_ranges))
-            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
-            self.s.threads_progress = [0] * self.s.total_ranges
-            self.logger.log_download_start(0, 0, self.s.total_ranges, self.s.adjust_threads)
-
-
-            # 세그먼트 저장용 임시 폴더 경로 설정
-            self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
-            # 세그먼트 저장용 임시 폴더가 있다면 내용 포함 삭제
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            # 세그먼트 저장용 임시 폴더 생성
-            os.makedirs(self.temp_dir)
-
-            for line in lines:
-                if line.startswith("#EXT-X-MAP:"):
-                    init_segment = line.split("URI=")[1].strip('"')
-            init_url = urljoin(self.s.base_url, init_segment)
-            init_segment_path = os.path.join(self.temp_dir, f"{0:0{self.width}d}.m4s")
-            # 초기화 세그먼트 다운로드
-            with open(init_segment_path, 'wb') as f:
-                f.write(get_thread_session().get(init_url).content)
-
-            with ThreadPoolExecutor(max_workers=self.s.max_threads, thread_name_prefix="DownloadM3U8Worker") as executor:
-                self.s.remaining_ranges = list(enumerate(segments))
-                # 재사용 시 초기화 필수
-                with self.lock:
-                    self.s.future_count = 0
-                    self.future_dict = {}
-
-                while not self.task.state == DownloadState.WAITING:
-                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
-                        for part_num in range(self.s.adjust_threads):
-                            if not self.s.remaining_ranges:
-                                break
-                            with self.lock:
-                                if part_num not in self.future_dict:
-                                    segment_index, segment = self.s.remaining_ranges.pop(0)
-                                    self.s.future_count += 1
-                                    self.logger.log_m3u8_thread_start(part_num, segment)
-                                    future = executor.submit(
-                                        self._download_segment,
-                                        index=segment_index,
-                                        segment=segment,
-                                        part_num=part_num,
-                                        total_ranges=self.s.total_ranges
-                                    )
-                                    future.add_done_callback(self._download_completed_callback)
-                                    self.future_dict[part_num] = (segment, future)
-
-                    # (2) 주기적으로 상태 확인 (non-blocking)
-                    tm.sleep(0.1)
-
-                    # (3) 남은 작업이 없고 스레드도 없으면 종료
-                    if not self.s.remaining_ranges and not self.future_dict:
-                        break
-                    
-                if self.task.state == DownloadState.RUNNING:
-                    # (4) 다운로드 완료 후 파일 합치기
-                    self.task.item.post_process = True
-                    with open(self.s.output_path, 'wb') as final_f:
-                        segment_files = sorted(os.listdir(self.temp_dir))
-                        for seg_file in segment_files:
-                            # 다운로드 중지 상태라면 중단
-                            if self.task.state == DownloadState.RUNNING:
-                                seg_path = os.path.join(self.temp_dir, seg_file)
-                                with open(seg_path, 'rb') as seg_f:
-                                    while True:
-                                        chunk = seg_f.read(8192)
-                                        if not chunk:
-                                            break
-                                        final_f.write(chunk)
-                                        # 일시정지 상태라면 대기
-                                        if self.task.state == DownloadState.PAUSED:
-                                            self.s._pause_event.wait()
-                                # 세그먼트 파일 합친 후 삭제
-                                self.safe_remove(seg_path)
-                                self.s.merged_segments += 1
-                                
-                    self.s.end_time = tm.time()
-                    total_time = self.s.end_time - self.s.start_time
-                    self.logger.log_download_complete(total_time)
-                    self.logger.save_and_close()
-                    self.completed.emit()
-                
-            # (5) 임시 폴더 삭제
-            shutil.rmtree(self.temp_dir)
-
+            self._resolve_base_url()
         except Exception as e:
-            # 오류 발생 시 임시 파일과 다운로드 파일 삭제
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-                self.task.item.post_process = False
-            self.stopped.emit(self.tr("Download failed"))
-            self.logger.log_exception("Download failed", e)
-            self.logger.save_and_close()
-
-        # 사용자가 강제로 중단한 경우 임시 파일과 다운로드 파일 삭제
-        if self.task.state == DownloadState.WAITING:
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-            self.task.item.post_process = False
-                
-    # ============ 다운로드 동작 관련 메서드들 ============
-
-    def _download_segment(self, index, segment, part_num, total_ranges):
-        """
-        개별 세그먼트 다운로드(재시도 포함)
-        """
-        slow_count = 0
-        downloaded_size = 0
-        segment_url = urljoin(self.s.base_url, segment)
-        while not self.task.state == DownloadState.WAITING:
-            try:
-                # 스레드로컬 세션으로 같은 워커의 세그먼트 요청 간 연결을 재사용한다 (#31)
-                response = get_thread_session().get(segment_url, stream=True, timeout=30)
-                response.raise_for_status()
-                part_start_time = tm.time()
-
-                temp_file = os.path.join(self.temp_dir, f"{index+1:0{self.width}d}.m4v")
-                with open(temp_file, 'wb') as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        if self.task.state == DownloadState.WAITING:
-                            return part_num
-                        if self.task.state == DownloadState.PAUSED:
-                            self.s._pause_event.wait()
-
-                        if chunk:
-                            f.write(chunk)
-                            downloaded_size += len(chunk)
-                            elapsed = tm.time() - part_start_time
-
-                            if elapsed > 0:
-                                speed_kb_s = downloaded_size / elapsed / 1024
-                                self._check_speed_and_update_progress(
-                                    part_num, downloaded_size, total_ranges, speed_kb_s
-                                )
-                                if speed_kb_s < 100:
-                                    slow_count += 1
-                                    if slow_count > 5:
-                                        # 속도가 너무 느리면 스레드 재시작
-                                        with self.lock:
-                                            self._download_stop_callback(index, segment, part_num)
-                                        return part_num
-                                else:
-                                    slow_count = 0
-
-                # 성공적으로 마무리된 경우
-                with self.lock:
-                    self.s.completed_threads += 1
-                    self.s.completed_progress += downloaded_size
-                    self.s.threads_progress[part_num] = 0
-                self.logger.log_thread_complete(part_num, downloaded_size)
-                return part_num
-
-            except (requests.RequestException, requests.Timeout) as e:
-                with self.lock:
-                    self._download_failed_callback(index, segment, part_num)
-                self.logger.log_error(f"Part {part_num} download failed", e)
-                return part_num
-                
-
-    def _check_speed_and_update_progress(self, part_num, downloaded_size, total_size, speed_kb_s):
-        """
-        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
-        """
-        with self.lock:
-            self.s.threads_progress[part_num] = downloaded_size
-            self.update_progress()
-
-    # ============ 다운로드 조정 및 콜백 메서드 ============
-
-    def _download_completed_callback(self, future):
-        """
-        특정 future(스레드)가 끝났을 때 호출되는 콜백.
-        """
-        try:
-            part_num = future.result()
-            # part_num 식별 후 future_dict에서 제거
-            with self.lock:
-                if part_num in self.future_dict:
-                    del self.future_dict[part_num]
-                    self.s.future_count -= 1
-            self.update_progress()  # 즉각적 진행도 반영
-
-        except Exception as e:
-            # 일부 스레드가 오류로 중단된 경우
-            self.stopped.emit(self.tr("Download failed"))
-            self.logger.log_error("Thread failed", e)
-
-    def _download_failed_callback(self, index, segment, part_num):
-        """
-        예외 발생 시 파일 구간을 다시 다운로드할 수 있도록 remaining_ranges에 등록.
-        """
-        self.s.failed_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((index, segment))
-
-    def _download_stop_callback(self, index, segment, part_num):
-        """
-        특정 스레드를 중도 중단하고, 해당 구간을 재시작하도록 설정.
-        """
-        self.s.restart_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((index, segment))
-        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
-
-    # ============ 진행 상황 업데이트 / 제어 메서드 ============
-
-    def update_progress(self):
-        """
-        다운로드된 총량을 저장한다.
-        """
-        if self.task.state in [DownloadState.PAUSED, DownloadState.WAITING]:    # 중단 플래그 확인
+            # 조회 실패는 엔진 실패와 같은 형식으로 보고한다 (구 코드의 단일 except와 동일)
+            self._relay_failed(e)
+            self.task.logger.log_exception("Download failed", e)
+            self.task.logger.save_and_close()
             return
-        
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+        self.engine.run()
+        # 사용자가 강제로 중단한 경우 병합 표시 해제 (구 코드의 WAITING 정리와 동일)
+        if self.task.state == DownloadState.WAITING:
+            self.task.item.post_process = False
 
-    def safe_remove(self, path, retries=5, delay=0.2):
-        """
-        파일 삭제 시도 (PermissionError 방지용 재시도 포함)
-        """
-        for i in range(int(retries)):
-            try:
-                os.remove(path)
-                return
-            except PermissionError:  # [WinError 32]
-                tm.sleep(delay)
-        raise PermissionError(f"Failed to remove {path} after {retries} attempts")
+    def _resolve_base_url(self):
+        """쿠키를 읽고 치지직 API로 선택 해상도의 m3u8 플레이리스트 URL을 해석한다."""
+        data = config.load_config().get("cookies", {})
+        cookies = {
+            "NID_AUT": data.get("NID_AUT", ""),
+            "NID_SES": data.get("NID_SES", ""),
+        }
+        s = self.task.data
+        content_type, content_no = NetworkManager.extract_content_no(s.vod_url)
+        info = NetworkManager.get_video_info(content_no, cookies)
+        s.base_url = NetworkManager.get_video_m3u8_base_url(
+            info.live_rewind_playback_json, s.resolution, cookies
+        )
+
+    def _relay_finished(self):
+        """엔진 완료 콜백 → completed Signal (emit은 스레드 세이프)."""
+        self.completed.emit()
+
+    def _relay_failed(self, exc: BaseException):
+        """엔진 실패 콜백 → stopped Signal. 병합 표시 해제와 메시지 번역은 여기서 한다."""
+        self.task.item.post_process = False
+        self.stopped.emit(self.tr("Download failed"))
+
+    def _relay_merge_start(self):
+        """엔진 병합 시작 콜백 → UI 병합 단계 플래그 (구 코드의 post_process = True)."""
+        self.task.item.post_process = True

--- a/download/monitor_m3u8.py
+++ b/download/monitor_m3u8.py
@@ -1,134 +1,80 @@
-import time as t
-import threading
+"""m3u8 진행 관측 어댑터 — core 엔진의 ProgressEvent를 progress Signal로 중계 (#74).
+
+관측 루프(속도 측정·해상도별 스레드 조정·주기 통지)는 core M3U8Downloader가
+소유하는 일반 스레드로 흡수됐다. 이 클래스는 다음만 담당한다:
+- 엔진의 ProgressEvent 콜백을 기존 progress Signal 형식(남은 시간·크기·속도·%)으로
+  변환해 emit (DownloadManager 호출부 무변경). m3u8은 전체 크기를 미리 알 수 없어
+  진행률·남은 시간을 세그먼트 수 기반으로 계산한다 — 계산식은 구 코드와 동일하다.
+- manager.finish가 쓰는 update_progress()/get_download_time() 인터페이스 유지
+"""
+
+from time import gmtime, strftime
 
 from PySide6.QtCore import QThread, Signal
+
+from core.models.events import ProgressEvent
 from download.task import DownloadTask
-from download.state import DownloadState
-from time import strftime, gmtime
+
 
 class MonitorM3U8Thread(QThread):
     """
-    VOD 파일을 multi-thread로 다운로드하는 작업 스레드 클래스
+    m3u8 다운로드 진행 상황을 UI로 중계하는 어댑터 스레드 클래스
     """
+
     progress = Signal(str, str, str, int)
 
     def __init__(self, task: DownloadTask):
         super().__init__()
         self.task = task
         self.data = self.task.data
-        self.logger = self.task.logger # 로거 초기화
-        self.adjust_count = 0
+        # DownloadM3U8Thread 어댑터가 먼저 생성되어 task.engine을 채운다 (manager의 생성 순서)
+        self.engine = task.engine
+        self.engine.set_on_progress(self._relay_progress)
 
     def run(self):
+        """관측 루프는 core 엔진 내부로 이주했다 — QThread는 시작 즉시 종료한다."""
+
+    def _relay_progress(self, event: ProgressEvent):
+        """ProgressEvent를 기존 Signal 인자(남은 시간, 크기, 속도 문자열, %)로 변환한다.
+
+        엔진의 관측 스레드에서 호출되므로 Signal emit까지만 수행한다 (스레드 규칙).
+        계산식은 구 MonitorM3U8Thread.update_progress와 동일하다 — 진행률은
+        병합 단계(post_process)에서는 병합된 세그먼트 수, 그 전에는 완료된
+        세그먼트 수 기반이고, 남은 시간은 평균 세그먼트 크기로 추정한다.
         """
-        스레드가 시작될 때 자동으로 호출되는 메서드.
-        실제 다운로드 파이프라인이 여기서 진행된다.
-        """
-        threading.current_thread().name = "MonitorThread"  # 스레드 시작 시 이름 재설정
-        t.sleep(1)
-        while self.task.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-            if not self.data._pause_event.is_set():
-                self.data._pause_event.wait()
-                self.measure_speed()
-            else:
-                self._adjust_threads()
-                self.measure_speed()
-                self.update_progress()
-            total_sleep = 1.0    # 총 1초 대기
-            interval = 0.1       # 0.1초씩 대기
-            elapsed = 0.0
-            while elapsed < total_sleep and self.task.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-                t.sleep(interval)
-                elapsed += interval
-
-    # ============ 다운로드 조정 및 콜백 메서드 ============
-
-    def _adjust_threads(self):
-        """
-        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
-        """
-        with self.task.lock:
-            future_count = self.data.future_count
-
-        avg_active_speed = (
-            self.data.speed_mb / future_count if future_count > 0 else 0
-        )
-
-        standard_speed = self._get_standard_speed()
-
-        if avg_active_speed > standard_speed:
-            self.adjust_count += 1
-        elif avg_active_speed < standard_speed / 2:
-            self.adjust_count -= 1
-        else:
-            if self.adjust_count > 0:
-                self.adjust_count -= 1
-            elif self.adjust_count < 0:
-                self.adjust_count += 1
-        
-        if self.adjust_count > 1:
-            self.data.adjust_threads = min(self.data.max_threads, self.data.adjust_threads + 4)
-            self.logger.log_thread_adjust(self.data.adjust_threads, self.data.speed_mb) # 스레드 조정 로그
-            self.adjust_count = 0
-        elif self.adjust_count < -4:
-            self.data.adjust_threads = max(1, self.data.adjust_threads // 2)
-            self.logger.log_thread_adjust(self.data.adjust_threads, self.data.speed_mb) # 스레드 조정 로그
-            self.adjust_count = 0
-
-    def measure_speed(self):
-            current_size = self.data.total_downloaded_size
-            speed = current_size - self.data.prev_size
-            self.data.prev_size = current_size
-
-            with self.task.lock:
-                future_count = self.data.future_count
-            # MB/s로 변환
-            self.data.speed_mb = speed / (1024*1024)
-            avg_speed = self.data.speed_mb / future_count if future_count > 0 else 0
-            self.logger.log_thread_debug(future_count, self.data.speed_mb, avg_speed)
-
-    def update_progress(self):
-        """
-        진행률, 다운로드 속도, 예상 남은 시간 등 정보를 계산 후 시그널로 전송한다.
-        """
-        active_downloaded_size = sum(self.data.threads_progress)
-        self.data.total_downloaded_size = self.data.completed_progress + active_downloaded_size
-        # elapsed_time = time() - self.data.start_time
+        speed_mb = event.speed or 0.0
 
         if self.task.item.post_process:
-            progress = int((self.data.merged_segments / (self.data.max_threads + 1)) * 100) if self.data.max_threads > 0 else 0
-        else:
-            progress = int((self.data.completed_threads / self.data.max_threads) * 100) if self.data.max_threads > 0 else 0
-
-
-        if self.data.speed_mb > 0 and self.data.completed_threads > 0:
-            avg_segment_size = self.data.total_downloaded_size / self.data.completed_threads
-            remaining_segments = self.data.max_threads - self.data.completed_threads
-            remaining_time = (
-                (avg_segment_size * remaining_segments)
-                / (self.data.speed_mb * 1024 * 1024)
+            progress = (
+                int((self.data.merged_segments / (self.data.max_threads + 1)) * 100)
+                if self.data.max_threads > 0
+                else 0
             )
-            remaining_time_str = strftime('%H:%M:%S', gmtime(remaining_time))
+        else:
+            progress = (
+                int((self.data.completed_threads / self.data.max_threads) * 100)
+                if self.data.max_threads > 0
+                else 0
+            )
+
+        if speed_mb > 0 and self.data.completed_threads > 0:
+            avg_segment_size = event.downloaded_size / self.data.completed_threads
+            remaining_segments = self.data.max_threads - self.data.completed_threads
+            remaining_time = (avg_segment_size * remaining_segments) / (speed_mb * 1024 * 1024)
+            remaining_time_str = strftime("%H:%M:%S", gmtime(remaining_time))
         else:
             remaining_time_str = "N/A"
-        
+
         # 시그널 전송
-        self.progress.emit(remaining_time_str, str(self.data.total_downloaded_size), f"{self.data.speed_mb:.1f} MB/s", progress)
+        self.progress.emit(
+            remaining_time_str, str(event.downloaded_size), f"{speed_mb:.1f} MB/s", progress
+        )
 
-    def get_download_time(self):
+    def update_progress(self):
+        """(manager.finish 호환) 최종 진행 상태를 집계해 progress Signal로 내보낸다."""
+        self.engine.emit_progress()
+
+    def get_download_time(self) -> str:
+        """다운로드 소요 시간을 HH:MM:SS 문자열로 반환한다."""
         download_time = self.data.end_time - self.data.start_time
-        download_time_str = strftime('%H:%M:%S', gmtime(download_time))
-        return download_time_str
-
-    def _get_standard_speed(self):
-        """
-        해상도에 따른 표준 속도 값을 반환합니다.
-        """
-        if self.data.resolution == 144:
-            return 0.2
-        elif self.data.resolution in [360, 480]:
-            return 0.5
-        elif self.data.resolution == 720:
-            return 1.2
-        else:
-            return 3
+        return strftime("%H:%M:%S", gmtime(download_time))

--- a/tests/unit/core/test_m3u8_downloader_rules.py
+++ b/tests/unit/core/test_m3u8_downloader_rules.py
@@ -1,0 +1,425 @@
+"""m3u8 스레드 스케일링·느린 세그먼트 판정·속도 계산 규칙 박제 (#74 착수 조건 1).
+
+이 테스트는 m3u8 다운로드 엔진 이주(QThread → threading) 전후 모두 통과해야 한다.
+규칙 자체를 고정하는 것이 목적이므로, 시나리오와 단언은 이주 후에도 바꾸지 않는다.
+이주 시에는 아래 팩토리(_make_scaler/_make_engine)의 대상 클래스만 교체한다.
+
+박제하는 규칙 (현행 동작 그대로 — 파일 경로(#73)와의 차이는 ★ 표시):
+- ★ 기준 속도는 해상도별 테이블을 따른다: 144→0.2, 360·480→0.5, 720→1.2, 그 외→3 (MB/s)
+- 스레드 증가: 활성 스레드당 평균 속도 > 기준 속도 틱마다 adjust_count += 1,
+  adjust_count > 1이면 adjust_threads를 +4 (max_threads 상한), 카운터 리셋
+- 스레드 감소: 평균 속도 < 기준 속도/2 틱마다 adjust_count -= 1,
+  adjust_count < -4이면 adjust_threads를 절반으로 (하한 1), 카운터 리셋
+- 중간 대역(기준/2 ~ 기준)에서는 adjust_count가 0을 향해 1씩 감쇠
+- 속도 계산: 직전 틱 대비 바이트 증가량을 MB/s로 환산, prev_size 갱신
+- 느린 세그먼트: 청크 속도 < 100 KB/s가 연속 6회(slow_count > 5) 누적되면
+  해당 세그먼트를 중단하고 (index, segment)를 재큐잉(restart_threads += 1)
+- 세그먼트 실패: 요청 예외 시 (index, segment) 재큐잉(failed_threads += 1)
+- ★ 세그먼트 임시 파일명은 (index+1)을 width 자리로 0채움한 .m4v — 병합 순서의 전제
+"""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from download.data import DownloadData
+
+MB = 1024 * 1024
+
+
+class RecordingLogger:
+    """DownloadLogger 호환 가짜 로거 — 실제 파일을 만들지 않고 호출만 기록한다."""
+
+    def __init__(self):
+        self.adjust_calls: list[tuple] = []
+        self.debug_calls: list[tuple] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+        self.thread_completes: list[tuple] = []
+
+    def log_thread_adjust(self, active_threads, avg_speed):
+        self.adjust_calls.append((active_threads, avg_speed))
+
+    def log_thread_debug(self, active_threads, download_speed, avg_speed):
+        self.debug_calls.append((active_threads, download_speed, avg_speed))
+
+    def log_m3u8_thread_start(self, thread_id, segment_url):
+        pass
+
+    def log_thread_complete(self, thread_id, downloaded_size):
+        self.thread_completes.append((thread_id, downloaded_size))
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+class FakeTask:
+    """DownloadTask 호환 최소 객체 — 상태는 core 모델에 위임한다.
+
+    이주 전 클래스(QThread)들이 쓰는 인터페이스(data·lock·logger·item·state)만 제공한다.
+    이주 후에는 팩토리가 태스크를 요구하지 않으므로 자연히 쓰이지 않는다.
+    """
+
+    def __init__(self, data: DownloadData, logger: RecordingLogger):
+        self.data = data
+        self.logger = logger
+        self.lock = threading.Lock()
+        self.item = SimpleNamespace(post_process=False)
+
+    @property
+    def state(self):
+        return self.data.model.state
+
+
+def _make_data(resolution: int = 1080, output_path: str = "unused.mp4") -> DownloadData:
+    """테스트용 DownloadData를 만든다 (네트워크 정보는 더미)."""
+    return DownloadData(
+        base_url="https://example.invalid/hls/video.m3u8",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=resolution,
+        content_type="m3u8",
+    )
+
+
+def _make_scaler(data: DownloadData, logger: RecordingLogger):
+    """스케일링 규칙(_adjust_threads/measure_speed/_get_standard_speed) 보유 객체를 만든다.
+
+    이주 전: download.monitor_m3u8.MonitorM3U8Thread / 이주 후: core M3U8Downloader.
+    반환 객체는 adjust_count 속성과 세 메서드를 노출해야 한다.
+    """
+    from download.monitor_m3u8 import MonitorM3U8Thread
+
+    return MonitorM3U8Thread(FakeTask(data, logger))
+
+
+def _make_engine(data: DownloadData, logger: RecordingLogger):
+    """세그먼트 다운로드 로직(_download_segment) 보유 객체를 만든다.
+
+    이주 전: download.download_m3u8.DownloadM3U8Thread / 이주 후: core M3U8Downloader.
+    """
+    from download.download_m3u8 import DownloadM3U8Thread
+
+    return DownloadM3U8Thread(FakeTask(data, logger))
+
+
+def _engine_module():
+    """_download_segment가 사는 모듈 — 시간·세션 몽키패치 대상."""
+    import download.download_m3u8 as mod
+
+    return mod
+
+
+# ================================================================ 해상도별 기준 속도
+
+
+@pytest.mark.parametrize(
+    ("resolution", "standard"),
+    [(144, 0.2), (360, 0.5), (480, 0.5), (720, 1.2), (1080, 3), (1440, 3)],
+)
+def test_standard_speed_table(resolution, standard):
+    """기준 속도는 해상도별 고정 테이블을 따른다 (그 외 해상도는 3 MB/s)."""
+    data, logger = _make_data(resolution=resolution), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    assert scaler._get_standard_speed() == pytest.approx(standard)
+
+
+def test_same_speed_judged_by_resolution_band():
+    """같은 평균 속도라도 해상도 기준에 따라 증가/감소 방향이 갈린다."""
+    # 평균 1.3 MB/s: 720p(기준 1.2)에서는 증가 방향
+    data, logger = _make_data(resolution=720), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+    data.future_count = 2
+    data.speed_mb = 2.6
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 1
+
+    # 1080p(기준 3, 하한 1.5)에서는 같은 1.3 MB/s가 감소 방향
+    data, logger = _make_data(resolution=1080), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+    data.future_count = 2
+    data.speed_mb = 2.6
+    scaler._adjust_threads()
+    assert scaler.adjust_count == -1
+
+
+# ================================================================ 스레드 증가/감소
+
+
+def test_fast_two_ticks_increase_threads_by_4():
+    """평균 > 기준(1080p: 3 MB/s) 틱 2회 → adjust_count 2(>1) → 스레드 +4, 카운터 리셋."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 4
+    data.speed_mb = 20.0  # 평균 5 MB/s
+    scaler._adjust_threads()
+    assert (scaler.adjust_count, data.adjust_threads) == (1, 4)  # 1틱으로는 불변
+
+    scaler._adjust_threads()
+    assert data.adjust_threads == 8
+    assert scaler.adjust_count == 0
+    assert logger.adjust_calls == [(8, 20.0)]
+
+
+def test_increase_is_capped_at_max_threads():
+    """증가 시 상한은 max_threads(세그먼트 수)다."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 10
+    data.adjust_threads = 8
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 8
+    data.speed_mb = 40.0  # 평균 5 MB/s
+    scaler._adjust_threads()
+    scaler._adjust_threads()
+
+    assert data.adjust_threads == 10  # 8+4=12가 아니라 상한 10
+
+
+def test_slow_five_ticks_halve_threads():
+    """평균 < 기준/2(1080p: 1.5 MB/s) 틱 5회 → adjust_count -5(<-4) → 스레드 절반, 카운터 리셋."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    data.adjust_threads = 8
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 8
+    data.speed_mb = 8.0  # 평균 1 MB/s
+    for _ in range(4):
+        scaler._adjust_threads()
+    assert data.adjust_threads == 8  # 4틱까지는 불변 (-4는 경계 미달)
+
+    scaler._adjust_threads()
+    assert data.adjust_threads == 4
+    assert scaler.adjust_count == 0
+    assert logger.adjust_calls == [(4, 8.0)]
+
+
+def test_halving_floor_is_one_thread():
+    """감소 시 하한은 1스레드다."""
+    data, logger = _make_data(), RecordingLogger()
+    data.adjust_threads = 1
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 1
+    data.speed_mb = 0.5
+    for _ in range(5):
+        scaler._adjust_threads()
+
+    assert data.adjust_threads == 1
+
+
+def test_middle_band_decays_adjust_count_toward_zero():
+    """중간 대역(1080p: 1.5~3 MB/s)은 누적 카운터를 0으로 1씩 되돌린다 (히스테리시스)."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 4
+    data.speed_mb = 20.0  # 평균 5 → +1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 1
+
+    data.speed_mb = 8.0  # 평균 2 → 감쇠 -1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+    assert data.adjust_threads == 4  # 임계 미달로 불변
+
+    data.speed_mb = 4.0  # 평균 1 → -1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == -1
+    data.speed_mb = 8.0  # 평균 2 → 감쇠 +1
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+
+def test_band_boundaries_are_exclusive():
+    """경계값(기준·기준/2)은 중간 대역이다 (초과/미만 판정)."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 2
+    data.speed_mb = 6.0  # 평균 정확히 3 → 증가 아님
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+    data.speed_mb = 3.0  # 평균 정확히 1.5 → 감소 아님
+    scaler._adjust_threads()
+    assert scaler.adjust_count == 0
+
+
+def test_zero_active_threads_counts_as_slow_tick():
+    """활성 스레드 0이면 평균 0으로 간주되어 감소 방향 틱이다 (병합 꼬리 구간의 동력)."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 0
+    data.speed_mb = 10.0
+    scaler._adjust_threads()
+
+    assert scaler.adjust_count == -1
+
+
+# ================================================================ 속도 계산
+
+
+def test_measure_speed_uses_delta_from_previous_tick():
+    """속도 = (현재 누적 - 직전 누적) 바이트를 MB/s로 환산, prev_size 갱신."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.total_downloaded_size = 5 * MB
+    data.prev_size = 2 * MB
+    data.future_count = 3
+
+    scaler.measure_speed()
+
+    assert data.speed_mb == pytest.approx(3.0)
+    assert data.prev_size == 5 * MB
+    assert logger.debug_calls == [(3, pytest.approx(3.0), pytest.approx(1.0))]
+
+
+def test_measure_speed_with_no_active_threads_reports_zero_average():
+    """활성 스레드 0이면 평균 속도는 0으로 기록한다 (0 나눗셈 금지)."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    data.total_downloaded_size = 1 * MB
+    data.prev_size = 0
+    data.future_count = 0
+
+    scaler.measure_speed()
+
+    assert logger.debug_calls == [(0, pytest.approx(1.0), 0)]
+
+
+# ================================================================ 느린 세그먼트·실패 처리
+
+
+class FakeResponse:
+    """스트리밍 응답 흉내 — 지정한 청크 목록을 그대로 흘린다."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        yield from self._chunks
+
+
+class FakeSession:
+    """get_thread_session() 대체 — 준비된 응답을 반환하거나 예외를 던진다."""
+
+    def __init__(self, response=None, exception=None):
+        self._response = response
+        self._exception = exception
+
+    def get(self, url, **kwargs):
+        if self._exception is not None:
+            raise self._exception
+        return self._response
+
+
+class TickingClock:
+    """time.time 대체 — 호출마다 지정 간격으로 흐르는 가짜 시계."""
+
+    def __init__(self, step: float):
+        self.now = 1_000_000.0
+        self.step = step
+
+    def __call__(self) -> float:
+        self.now += self.step
+        return self.now
+
+
+def _prepare_running_engine(tmp_path, monkeypatch, chunks=None, exception=None, clock_step=1.0):
+    """RUNNING 상태의 엔진과 부속(데이터·로거)을 준비한다.
+
+    clock_step=1.0이면 청크당 1초가 흘러 항상 저속(<100 KB/s) 판정,
+    아주 작은 값이면 항상 고속 판정이 난다.
+    """
+    data = _make_data(output_path=str(tmp_path / "out.mp4"))
+    logger = RecordingLogger()
+    engine = _make_engine(data, logger)
+
+    data.model.start()  # RUNNING 상태로 진입
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+    # run()이 채우는 실행 컨텍스트를 직접 주입한다 (세그먼트 로직만 단위 검증)
+    engine.temp_dir = str(tmp_path)
+    engine.width = 4
+
+    mod = _engine_module()
+    monkeypatch.setattr(
+        mod, "get_thread_session", lambda: FakeSession(FakeResponse(chunks or []), exception)
+    )
+    monkeypatch.setattr(mod.tm, "time", TickingClock(clock_step))
+    return engine, data, logger
+
+
+def test_slow_segment_restarts_after_six_slow_chunks(tmp_path, monkeypatch):
+    """청크 속도 < 100 KB/s 연속 6회(slow_count > 5)면 세그먼트를 중단·재큐잉한다."""
+    chunks = [b"x" * 8192] * 10  # 1초/청크 → 8 KB/s로 항상 저속
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, chunks=chunks, clock_step=1.0
+    )
+
+    returned = engine._download_segment(
+        index=7, segment="segment_007.m4v", part_num=0, total_ranges=4
+    )
+
+    assert returned == 0
+    assert data.restart_threads == 1
+    assert data.remaining_ranges == [(7, "segment_007.m4v")]  # 같은 세그먼트 재큐잉
+    assert data.threads_progress[0] == 0  # 진행 바이트 롤백
+    assert data.completed_threads == 0
+    assert any("slow" in w for w in logger.warnings)
+
+
+def test_fast_segment_completes_and_accumulates_progress(tmp_path, monkeypatch):
+    """정상 속도면 세그먼트를 완주하고 완료 카운터·누적 진행에 반영한다."""
+    segment_size = 3 * 8192
+    chunks = [b"x" * 8192] * 3
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, chunks=chunks, clock_step=1e-6
+    )
+
+    returned = engine._download_segment(
+        index=7, segment="segment_007.m4v", part_num=0, total_ranges=4
+    )
+
+    assert returned == 0
+    assert data.completed_threads == 1
+    assert data.completed_progress == segment_size
+    assert data.restart_threads == 0
+    assert data.remaining_ranges == []
+    assert logger.thread_completes == [(0, segment_size)]
+    # 임시 파일명은 (index+1)을 width 자리로 0채움 — sorted() 병합 순서의 전제
+    assert (tmp_path / "0008.m4v").read_bytes() == b"x" * segment_size
+
+
+def test_request_exception_requeues_segment_as_failed(tmp_path, monkeypatch):
+    """요청 예외 시 실패 카운터를 올리고 같은 세그먼트를 재큐잉한다."""
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, exception=requests.ConnectionError("boom")
+    )
+
+    returned = engine._download_segment(
+        index=3, segment="segment_003.m4v", part_num=0, total_ranges=4
+    )
+
+    assert returned == 0
+    assert data.failed_threads == 1
+    assert data.remaining_ranges == [(3, "segment_003.m4v")]
+    assert data.threads_progress[0] == 0
+    assert len(logger.errors) == 1

--- a/tests/unit/core/test_m3u8_downloader_rules.py
+++ b/tests/unit/core/test_m3u8_downloader_rules.py
@@ -18,9 +18,6 @@
 - ★ 세그먼트 임시 파일명은 (index+1)을 width 자리로 0채움한 .m4v — 병합 순서의 전제
 """
 
-import threading
-from types import SimpleNamespace
-
 import pytest
 import requests
 
@@ -58,24 +55,6 @@ class RecordingLogger:
         self.warnings.append(message)
 
 
-class FakeTask:
-    """DownloadTask 호환 최소 객체 — 상태는 core 모델에 위임한다.
-
-    이주 전 클래스(QThread)들이 쓰는 인터페이스(data·lock·logger·item·state)만 제공한다.
-    이주 후에는 팩토리가 태스크를 요구하지 않으므로 자연히 쓰이지 않는다.
-    """
-
-    def __init__(self, data: DownloadData, logger: RecordingLogger):
-        self.data = data
-        self.logger = logger
-        self.lock = threading.Lock()
-        self.item = SimpleNamespace(post_process=False)
-
-    @property
-    def state(self):
-        return self.data.model.state
-
-
 def _make_data(resolution: int = 1080, output_path: str = "unused.mp4") -> DownloadData:
     """테스트용 DownloadData를 만든다 (네트워크 정보는 더미)."""
     return DownloadData(
@@ -93,9 +72,9 @@ def _make_scaler(data: DownloadData, logger: RecordingLogger):
     이주 전: download.monitor_m3u8.MonitorM3U8Thread / 이주 후: core M3U8Downloader.
     반환 객체는 adjust_count 속성과 세 메서드를 노출해야 한다.
     """
-    from download.monitor_m3u8 import MonitorM3U8Thread
+    from core.downloaders.m3u8_downloader import M3U8Downloader
 
-    return MonitorM3U8Thread(FakeTask(data, logger))
+    return M3U8Downloader(data, logger)
 
 
 def _make_engine(data: DownloadData, logger: RecordingLogger):
@@ -103,14 +82,14 @@ def _make_engine(data: DownloadData, logger: RecordingLogger):
 
     이주 전: download.download_m3u8.DownloadM3U8Thread / 이주 후: core M3U8Downloader.
     """
-    from download.download_m3u8 import DownloadM3U8Thread
+    from core.downloaders.m3u8_downloader import M3U8Downloader
 
-    return DownloadM3U8Thread(FakeTask(data, logger))
+    return M3U8Downloader(data, logger)
 
 
 def _engine_module():
     """_download_segment가 사는 모듈 — 시간·세션 몽키패치 대상."""
-    import download.download_m3u8 as mod
+    import core.downloaders.m3u8_downloader as mod
 
     return mod
 

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -1,0 +1,245 @@
+"""M3U8Downloader.run 통합 검증 — 가짜 세션으로 전체 파이프라인 실행 (#74).
+
+실제 네트워크 없이 m3u8 플레이리스트·초기화 세그먼트·세그먼트 스트림을
+흉내 내는 세션으로 다음을 검증한다:
+- 완주: 결과 파일이 초기화 세그먼트 + 세그먼트들을 **인덱스 순서대로** 이어붙인
+  것과 바이트 단위로 동일(병합 순서 보장), 병합 시작 콜백·완료 콜백 각 1회,
+  임시 폴더 삭제
+- 일시정지 → 재개 → 완료: PAUSED 동안 진행 정지, 재개 후 완주,
+  허용되지 않는 상태 전이(warning) 0건
+- 중단(stop): 결과 파일·임시 폴더 삭제, 완료 콜백 없음
+"""
+
+import threading
+import time
+
+import core.downloaders.m3u8_downloader as m3u8_module
+from core.downloaders.m3u8_downloader import M3U8Downloader
+from core.models.download_state import DownloadState
+from download.data import DownloadData
+
+CHUNK = 8192
+SEGMENT_COUNT = 6
+BASE_URL = "https://example.invalid/hls/video.m3u8"
+
+INIT_CONTENT = b"\xf0" * CHUNK
+
+
+def _segment_content(index: int, chunks_per_segment: int) -> bytes:
+    """세그먼트별로 구별되는 결정적 본문 — 병합 순서를 바이트로 검증하기 위함."""
+    return bytes([index + 1]) * (CHUNK * chunks_per_segment)
+
+
+def _playlist_text() -> str:
+    """EXT-X-MAP 초기화 세그먼트와 세그먼트 목록을 가진 최소 플레이리스트."""
+    lines = ["#EXTM3U", "#EXT-X-VERSION:7", '#EXT-X-MAP:URI="init.m4s"']
+    for i in range(SEGMENT_COUNT):
+        lines.append("#EXTINF:2.000,")
+        lines.append(f"seg_{i}.m4v")
+    lines.append("#EXT-X-ENDLIST")
+    return "\n".join(lines)
+
+
+class StreamResponse:
+    """세그먼트 본문을 청크로 흘리는 가짜 응답. throttle 초/청크로 속도를 조절한다."""
+
+    def __init__(self, body: bytes, throttle: float):
+        self._body = body
+        self._throttle = throttle
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=CHUNK):
+        for i in range(0, len(self._body), chunk_size):
+            if self._throttle:
+                time.sleep(self._throttle)
+            yield self._body[i : i + chunk_size]
+
+
+class TextResponse:
+    """플레이리스트(.text)·초기화 세그먼트(.content) 겸용 가짜 응답."""
+
+    def __init__(self, text: str = "", content: bytes = b""):
+        self.text = text
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+class M3U8Session:
+    """m3u8 경로의 세 요청(플레이리스트/초기화/세그먼트)을 URL로 분기하는 가짜 세션."""
+
+    def __init__(self, chunks_per_segment: int, throttle: float = 0.0):
+        self._chunks_per_segment = chunks_per_segment
+        self._throttle = throttle
+
+    def get(self, url, **kwargs):
+        if url.endswith(".m3u8"):
+            return TextResponse(text=_playlist_text())
+        if url.endswith("init.m4s"):
+            return TextResponse(content=INIT_CONTENT)
+        index = int(url.rsplit("seg_", 1)[1].removesuffix(".m4v"))
+        return StreamResponse(_segment_content(index, self._chunks_per_segment), self._throttle)
+
+
+def _expected_output(chunks_per_segment: int) -> bytes:
+    """초기화 세그먼트 + 세그먼트들을 인덱스 순서로 이어붙인 기대 결과."""
+    return INIT_CONTENT + b"".join(
+        _segment_content(i, chunks_per_segment) for i in range(SEGMENT_COUNT)
+    )
+
+
+class RunLogger:
+    """run() 경로 전체가 쓰는 로거 인터페이스를 기록만 하며 흉내 낸다."""
+
+    def __init__(self):
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+        self.completed_times: list[float] = []
+        self.closed = 0
+
+    def log_download_start(self, total_size, part_size, segments, initial_threads):
+        pass
+
+    def log_m3u8_thread_start(self, thread_id, segment_url):
+        pass
+
+    def log_thread_complete(self, thread_id, downloaded_size):
+        pass
+
+    def log_thread_adjust(self, active_threads, avg_speed):
+        pass
+
+    def log_thread_debug(self, active_threads, download_speed, avg_speed):
+        pass
+
+    def log_download_complete(self, total_time):
+        self.completed_times.append(total_time)
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def log_exception(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def save_and_close(self):
+        self.closed += 1
+
+
+def _make_engine(tmp_path, monkeypatch, chunks_per_segment: int = 3, throttle: float = 0.0):
+    """가짜 세션이 연결된 RUNNING 이전 상태의 엔진을 준비한다."""
+    output = tmp_path / "out.mp4"
+    data = DownloadData(
+        base_url=BASE_URL,
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=str(output),
+        resolution=1080,
+        content_type="m3u8",
+    )
+    logger = RunLogger()
+    session = M3U8Session(chunks_per_segment, throttle)
+    monkeypatch.setattr(m3u8_module, "get_thread_session", lambda: session)
+
+    finished = threading.Event()
+    failures: list[BaseException] = []
+    merge_starts: list[bool] = []
+
+    def on_finished():
+        # 실제 어댑터 경로(manager.finish → task.finish)를 흉내 내 상태를 종결한다
+        data.model.finish()
+        finished.set()
+
+    engine = M3U8Downloader(
+        data,
+        logger,
+        on_finished=on_finished,
+        on_failed=failures.append,
+        on_merge_start=lambda: merge_starts.append(True),
+    )
+    return engine, data, logger, output, finished, failures, merge_starts
+
+
+def _run_in_thread(engine) -> threading.Thread:
+    """엔진 run()을 별도 스레드에서 실행한다 (호출 규약: start() 후 run())."""
+    thread = threading.Thread(target=engine.run, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_run_merges_segments_in_index_order_byte_exact(tmp_path, monkeypatch):
+    """전체 파이프라인이 초기화+세그먼트 순서 그대로의 파일을 만들고 콜백을 1회씩 호출한다."""
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert output.read_bytes() == _expected_output(chunks_per_segment=3)
+    assert merge_starts == [True]  # 병합 시작 통지 1회
+    assert failures == []
+    assert logger.errors == []
+    assert logger.warnings == []  # 느린 세그먼트 오탐·전이 warning 없음
+    assert logger.completed_times and logger.closed == 1
+    assert data.completed_threads == SEGMENT_COUNT  # 세그먼트 전부 정상 완료
+    assert data.merged_segments == SEGMENT_COUNT + 1  # 초기화 세그먼트 포함 병합
+    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+
+
+def test_pause_resume_then_complete(tmp_path, monkeypatch):
+    """일시정지 동안 진행이 멈추고, 재개 후 완주한다. 전이 warning 0건."""
+    # 청크당 5ms 스로틀 × 세그먼트당 120청크 → 일시정지할 여유를 만들고,
+    # 일시정지 시점까지 누적 바이트를 충분히 키워 재개 직후 평균 속도가
+    # 저속 판정(<100 KB/s)에 걸리는 오탐을 피한다 (판정식은 누적/경과 기반)
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch, chunks_per_segment=120, throttle=0.005
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+
+    time.sleep(0.25)  # 다운로드가 진행되는 중간 지점
+    assert data.model.pause() is True  # RUNNING → PAUSED (유효 전이)
+    assert data.model.state is DownloadState.PAUSED
+
+    # 워커들이 pause_event 대기에 도달할 시간을 준 뒤 진행량이 고정되는지 확인
+    time.sleep(0.3)
+    snapshot = sum(data.threads_progress) + data.completed_progress
+    time.sleep(0.5)
+    assert sum(data.threads_progress) + data.completed_progress == snapshot
+
+    assert data.model.resume() is True  # PAUSED → RUNNING (유효 전이)
+    assert finished.wait(timeout=60), "재개 후 완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert output.read_bytes() == _expected_output(chunks_per_segment=120)
+    assert failures == []
+    assert logger.warnings == []  # 상태 전이 warning 0건 (완료 조건)
+    assert data.model.state is DownloadState.FINISHED
+
+
+def test_stop_removes_partial_file_and_temp_dir(tmp_path, monkeypatch):
+    """중단(stop)하면 임시 폴더·부분 파일을 삭제하고 완료 콜백을 호출하지 않는다."""
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch, chunks_per_segment=40, throttle=0.005
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+
+    time.sleep(0.25)
+    data.model.stop()  # RUNNING → WAITING (취소)
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    assert not output.exists()  # 부분 파일 없음
+    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+    assert not finished.is_set()
+    assert failures == []


### PR DESCRIPTION
## 관련 이슈

Closes #74

## 변경 내용

이슈 #73(파일 다운로더)에서 확립한 패턴을 m3u8 경로에 그대로 적용했다. 새 설계 없음.

- `core/downloaders/m3u8_downloader.py` 신설 — 구 `DownloadM3U8Thread`(실행)와 `MonitorM3U8Thread`(관측)를 Qt 없이 한 클래스로 흡수. threading 기반, 보고는 `ProgressEvent` 콜백(#72 계약). 플레이리스트 파싱·세그먼트 스케줄링·해상도별 스레드 스케일링·느린 세그먼트 재시도·실패 재큐잉·순서 보장 병합 로직은 식 그대로 이동
- `download/download_m3u8.py` — Signal 변환 어댑터로 축소. base_url 해석(쿠키 로드·`NetworkManager` 조회)은 네트워크 계층이 아직 앱 영역이라 어댑터가 run() 시작 시 수행(#72와 같은 이유). 병합 시작은 엔진의 `on_merge_start` 콜백을 받아 `item.post_process` 플래그로 변환
- `download/monitor_m3u8.py` — `ProgressEvent` → 기존 `progress` Signal(남은 시간·크기·속도·%) 변환 어댑터로 축소. 세그먼트 수 기반 진행률·남은 시간 계산식은 구 코드와 동일
- `DownloadManager` 호출부 무변경, 파일 다운로더 경로 무변경

## 검증

- [x] `uv run ruff check .` 통과 (format은 신규·수정 5개 파일 확인 — 기존 레거시 파일은 범위 외)
- [x] `uv run pytest` 전체 171개 통과 (Windows, GUI 포함 헤드리스)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시)
  - 박제 테스트 `tests/unit/core/test_m3u8_downloader_rules.py` 19개 — **이주 전 코드로 통과시켜 먼저 커밋(be2c7c2)** 후 팩토리만 core 엔진으로 교체(655a804). 커밋 이력이 전후 통과를 입증
  - 실행 통합 테스트 `tests/unit/core/test_m3u8_downloader_run.py` 3개 — 가짜 m3u8 세션으로 초기화 세그먼트+세그먼트 **인덱스 순서 병합 바이트 대조**, 일시정지→재개 완주(전이 warning 0건), 중단 시 임시 폴더·부분 파일 정리
- [x] 헤드리스 스크립트로 m3u8 경로 다운로드 성공 — #52에서 미검증으로 남았던 항목 해소. VOD 14348487(1080p, 세그먼트 6996개, 3.9시간) 완주, exit 0, 14,344,950,352 bytes, 소요 4:26

### 기준선 비교 — 판정 기준에 대하여

**재시도 건수와 소요 시간은 합격 기준에서 제외했다.** 근거: 이주 전 동일 VOD·동일 코드로 기준선을 2회 확보했는데 실행 간 편차가 컸다 — 재시도 0건/191.43초 vs 재시도 56건/223.85초. m3u8 경로는 세그먼트 단위 요청 수천 건(6996개)이 네트워크 상태에 그대로 노출되므로 이 지표들은 코드가 아니라 실행 시점의 네트워크를 측정한다. 따라서 비교는 **구조적 특징**만으로 판정했다:

| 지표 | 기준선 1 (이주 전) | 기준선 2 (이주 전) | 이주 후 |
|---|---|---|---|
| 세그먼트 수 | 6996 | 6996 | 6996 |
| 초기 스레드 | 4 | 4 | 4 |
| 증가 궤적 | 4→8→12→…→40 (+4 계단) | 4→8→12→…→40 (+4 계단) | 4→8→12→…→36 (+4 계단) |
| 병합 꼬리 | 40→20→10→5→2→1, speed 0.00 | 40→20→10→5→2→1, speed 0.00 | 36→18→9→4→2→1, speed 0.00 |
| 완주 | 예 | 예 | 예 |
| (참고) 재시도/시간 | 0건 / 191.4s | 56건 / 223.9s | 74건 / 266.9s |

- **증가 궤적**: +4 등차 계단 모양 동일. 정점(36 vs 40)은 증가 틱 횟수가 그 실행의 평균 속도에 좌우된 결과로, 재시도 74건이 낀 실행이라 기준선 2회 사이의 편차와 같은 성질이다
- **병합 꼬리**: 정점에서 절반씩(5틱마다) 1까지 감쇠 + speed 0.00 — 세 실행 모두 동일 구조. 이 꼬리는 다운로드 특성이 아니라 **후처리(세그먼트 병합) 중에도 관측 루프가 계속 돌면서 절반 감소 규칙이 speed 0에 반응한 아티팩트**다. 바람직한 동작은 아니지만 Phase 3의 동작 보존 원칙에 따라 그대로 유지했고, 여기서는 이주 전후 동작이 같다는 비교 마커로만 사용했다

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — `test_no_qt_import.py` 가드 통과, data·logger는 호환 객체 주입(#72·#73과 동일)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음 (`core/downloaders/` 하위 모듈 추가는 #73에서 확립된 배치)

## 리뷰어에게

- **오너 스모크 요청** (완료 조건): GUI에서 m3u8 경로 VOD 1건 — ① 장시간 VOD 완주 후 파일 크기·재생 확인, ② 일시정지 → 재개 정상 확인. 헤드리스 완주와 단위 테스트는 통과했지만 GUI 시그널 경로·재생 품질은 사람 확인이 필요하다
- `on_merge_start` 콜백은 m3u8 엔진에만 있는 추가 주입점이다. `events.py` 계약(진행·완료·실패)은 변경하지 않았고, 병합 단계 플래그(`item.post_process`)는 UI 소관이라 어댑터가 변환한다
- 구 코드에서 base_url 해석 실패 시 except 블록이 아직 생성되지 않은 `temp_dir`를 참조하는 잠재 결함이 있었다. 새 구조에서는 해석이 어댑터로 분리되고 엔진은 temp_dir를 run() 최상단에서 계산하므로 이 경로가 사라졌다 (동작 변경 아님 — 실패 보고 형식은 동일)
- **후속 개선 후보 (이슈 미등록, 기록만)**: 병합 단계의 모니터 꼬리 아티팩트 — 후처리 시점에 관측 루프를 정지하거나 병합 진행을 별도로 표현하도록 분리하면 로그·스레드 조정 노이즈가 사라진다. Phase 3 범위(동작 보존) 밖이라 이번 PR에서는 손대지 않았다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
