### PR TITLE
refactor: BaseDownloader 추상 도입 및 file/m3u8 실행 엔진 통합 (#82)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -1,0 +1,390 @@
+"""다운로더 공통 실행 엔진 — BaseDownloader 추상 (#82, SPEC §6).
+
+file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진을 이 클래스
+한 곳으로 흡수했다: 워커 풀 관리·작업 큐잉·실패/저속 재큐잉, 적응형 스레드
+스케일링과 관측 스레드, 일시정지/재개 처리, 진행률 집계 → ProgressEvent 통지.
+로직·수식은 두 엔진에서 식 그대로 옮겼다 — 규칙은 기존 박제 테스트
+(tests/unit/core/test_file_downloader_rules.py / test_m3u8_downloader_rules.py)가
+시나리오·단언 무수정으로 고정한다.
+
+하위 다운로더가 구현·오버라이드하는 것 (새 다운로더를 추가할 때 보는 목록):
+
+필수 (추상):
+- ``supports(content)``: 이 다운로더가 처리할 컨텐츠 타입 판정 — 서비스의
+  선택 로직이 구체 클래스 분기 없이 이 답을 따른다
+- ``prepare(content)``: "무엇을 받을지" 작업 목록 생성 (file: 바이트 범위,
+  m3u8: (index, 세그먼트) 목록). 총 크기 조회·매니페스트 파싱 등 타입 고유
+  사전 조회는 여기서 한다
+- ``_download_item(item, part_num)``: 작업 1건의 다운로드 (재시도 판정 포함)
+- ``_log_item_start(part_num, item)`` / ``_download_start_log_args()``:
+  타입별 로그 형식 유지용
+- ``_prepare_output()``: 수신 준비 (file: 빈 파일, m3u8: 임시 폴더·초기화 세그먼트)
+- ``_cleanup_partial()``: 실패·중단 시 부분 산출물 정리
+
+선택 (기본 구현 있음):
+- ``postprocess()``: 다운로드 완료 후 마무리 (기본 no-op, m3u8: 병합)
+- ``_initial_queue(items)``: 시작 시 작업 큐 구성 (기본: 목록 그대로)
+- ``_cleanup_after_run()``: 정상 경로 종료 후 정리 (기본 no-op)
+- ``_get_standard_speed()``: 스레드 스케일링 기준 속도 (기본 4 MB/s — 구 파일
+  엔진의 고정 임계 4/2와 동일. m3u8은 해상도별 테이블로 오버라이드)
+- ``_progress_total_size()``: ProgressEvent.total_size (기본: 전체 크기,
+  m3u8은 미리 알 수 없어 None)
+- 클래스 속성: ``run_thread_name``(서비스 워커 스레드 이름),
+  ``worker_pool_prefix``(풀 스레드 이름), ``requires_base_url_resolution``
+  (다운로드 시작 전 base_url 해석 필요 여부 — 서비스가 resolver를 주입·실행),
+  ``_failure_exceptions``(run이 실패로 처리할 예외 — 그 외는 전파)
+
+스레드·콜백 규칙 (#72~#75와 동일):
+- 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
+  (_monitor_loop)가 수행하고, core/models/events.py의 ProgressEvent 콜백으로
+  보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
+- 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다.
+- 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다.
+
+호출 규약: 소유자(서비스·스크립트)가 DownloadTaskModel.start()로 RUNNING
+전이를 마친 뒤 run()을 호출한다. run()은 완료·중단·실패까지 블로킹한다.
+data·logger는 DownloadData/DownloadLogger 호환 객체를 주입받는다.
+"""
+
+import threading
+import time as tm
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+
+from core.models.content import Content
+from core.models.download_state import DownloadState
+from core.models.events import (
+    FailedCallback,
+    FinishedCallback,
+    ProgressCallback,
+    ProgressEvent,
+)
+
+
+class BaseDownloader(ABC):
+    """작업 목록 기반 멀티스레드 다운로드의 공통 실행 엔진."""
+
+    # 서비스가 이 다운로더의 run()을 실행할 워커 스레드 이름 (다운로드 로그 형식 보존)
+    run_thread_name: str = "DownloadThread"
+    # ThreadPoolExecutor 풀 스레드 이름 접두사
+    worker_pool_prefix: str = "DownloadWorker"
+    # 다운로드 시작 전 base_url 해석(resolver 주입·실행)이 필요한지 — 서비스가 참조
+    requires_base_url_resolution: bool = False
+    # run()이 실패 콜백으로 환원할 예외 타입 — 그 외 예외는 전파한다
+    _failure_exceptions: tuple[type[BaseException], ...] = (Exception,)
+
+    def __init__(
+        self,
+        data,
+        logger,
+        on_progress: ProgressCallback | None = None,
+        on_finished: FinishedCallback | None = None,
+        on_failed: FailedCallback | None = None,
+        on_merge_start: Callable[[], None] | None = None,
+    ):
+        """엔진을 생성한다.
+
+        Args:
+            data: DownloadData 호환 공유 데이터 (진행률·엔진 변수·model 보유)
+            logger: DownloadLogger 호환 로거
+            on_progress: 관측 주기마다 ProgressEvent를 받는 콜백
+            on_finished: 정상 완료 시 인자 없이 호출되는 콜백
+            on_failed: 실패 시 예외 객체를 그대로 받는 콜백
+            on_merge_start: 후처리(병합) 시작 시 인자 없이 호출되는 콜백.
+                후처리가 없는 다운로더는 호출하지 않는다
+        """
+        self.s = data
+        self.model = data.model
+        self.logger = logger
+        self.lock = threading.Lock()
+        self.future_dict: dict = {}
+        self.adjust_count = 0
+        self._on_progress: ProgressCallback = on_progress or (lambda event: None)
+        self._on_finished: FinishedCallback = on_finished or (lambda: None)
+        self._on_failed: FailedCallback = on_failed or (lambda exc: None)
+        self._on_merge_start: Callable[[], None] = on_merge_start or (lambda: None)
+
+    @property
+    def state(self) -> DownloadState:
+        """현재 다운로드 상태 (DownloadTaskModel에 위임)."""
+        return self.model.state
+
+    def set_on_progress(self, callback: ProgressCallback) -> None:
+        """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
+        self._on_progress = callback
+
+    # ============ 하위 다운로더의 책임 (추상) ============
+
+    @classmethod
+    @abstractmethod
+    def supports(cls, content: Content) -> bool:
+        """이 다운로더가 해당 컨텐츠를 처리할 수 있는지 판정한다."""
+
+    @abstractmethod
+    def prepare(self, content: Content) -> list:
+        """다운로드할 작업 목록을 만든다 (타입 고유 사전 조회 포함).
+
+        반환한 목록의 길이가 max_threads·total_ranges·진행 배열의 기준이 된다.
+        """
+
+    @abstractmethod
+    def _download_item(self, item, part_num: int):
+        """작업 1건을 다운로드한다 (저속 재시도·일시정지·중단 핸들링 포함).
+
+        풀 스레드에서 실행된다. part_num 반환이 완료 콜백의 슬롯 해제 신호다.
+        """
+
+    @abstractmethod
+    def _log_item_start(self, part_num: int, item) -> None:
+        """작업 시작 로그를 남긴다 (타입별 로그 메서드·형식 유지)."""
+
+    @abstractmethod
+    def _download_start_log_args(self) -> tuple:
+        """log_download_start 인자 (타입별 로그 형식 유지)."""
+
+    @abstractmethod
+    def _prepare_output(self) -> None:
+        """수신 준비 — 결과 파일·임시 폴더 등 산출물 자리를 만든다."""
+
+    @abstractmethod
+    def _cleanup_partial(self) -> None:
+        """실패·중단 시 부분 산출물을 정리한다."""
+
+    # ============ 하위 다운로더가 선택적으로 오버라이드 ============
+
+    def postprocess(self) -> None:
+        """다운로드 완료 후 마무리 (기본 no-op). m3u8은 여기서 병합한다."""
+
+    def _initial_queue(self, items: list) -> list:
+        """시작 시 작업 큐를 구성한다 (기본: prepare 결과 그대로)."""
+        return list(items)
+
+    def _cleanup_after_run(self) -> None:
+        """정상 경로(비예외) 종료 후 정리 (기본 no-op). m3u8은 임시 폴더를 지운다."""
+
+    def _get_standard_speed(self) -> float:
+        """스레드 스케일링 기준 속도(MB/s). 기본 4 — 구 파일 엔진의 고정 임계와 동일."""
+        return 4.0
+
+    def _progress_total_size(self) -> int | None:
+        """ProgressEvent에 실을 전체 크기. 미리 알 수 없는 다운로더는 None."""
+        return self.s.total_size
+
+    # ============ 실행 파이프라인 (구 file/m3u8 run의 공통 골격) ============
+
+    def run(self) -> None:
+        """다운로드 파이프라인을 실행한다. 관측 스레드도 여기서 소유·시작한다."""
+        monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
+        try:
+            self.s.start_time = tm.time()
+            items = self.prepare(self.s.content)
+
+            self.s.max_threads = self.s.total_ranges = len(items)
+            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
+            self.s.threads_progress = [0] * self.s.total_ranges
+            self.logger.log_download_start(*self._download_start_log_args())
+
+            self._prepare_output()
+
+            # 진행률 배열이 준비된 뒤에 관측을 시작한다
+            monitor.start()
+
+            with ThreadPoolExecutor(
+                max_workers=self.s.max_threads, thread_name_prefix=self.worker_pool_prefix
+            ) as executor:
+                self.s.remaining_ranges = self._initial_queue(items)
+                # 재사용 시 초기화 필수
+                with self.lock:
+                    self.s.future_count = 0
+                    self.future_dict = {}
+
+                while not self.state == DownloadState.WAITING:
+                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
+                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
+                        for part_num in range(self.s.adjust_threads):
+                            if not self.s.remaining_ranges:
+                                break
+                            with self.lock:
+                                if part_num not in self.future_dict:
+                                    item = self.s.remaining_ranges.pop(0)
+                                    self.s.future_count += 1
+                                    self._log_item_start(part_num, item)
+                                    future = executor.submit(self._download_item, item, part_num)
+                                    future.add_done_callback(self._download_completed_callback)
+                                    self.future_dict[part_num] = (item, future)
+
+                    # (2) 주기적으로 상태 확인 (non-blocking)
+                    tm.sleep(0.1)
+
+                    # (3) 남은 작업이 없고 스레드도 없으면 종료
+                    if not self.s.remaining_ranges and not self.future_dict:
+                        break
+
+            if self.state == DownloadState.RUNNING:
+                # (4) 다운로드 완료 후 타입별 마무리(병합 등) 후 완료 통지
+                self.postprocess()
+                self.s.end_time = tm.time()
+                total_time = self.s.end_time - self.s.start_time
+                self.logger.log_download_complete(total_time)
+                self.logger.save_and_close()
+                self._on_finished()
+
+            # (5) 정상 경로 종료 후 정리 (중단으로 빠져나온 경우 포함)
+            self._cleanup_after_run()
+
+        except self._failure_exceptions as e:
+            # 오류 발생 시 부분 산출물 삭제
+            self._cleanup_partial()
+            self._on_failed(e)
+            self.logger.log_exception("Download failed", e)
+            self.logger.save_and_close()
+
+        # 사용자가 강제로 중단한 경우 부분 산출물 삭제
+        if self.state == DownloadState.WAITING:
+            self._cleanup_partial()
+
+    # ============ 다운로드 조정 및 콜백 메서드 ============
+
+    def _download_completed_callback(self, future):
+        """
+        특정 future(스레드)가 끝났을 때 호출되는 콜백.
+        """
+        try:
+            part_num = future.result()
+            # part_num 식별 후 future_dict에서 제거
+            with self.lock:
+                if part_num in self.future_dict:
+                    del self.future_dict[part_num]
+                    self.s.future_count -= 1
+            self.update_progress()  # 즉각적 진행도 반영
+
+        except Exception as e:
+            # 일부 스레드가 오류로 중단된 경우
+            self._on_failed(e)
+            self.logger.log_error("Thread failed", e)
+
+    def _requeue_failed(self, item, part_num: int) -> None:
+        """예외 발생 시 작업을 다시 다운로드할 수 있도록 remaining_ranges에 등록."""
+        self.s.failed_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append(item)
+
+    def _requeue_slow(self, item, part_num: int) -> None:
+        """저속으로 중도 중단한 작업을 재시작하도록 등록."""
+        self.s.restart_threads += 1
+        self.s.threads_progress[part_num] = 0
+        self.s.remaining_ranges.append(item)
+        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
+
+    def _check_speed_and_update_progress(
+        self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float
+    ):
+        """
+        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
+        """
+        with self.lock:
+            self.s.threads_progress[part_num] = downloaded_size
+            self.update_progress()
+
+    # ============ 관측 루프 (구 Monitor 스레드 — 엔진이 흡수) ============
+
+    def _monitor_loop(self):
+        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
+        tm.sleep(1)
+        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
+            if not self.s._pause_event.is_set():
+                self.s._pause_event.wait()
+                self.measure_speed()
+            else:
+                self._adjust_threads()
+                self.measure_speed()
+                self.emit_progress()
+            total_sleep = 1.0  # 총 1초 대기
+            interval = 0.1  # 0.1초씩 대기
+            elapsed = 0.0
+            while elapsed < total_sleep and self.state in [
+                DownloadState.RUNNING,
+                DownloadState.PAUSED,
+            ]:
+                tm.sleep(interval)
+                elapsed += interval
+
+    def _adjust_threads(self):
+        """
+        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정한다.
+
+        기준 속도(_get_standard_speed) 초과 틱이 쌓이면 +4, 기준/2 미만 틱이
+        쌓이면 절반으로. 중간 대역은 카운터를 0으로 감쇠한다 (히스테리시스).
+        """
+        with self.lock:
+            future_count = self.s.future_count
+
+        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+
+        standard_speed = self._get_standard_speed()
+
+        if avg_active_speed > standard_speed:
+            self.adjust_count += 1
+        elif avg_active_speed < standard_speed / 2:
+            self.adjust_count -= 1
+        else:
+            if self.adjust_count > 0:
+                self.adjust_count -= 1
+            elif self.adjust_count < 0:
+                self.adjust_count += 1
+
+        if self.adjust_count > 1:
+            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+        elif self.adjust_count < -4:
+            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
+            self.logger.log_thread_adjust(
+                self.s.adjust_threads, self.s.speed_mb
+            )  # 스레드 조정 로그
+            self.adjust_count = 0
+
+    def measure_speed(self):
+        """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""
+        current_size = self.s.total_downloaded_size
+        speed = current_size - self.s.prev_size
+        self.s.prev_size = current_size
+
+        with self.lock:
+            future_count = self.s.future_count
+        # MB/s로 변환
+        self.s.speed_mb = speed / (1024 * 1024)
+        avg_speed = self.s.speed_mb / future_count if future_count > 0 else 0
+        self.logger.log_thread_debug(future_count, self.s.speed_mb, avg_speed)
+
+    # ============ 진행 상황 업데이트 ============
+
+    def update_progress(self):
+        """
+        다운로드된 총량을 저장한다.
+        """
+        if self.state in [DownloadState.PAUSED, DownloadState.WAITING]:  # 중단 플래그 확인
+            return
+
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+    def emit_progress(self):
+        """진행 상태를 집계해 ProgressEvent 콜백으로 통지한다 (구 Monitor.update_progress)."""
+        active_downloaded_size = sum(self.s.threads_progress)
+        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
+
+        with self.lock:
+            future_count = self.s.future_count
+
+        self._on_progress(
+            ProgressEvent(
+                downloaded_size=self.s.total_downloaded_size,
+                total_size=self._progress_total_size(),
+                speed=self.s.speed_mb,
+                active_threads=future_count,
+            )
+        )

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -1,163 +1,84 @@
-"""파일(범위 분할) 다운로드 엔진 — 표준 threading 기반 (#73, SPEC §5·§6).
+"""파일(범위 분할) 다운로드 엔진 — BaseDownloader 하위 구현 (#73, #82, SPEC §5·§6).
 
-구 download/download.py의 DownloadThread(QThread)와 download/monitor.py의
-MonitorThread(QThread)에 나뉘어 있던 실행·관측 로직을 Qt 없이 한 클래스로 흡수했다.
-로직(범위 분할·스케줄링·적응형 스레드 스케일링·느린 파트 재시도·실패 재큐잉)은
-식 그대로 이동했다 — 규칙은 tests/unit/core/test_file_downloader_rules.py가 박제한다.
+공통 실행 엔진(워커 풀·스케일링·관측·재큐잉·일시정지)은
+core/downloaders/base.py의 BaseDownloader로 이주했다(#82). 이 클래스에는
+파일 경로 고유 부분만 남는다:
 
-- 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
-  (_monitor_loop)가 수행하고, 결과는 core/models/events.py의 ProgressEvent
-  콜백으로 보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
-- 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다(#60).
-- 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다
-  (스레드 규칙은 core/models/events.py docstring 참고).
+- prepare: HEAD로 총 크기 조회 → 해상도별 part_size 결정 → 바이트 범위 분할
+  (ranges.py 사용). 총 크기를 미리 알므로 ProgressEvent.total_size를 채운다
+- _download_part: 파트(바이트 구간) 단위 다운로드 — 저속 재시도·일시정지·
+  중단 핸들링 포함. 규칙은 tests/unit/core/test_file_downloader_rules.py가 박제한다
+- postprocess 없음 (베이스 기본 no-op)
 
-data·logger 매개변수는 앱 영역(download/data.py의 DownloadData,
-download/logger.py의 DownloadLogger)과 호환되는 객체를 주입받는다.
-core에서 직접 import하지 않는 이유는 core→app 의존 금지 때문이다 (#72와 동일한 방식).
+스레드 스케일링 기준 속도는 베이스 기본값(4 MB/s — 구 고정 임계 4/2와 동일)을
+그대로 쓴다.
 """
 
 import os
-import threading
 import time as tm
-from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
 from core.api.session import get_thread_session
+from core.downloaders.base import BaseDownloader
 from core.downloaders.ranges import decide_part_size, split_ranges
+from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
-from core.models.events import (
-    FailedCallback,
-    FinishedCallback,
-    ProgressCallback,
-    ProgressEvent,
-)
 
 
-class FileDownloader:
+class FileDownloader(BaseDownloader):
     """VOD 파일을 범위 분할 멀티스레드로 다운로드하는 엔진.
 
-    호출 규약: 소유자(어댑터·스크립트)가 DownloadTaskModel.start()로 RUNNING
+    호출 규약: 소유자(서비스·스크립트)가 DownloadTaskModel.start()로 RUNNING
     전이를 마친 뒤 run()을 호출한다. run()은 완료·중단·실패까지 블로킹한다.
     """
 
-    def __init__(
-        self,
-        data,
-        logger,
-        on_progress: ProgressCallback | None = None,
-        on_finished: FinishedCallback | None = None,
-        on_failed: FailedCallback | None = None,
-    ):
-        """엔진을 생성한다.
+    run_thread_name = "DownloadThread"
+    worker_pool_prefix = "DownloadWorker"
+    # 구 코드와 동일하게 요청 예외만 실패로 처리한다 — 그 외 예외는 전파
+    _failure_exceptions = (requests.RequestException,)
 
-        Args:
-            data: DownloadData 호환 공유 데이터 (진행률·엔진 변수·model 보유)
-            logger: DownloadLogger 호환 로거
-            on_progress: 관측 주기마다 ProgressEvent를 받는 콜백
-            on_finished: 정상 완료 시 인자 없이 호출되는 콜백
-            on_failed: 실패 시 예외 객체를 그대로 받는 콜백
-        """
-        self.s = data
-        self.model = data.model
-        self.logger = logger
-        self.lock = threading.Lock()
-        self.future_dict: dict = {}
-        self.adjust_count = 0
-        self._on_progress: ProgressCallback = on_progress or (lambda event: None)
-        self._on_finished: FinishedCallback = on_finished or (lambda: None)
-        self._on_failed: FailedCallback = on_failed or (lambda exc: None)
+    @classmethod
+    def supports(cls, content: Content) -> bool:
+        """일반 VOD(video)와 클립(clip)을 처리한다 — 매니페스트가 파일 URL을 준다."""
+        return content.content_type in (ContentType.CHZZK_VIDEO, ContentType.CHZZK_CLIP)
 
-    @property
-    def state(self) -> DownloadState:
-        """현재 다운로드 상태 (DownloadTaskModel에 위임)."""
-        return self.model.state
+    # ============ 작업 목록·수신 준비 (구 run의 파일 고유 부분) ============
 
-    def set_on_progress(self, callback: ProgressCallback) -> None:
-        """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
-        self._on_progress = callback
+    def prepare(self, content: Content) -> list[tuple[int, int]]:
+        """총 크기를 조회하고 해상도별 part_size로 바이트 범위 목록을 만든다."""
+        total_size = self.s.total_size = self._get_total_size()
 
-    # ============ 실행 파이프라인 (구 DownloadThread.run) ============
+        # part_size 결정(해상도별 가중 적용)
+        self._part_size = decide_part_size(self.s.content_type, self.s.resolution)
 
-    def run(self) -> None:
-        """다운로드 파이프라인을 실행한다. 관측 스레드도 여기서 소유·시작한다."""
-        monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
-        try:
-            self.s.start_time = tm.time()
-            total_size = self.s.total_size = self._get_total_size()
+        # 다운로드할 구간 분할
+        return split_ranges(total_size, self._part_size)
 
-            # part_size 결정(해상도별 가중 적용)
-            part_size = decide_part_size(self.s.content_type, self.s.resolution)
+    def _download_start_log_args(self) -> tuple:
+        return (self.s.total_size, self._part_size, self.s.total_ranges, self.s.adjust_threads)
 
-            # 다운로드할 구간 분할
-            ranges = split_ranges(total_size, part_size)
-            self.s.max_threads = self.s.total_ranges = len(ranges)
-            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
-            self.s.threads_progress = [0] * self.s.total_ranges
-            self.logger.log_download_start(
-                total_size, part_size, self.s.total_ranges, self.s.adjust_threads
-            )
+    def _prepare_output(self) -> None:
+        """빈 파일 생성(사이즈: 0)."""
+        with open(self.s.output_path, "wb"):
+            pass
 
-            # 빈 파일 생성(사이즈: 0)
-            with open(self.s.output_path, "wb"):
-                pass
+    def _initial_queue(self, items: list) -> list:
+        """중단 이후 재시작 같은 상황을 고려해 미수신 구간만 큐에 넣는다."""
+        return self._get_remaining_ranges(items)
 
-            # 진행률 배열이 준비된 뒤에 관측을 시작한다
-            monitor.start()
+    def _log_item_start(self, part_num: int, item) -> None:
+        start, end = item
+        self.logger.log_thread_start(part_num, start, end)
 
-            with ThreadPoolExecutor(
-                max_workers=self.s.max_threads, thread_name_prefix="DownloadWorker"
-            ) as executor:
-                self.s.remaining_ranges = self._get_remaining_ranges(ranges)
-                # 재사용 시 초기화 필수
-                with self.lock:
-                    self.s.future_count = 0
-                    self.future_dict = {}
+    def _download_item(self, item, part_num: int):
+        start, end = item
+        return self._download_part(start, end, part_num, self.s.total_size)
 
-                while not self.state == DownloadState.WAITING:
-                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
-                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
-                        for part_num in range(self.s.adjust_threads):
-                            if not self.s.remaining_ranges:
-                                break
-                            with self.lock:
-                                if part_num not in self.future_dict:
-                                    start, end = self.s.remaining_ranges.pop(0)
-                                    self.s.future_count += 1
-                                    self.logger.log_thread_start(part_num, start, end)
-                                    future = executor.submit(
-                                        self._download_part, start, end, part_num, total_size
-                                    )
-                                    future.add_done_callback(self._download_completed_callback)
-                                    self.future_dict[part_num] = (start, end, future)
-
-                    # (2) 주기적으로 상태 확인 (non-blocking)
-                    tm.sleep(0.1)
-
-                    # (3) 남은 작업이 없고 스레드도 없으면 종료
-                    if not self.s.remaining_ranges and not self.future_dict:
-                        break
-
-            if self.state == DownloadState.RUNNING:
-                self.s.end_time = tm.time()
-                total_time = self.s.end_time - self.s.start_time
-                self.logger.log_download_complete(total_time)
-                self.logger.save_and_close()
-                self._on_finished()
-
-        except requests.RequestException as e:
-            # 오류 발생 시 다운로드 파일 삭제
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-            self._on_failed(e)
-            self.logger.log_exception("Download failed", e)
-            self.logger.save_and_close()
-
-        # 사용자가 강제로 중단한 경우 다운로드 파일 삭제
-        if self.state == DownloadState.WAITING:
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
+    def _cleanup_partial(self) -> None:
+        """실패·중단 시 다운로드 파일 삭제."""
+        if os.path.exists(self.s.output_path):
+            os.remove(self.s.output_path)
 
     # ============ 다운로드 동작 관련 메서드들 ============
 
@@ -201,7 +122,7 @@ class FileDownloader:
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
                                         with self.lock:
-                                            self._download_stop_callback(start, end, part_num)
+                                            self._requeue_slow((start, end), part_num)
                                         return part_num
                                 else:
                                     slow_count = 0
@@ -219,153 +140,9 @@ class FileDownloader:
 
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
-                    self._download_failed_callback(start, end, part_num)
+                    self._requeue_failed((start, end), part_num)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
-
-    def _check_speed_and_update_progress(
-        self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float
-    ):
-        """
-        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
-        """
-        with self.lock:
-            self.s.threads_progress[part_num] = downloaded_size
-            self.update_progress()
-
-    # ============ 다운로드 조정 및 콜백 메서드 ============
-
-    def _download_completed_callback(self, future):
-        """
-        특정 future(스레드)가 끝났을 때 호출되는 콜백.
-        """
-        try:
-            part_num = future.result()
-            # part_num 식별 후 future_dict에서 제거
-            with self.lock:
-                if part_num in self.future_dict:
-                    del self.future_dict[part_num]
-                    self.s.future_count -= 1
-            self.update_progress()  # 즉각적 진행도 반영
-
-        except Exception as e:
-            # 일부 스레드가 오류로 중단된 경우
-            self._on_failed(e)
-            self.logger.log_error("Thread failed", e)
-
-    def _download_failed_callback(self, start: int, end: int, part_num: int):
-        """
-        예외 발생 시 파일 구간을 다시 다운로드할 수 있도록 remaining_ranges에 등록.
-        """
-        self.s.failed_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((start, end))
-
-    def _download_stop_callback(self, start: int, end: int, part_num: int):
-        """
-        특정 스레드를 중도 중단하고, 해당 구간을 재시작하도록 설정.
-        """
-        self.s.restart_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((start, end))
-        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
-
-    # ============ 관측 루프 (구 MonitorThread — 엔진이 흡수) ============
-
-    def _monitor_loop(self):
-        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
-        tm.sleep(1)
-        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-            if not self.s._pause_event.is_set():
-                self.s._pause_event.wait()
-                self.measure_speed()
-            else:
-                self._adjust_threads()
-                self.measure_speed()
-                self.emit_progress()
-            total_sleep = 1.0  # 총 1초 대기
-            interval = 0.1  # 0.1초씩 대기
-            elapsed = 0.0
-            while elapsed < total_sleep and self.state in [
-                DownloadState.RUNNING,
-                DownloadState.PAUSED,
-            ]:
-                tm.sleep(interval)
-                elapsed += interval
-
-    def _adjust_threads(self):
-        """
-        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
-        """
-        with self.lock:
-            future_count = self.s.future_count
-
-        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
-
-        if avg_active_speed > 4:
-            self.adjust_count += 1
-        elif avg_active_speed < 2:
-            self.adjust_count -= 1
-        else:
-            if self.adjust_count > 0:
-                self.adjust_count -= 1
-            elif self.adjust_count < 0:
-                self.adjust_count += 1
-
-        if self.adjust_count > 1:
-            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
-        elif self.adjust_count < -4:
-            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
-
-    def measure_speed(self):
-        """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""
-        current_size = self.s.total_downloaded_size
-        speed = current_size - self.s.prev_size
-        self.s.prev_size = current_size
-
-        with self.lock:
-            future_count = self.s.future_count
-        # MB/s로 변환
-        self.s.speed_mb = speed / (1024 * 1024)
-        avg_speed = self.s.speed_mb / future_count if future_count > 0 else 0
-        self.logger.log_thread_debug(future_count, self.s.speed_mb, avg_speed)
-
-    # ============ 진행 상황 업데이트 ============
-
-    def update_progress(self):
-        """
-        다운로드된 총량을 저장한다.
-        """
-        if self.state in [DownloadState.PAUSED, DownloadState.WAITING]:  # 중단 플래그 확인
-            return
-
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
-
-    def emit_progress(self):
-        """진행 상태를 집계해 ProgressEvent 콜백으로 통지한다 (구 MonitorThread.update_progress)."""
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
-
-        with self.lock:
-            future_count = self.s.future_count
-
-        self._on_progress(
-            ProgressEvent(
-                downloaded_size=self.s.total_downloaded_size,
-                total_size=self.s.total_size,
-                speed=self.s.speed_mb,
-                active_threads=future_count,
-            )
-        )
 
     # ============ 유틸 메서드 ============
 

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -1,224 +1,143 @@
-"""m3u8(세그먼트 분할) 다운로드 엔진 — 표준 threading 기반 (#74, SPEC §5·§6).
+"""m3u8(세그먼트 분할) 다운로드 엔진 — BaseDownloader 하위 구현 (#74, #82, SPEC §5·§6).
 
-구 download/download_m3u8.py의 DownloadM3U8Thread(QThread)와
-download/monitor_m3u8.py의 MonitorM3U8Thread(QThread)에 나뉘어 있던
-실행·관측 로직을 Qt 없이 한 클래스로 흡수했다 — 이슈 #73(파일 다운로더)과
-같은 패턴이다. 로직(플레이리스트 파싱·세그먼트 스케줄링·해상도별 적응형
-스레드 스케일링·느린 세그먼트 재시도·실패 재큐잉·순서 보장 병합)은 식 그대로
-이동했다 — 규칙은 tests/unit/core/test_m3u8_downloader_rules.py가 박제한다.
+공통 실행 엔진(워커 풀·스케일링·관측·재큐잉·일시정지)은
+core/downloaders/base.py의 BaseDownloader로 이주했다(#82). 이 클래스에는
+m3u8 고유 부분만 남는다:
 
-파일 경로 엔진(FileDownloader)과의 차이:
-- base_url은 m3u8 플레이리스트 URL이며 **호출 전에 해석이 끝나 있어야 한다**.
-  치지직 API 조회(쿠키·NetworkManager)는 아직 앱 영역이므로 어댑터가 수행한다.
-- 스레드 스케일링 기준 속도가 해상도별 테이블(_get_standard_speed)을 따른다.
-- 다운로드 완료 후 병합 단계가 있다. 병합 시작은 on_merge_start 콜백으로
-  알린다 — 앱 어댑터가 UI 플래그(item.post_process)로 변환한다.
+- prepare: 플레이리스트를 받아 세그먼트 목록 생성. base_url은 m3u8
+  플레이리스트 URL이며 **호출 전에 해석이 끝나 있어야 한다** —
+  requires_base_url_resolution=True로 서비스가 주입된 resolver를 시작
+  시점에 실행한다 (쿠키·치지직 API 조회는 아직 앱 영역)
+- _prepare_output: 임시 폴더 재생성 + EXT-X-MAP 초기화 세그먼트 다운로드
+- _download_segment: 세그먼트 단위 다운로드 — 저속 재시도·일시정지·중단
+  핸들링 포함. 규칙은 tests/unit/core/test_m3u8_downloader_rules.py가 박제한다
+- postprocess: 순서 보장 병합 — 시작은 on_merge_start 콜백으로 알린다
+- 스레드 스케일링 기준 속도는 해상도별 테이블(_get_standard_speed)
 - 전체 크기를 미리 알 수 없어 ProgressEvent.total_size는 None이다.
   진행률 계산(세그먼트 수 기반)은 어댑터의 몫이다.
-
-- 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
-  (_monitor_loop)가 수행하고, 결과는 core/models/events.py의 ProgressEvent
-  콜백으로 보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
-- 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다(#60).
-- 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다
-  (스레드 규칙은 core/models/events.py docstring 참고).
-
-data·logger 매개변수는 앱 영역(download/data.py의 DownloadData,
-download/logger.py의 DownloadLogger)과 호환되는 객체를 주입받는다.
-core에서 직접 import하지 않는 이유는 core→app 의존 금지 때문이다 (#72와 동일한 방식).
 """
 
 import os
 import shutil
-import threading
 import time as tm
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urljoin
 
 import requests
 
 from core.api.session import get_thread_session
+from core.downloaders.base import BaseDownloader
+from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
-from core.models.events import (
-    FailedCallback,
-    FinishedCallback,
-    ProgressCallback,
-    ProgressEvent,
-)
 
 
-class M3U8Downloader:
+class M3U8Downloader(BaseDownloader):
     """m3u8 VOD를 세그먼트 단위 멀티스레드로 다운로드·병합하는 엔진.
 
-    호출 규약: 소유자(어댑터·스크립트)가 data.base_url에 m3u8 플레이리스트 URL을
+    호출 규약: 소유자(서비스·스크립트)가 data.base_url에 m3u8 플레이리스트 URL을
     채우고 DownloadTaskModel.start()로 RUNNING 전이를 마친 뒤 run()을 호출한다.
     run()은 완료·중단·실패까지 블로킹한다.
     """
 
-    def __init__(
-        self,
-        data,
-        logger,
-        on_progress: ProgressCallback | None = None,
-        on_finished: FinishedCallback | None = None,
-        on_failed: FailedCallback | None = None,
-        on_merge_start: Callable[[], None] | None = None,
-    ):
-        """엔진을 생성한다.
+    run_thread_name = "DownloadM3U8Thread"
+    worker_pool_prefix = "DownloadM3U8Worker"
+    requires_base_url_resolution = True
+    # 구 코드와 동일하게 모든 예외를 실패로 처리한다 (플레이리스트 파싱 실패 포함)
+    _failure_exceptions = (Exception,)
 
-        Args:
-            data: DownloadData 호환 공유 데이터 (진행률·엔진 변수·model 보유)
-            logger: DownloadLogger 호환 로거
-            on_progress: 관측 주기마다 ProgressEvent를 받는 콜백
-            on_finished: 정상 완료 시 인자 없이 호출되는 콜백
-            on_failed: 실패 시 예외 객체를 그대로 받는 콜백
-            on_merge_start: 세그먼트 병합 단계 진입 시 인자 없이 호출되는 콜백
-        """
-        self.s = data
-        self.model = data.model
-        self.logger = logger
-        self.lock = threading.Lock()
-        self.future_dict: dict = {}
-        self.adjust_count = 0
-        self._on_progress: ProgressCallback = on_progress or (lambda event: None)
-        self._on_finished: FinishedCallback = on_finished or (lambda: None)
-        self._on_failed: FailedCallback = on_failed or (lambda exc: None)
-        self._on_merge_start: Callable[[], None] = on_merge_start or (lambda: None)
-
-    @property
-    def state(self) -> DownloadState:
-        """현재 다운로드 상태 (DownloadTaskModel에 위임)."""
-        return self.model.state
-
-    def set_on_progress(self, callback: ProgressCallback) -> None:
-        """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
-        self._on_progress = callback
-
-    # ============ 실행 파이프라인 (구 DownloadM3U8Thread.run) ============
-
-    def run(self) -> None:
-        """다운로드·병합 파이프라인을 실행한다. 관측 스레드도 여기서 소유·시작한다."""
-        monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
-        # 세그먼트 저장용 임시 폴더 경로 설정 (예외 정리 경로가 참조하므로 가장 먼저)
+    def __init__(self, data, logger, **callbacks):
+        super().__init__(data, logger, **callbacks)
+        # 세그먼트 저장용 임시 폴더 경로 (실패 정리 경로가 참조하므로 실행 전에 확정)
         self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
-        try:
-            self.s.start_time = tm.time()
 
-            response = get_thread_session().get(self.s.base_url)
-            response.raise_for_status()
-            lines = response.text.splitlines()
-            segments = [line for line in lines if line and not line.startswith("#")]
-            init_segment = None
-            self.s.merged_segments = 0
+    @classmethod
+    def supports(cls, content: Content) -> bool:
+        """라이브 다시보기(m3u8) VOD를 처리한다."""
+        return content.content_type is ContentType.CHZZK_VIDEO_M3U8
 
-            self.s.max_threads = self.s.total_ranges = len(segments)
-            self.width = len(str(self.s.total_ranges))
-            self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
-            self.s.threads_progress = [0] * self.s.total_ranges
-            self.logger.log_download_start(0, 0, self.s.total_ranges, self.s.adjust_threads)
+    # ============ 작업 목록·수신 준비 (구 run의 m3u8 고유 부분) ============
 
-            # 세그먼트 저장용 임시 폴더가 있다면 내용 포함 삭제 후 재생성
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            os.makedirs(self.temp_dir)
+    def prepare(self, content: Content) -> list[tuple[int, str]]:
+        """플레이리스트를 받아 (index, 세그먼트) 목록을 만든다."""
+        response = get_thread_session().get(self.s.base_url)
+        response.raise_for_status()
+        lines = response.text.splitlines()
+        segments = [line for line in lines if line and not line.startswith("#")]
+        # EXT-X-MAP(초기화 세그먼트) 추출을 위해 _prepare_output이 참조한다
+        self._playlist_lines = lines
+        self.s.merged_segments = 0
+        # 세그먼트 임시 파일명 0채움 자릿수 — sorted() 병합 순서의 전제
+        self.width = len(str(len(segments)))
+        return list(enumerate(segments))
 
-            for line in lines:
-                if line.startswith("#EXT-X-MAP:"):
-                    init_segment = line.split("URI=")[1].strip('"')
-            init_url = urljoin(self.s.base_url, init_segment)
-            init_segment_path = os.path.join(self.temp_dir, f"{0:0{self.width}d}.m4s")
-            # 초기화 세그먼트 다운로드
-            with open(init_segment_path, "wb") as f:
-                f.write(get_thread_session().get(init_url).content)
+    def _download_start_log_args(self) -> tuple:
+        # m3u8은 전체 크기·파트 크기를 미리 알 수 없다 (구 코드와 동일하게 0)
+        return (0, 0, self.s.total_ranges, self.s.adjust_threads)
 
-            # 진행률 배열이 준비된 뒤에 관측을 시작한다
-            monitor.start()
-
-            with ThreadPoolExecutor(
-                max_workers=self.s.max_threads, thread_name_prefix="DownloadM3U8Worker"
-            ) as executor:
-                self.s.remaining_ranges = list(enumerate(segments))
-                # 재사용 시 초기화 필수
-                with self.lock:
-                    self.s.future_count = 0
-                    self.future_dict = {}
-
-                while not self.state == DownloadState.WAITING:
-                    # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
-                    while self.s.future_count < self.s.adjust_threads and self.s.remaining_ranges:
-                        for part_num in range(self.s.adjust_threads):
-                            if not self.s.remaining_ranges:
-                                break
-                            with self.lock:
-                                if part_num not in self.future_dict:
-                                    segment_index, segment = self.s.remaining_ranges.pop(0)
-                                    self.s.future_count += 1
-                                    self.logger.log_m3u8_thread_start(part_num, segment)
-                                    future = executor.submit(
-                                        self._download_segment,
-                                        index=segment_index,
-                                        segment=segment,
-                                        part_num=part_num,
-                                        total_ranges=self.s.total_ranges,
-                                    )
-                                    future.add_done_callback(self._download_completed_callback)
-                                    self.future_dict[part_num] = (segment, future)
-
-                    # (2) 주기적으로 상태 확인 (non-blocking)
-                    tm.sleep(0.1)
-
-                    # (3) 남은 작업이 없고 스레드도 없으면 종료
-                    if not self.s.remaining_ranges and not self.future_dict:
-                        break
-
-                if self.state == DownloadState.RUNNING:
-                    # (4) 다운로드 완료 후 파일 합치기
-                    self._on_merge_start()
-                    with open(self.s.output_path, "wb") as final_f:
-                        segment_files = sorted(os.listdir(self.temp_dir))
-                        for seg_file in segment_files:
-                            # 다운로드 중지 상태라면 중단
-                            if self.state == DownloadState.RUNNING:
-                                seg_path = os.path.join(self.temp_dir, seg_file)
-                                with open(seg_path, "rb") as seg_f:
-                                    while True:
-                                        chunk = seg_f.read(8192)
-                                        if not chunk:
-                                            break
-                                        final_f.write(chunk)
-                                        # 일시정지 상태라면 대기
-                                        if self.state == DownloadState.PAUSED:
-                                            self.s._pause_event.wait()
-                                # 세그먼트 파일 합친 후 삭제
-                                self.safe_remove(seg_path)
-                                self.s.merged_segments += 1
-
-                    self.s.end_time = tm.time()
-                    total_time = self.s.end_time - self.s.start_time
-                    self.logger.log_download_complete(total_time)
-                    self.logger.save_and_close()
-                    self._on_finished()
-
-            # (5) 임시 폴더 삭제
+    def _prepare_output(self) -> None:
+        """임시 폴더를 재생성하고 초기화 세그먼트(EXT-X-MAP)를 받는다."""
+        # 세그먼트 저장용 임시 폴더가 있다면 내용 포함 삭제 후 재생성
+        if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
+        os.makedirs(self.temp_dir)
 
-        except Exception as e:
-            # 오류 발생 시 임시 파일과 다운로드 파일 삭제
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
-            self._on_failed(e)
-            self.logger.log_exception("Download failed", e)
-            self.logger.save_and_close()
+        init_segment = None
+        for line in self._playlist_lines:
+            if line.startswith("#EXT-X-MAP:"):
+                init_segment = line.split("URI=")[1].strip('"')
+        init_url = urljoin(self.s.base_url, init_segment)
+        init_segment_path = os.path.join(self.temp_dir, f"{0:0{self.width}d}.m4s")
+        # 초기화 세그먼트 다운로드
+        with open(init_segment_path, "wb") as f:
+            f.write(get_thread_session().get(init_url).content)
 
-        # 사용자가 강제로 중단한 경우 임시 파일과 다운로드 파일 삭제
-        if self.state == DownloadState.WAITING:
-            if os.path.exists(self.temp_dir):
-                shutil.rmtree(self.temp_dir)
-            if os.path.exists(self.s.output_path):
-                os.remove(self.s.output_path)
+    def _log_item_start(self, part_num: int, item) -> None:
+        _index, segment = item
+        self.logger.log_m3u8_thread_start(part_num, segment)
+
+    def _download_item(self, item, part_num: int):
+        index, segment = item
+        return self._download_segment(
+            index=index, segment=segment, part_num=part_num, total_ranges=self.s.total_ranges
+        )
+
+    def _cleanup_partial(self) -> None:
+        """실패·중단 시 임시 폴더와 다운로드 파일 삭제."""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+        if os.path.exists(self.s.output_path):
+            os.remove(self.s.output_path)
+
+    def _cleanup_after_run(self) -> None:
+        """임시 폴더 삭제 (구 run의 (5) — 병합 후에는 빈 폴더만 남는다)."""
+        shutil.rmtree(self.temp_dir)
+
+    def _progress_total_size(self) -> int | None:
+        # 전체 바이트 크기를 미리 알 수 없다 — 세그먼트 수 기반 계산은 어댑터가 한다
+        return None
+
+    # ============ 후처리: 순서 보장 병합 (구 run의 (4)) ============
+
+    def postprocess(self) -> None:
+        """세그먼트 파일들을 인덱스 순서대로 결과 파일에 병합한다."""
+        self._on_merge_start()
+        with open(self.s.output_path, "wb") as final_f:
+            segment_files = sorted(os.listdir(self.temp_dir))
+            for seg_file in segment_files:
+                # 다운로드 중지 상태라면 중단
+                if self.state == DownloadState.RUNNING:
+                    seg_path = os.path.join(self.temp_dir, seg_file)
+                    with open(seg_path, "rb") as seg_f:
+                        while True:
+                            chunk = seg_f.read(8192)
+                            if not chunk:
+                                break
+                            final_f.write(chunk)
+                            # 일시정지 상태라면 대기
+                            if self.state == DownloadState.PAUSED:
+                                self.s._pause_event.wait()
+                    # 세그먼트 파일 합친 후 삭제
+                    self.safe_remove(seg_path)
+                    self.s.merged_segments += 1
 
     # ============ 다운로드 동작 관련 메서드들 ============
 
@@ -259,7 +178,7 @@ class M3U8Downloader:
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
                                         with self.lock:
-                                            self._download_stop_callback(index, segment, part_num)
+                                            self._requeue_slow((index, segment), part_num)
                                         return part_num
                                 else:
                                     slow_count = 0
@@ -274,126 +193,11 @@ class M3U8Downloader:
 
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
-                    self._download_failed_callback(index, segment, part_num)
+                    self._requeue_failed((index, segment), part_num)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
 
-    def _check_speed_and_update_progress(
-        self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float
-    ):
-        """
-        스레드가 다운로드 중일 때 속도 체크 및 진행 상황 업데이트.
-        """
-        with self.lock:
-            self.s.threads_progress[part_num] = downloaded_size
-            self.update_progress()
-
-    # ============ 다운로드 조정 및 콜백 메서드 ============
-
-    def _download_completed_callback(self, future):
-        """
-        특정 future(스레드)가 끝났을 때 호출되는 콜백.
-        """
-        try:
-            part_num = future.result()
-            # part_num 식별 후 future_dict에서 제거
-            with self.lock:
-                if part_num in self.future_dict:
-                    del self.future_dict[part_num]
-                    self.s.future_count -= 1
-            self.update_progress()  # 즉각적 진행도 반영
-
-        except Exception as e:
-            # 일부 스레드가 오류로 중단된 경우
-            self._on_failed(e)
-            self.logger.log_error("Thread failed", e)
-
-    def _download_failed_callback(self, index: int, segment: str, part_num: int):
-        """
-        예외 발생 시 세그먼트를 다시 다운로드할 수 있도록 remaining_ranges에 등록.
-        """
-        self.s.failed_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((index, segment))
-
-    def _download_stop_callback(self, index: int, segment: str, part_num: int):
-        """
-        특정 스레드를 중도 중단하고, 해당 세그먼트를 재시작하도록 설정.
-        """
-        self.s.restart_threads += 1
-        self.s.threads_progress[part_num] = 0
-        self.s.remaining_ranges.append((index, segment))
-        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
-
-    # ============ 관측 루프 (구 MonitorM3U8Thread — 엔진이 흡수) ============
-
-    def _monitor_loop(self):
-        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
-        tm.sleep(1)
-        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
-            if not self.s._pause_event.is_set():
-                self.s._pause_event.wait()
-                self.measure_speed()
-            else:
-                self._adjust_threads()
-                self.measure_speed()
-                self.emit_progress()
-            total_sleep = 1.0  # 총 1초 대기
-            interval = 0.1  # 0.1초씩 대기
-            elapsed = 0.0
-            while elapsed < total_sleep and self.state in [
-                DownloadState.RUNNING,
-                DownloadState.PAUSED,
-            ]:
-                tm.sleep(interval)
-                elapsed += interval
-
-    def _adjust_threads(self):
-        """
-        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정하는 예시 스레드.
-        """
-        with self.lock:
-            future_count = self.s.future_count
-
-        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
-
-        standard_speed = self._get_standard_speed()
-
-        if avg_active_speed > standard_speed:
-            self.adjust_count += 1
-        elif avg_active_speed < standard_speed / 2:
-            self.adjust_count -= 1
-        else:
-            if self.adjust_count > 0:
-                self.adjust_count -= 1
-            elif self.adjust_count < 0:
-                self.adjust_count += 1
-
-        if self.adjust_count > 1:
-            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
-        elif self.adjust_count < -4:
-            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
-
-    def measure_speed(self):
-        """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""
-        current_size = self.s.total_downloaded_size
-        speed = current_size - self.s.prev_size
-        self.s.prev_size = current_size
-
-        with self.lock:
-            future_count = self.s.future_count
-        # MB/s로 변환
-        self.s.speed_mb = speed / (1024 * 1024)
-        avg_speed = self.s.speed_mb / future_count if future_count > 0 else 0
-        self.logger.log_thread_debug(future_count, self.s.speed_mb, avg_speed)
+    # ============ 스레드 스케일링 기준 (해상도별) ============
 
     def _get_standard_speed(self) -> float:
         """
@@ -407,39 +211,6 @@ class M3U8Downloader:
             return 1.2
         else:
             return 3
-
-    # ============ 진행 상황 업데이트 ============
-
-    def update_progress(self):
-        """
-        다운로드된 총량을 저장한다.
-        """
-        if self.state in [DownloadState.PAUSED, DownloadState.WAITING]:  # 중단 플래그 확인
-            return
-
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
-
-    def emit_progress(self):
-        """진행 상태를 집계해 ProgressEvent 콜백으로 통지한다 (구 MonitorM3U8Thread.update_progress).
-
-        m3u8은 전체 바이트 크기를 미리 알 수 없으므로 total_size는 None이다.
-        세그먼트 수 기반 진행률 계산은 어댑터가 공유 데이터로 수행한다.
-        """
-        active_downloaded_size = sum(self.s.threads_progress)
-        self.s.total_downloaded_size = self.s.completed_progress + active_downloaded_size
-
-        with self.lock:
-            future_count = self.s.future_count
-
-        self._on_progress(
-            ProgressEvent(
-                downloaded_size=self.s.total_downloaded_size,
-                total_size=None,
-                speed=self.s.speed_mb,
-                active_threads=future_count,
-            )
-        )
 
     # ============ 유틸 메서드 ============
 

--- a/core/services/download_service.py
+++ b/core/services/download_service.py
@@ -4,6 +4,10 @@ download/manager.py(DownloadManager)에 있던 오케스트레이션 —
 Content 타입에 맞는 다운로더 선택, 실행, 큐잉·동시 실행 수 제한, 완료 처리 —
 을 Qt 없이 수행한다. GUI 없이(CLI·헤드리스·테스트) 재사용할 수 있다.
 
+다운로더 선택은 각 다운로더의 supports() 판정을 따른다(#82) — 서비스는
+구체 클래스의 타입 분기를 갖지 않으며, 워커 스레드 이름과 base_url 해석
+필요 여부도 BaseDownloader 계약의 클래스 속성에서 읽는다.
+
 - 통지는 core/models/events.py의 콜백 계약만 사용한다(진행/완료/실패).
   콜백은 다운로드 워커 스레드에서 호출된다 — Qt 어댑터는 콜백 안에서
   Signal emit까지만 수행해야 한다(스레드 규칙은 events.py docstring이 정본).
@@ -30,7 +34,7 @@ from collections.abc import Callable
 
 from core.downloaders.file_downloader import FileDownloader
 from core.downloaders.m3u8_downloader import M3U8Downloader
-from core.models.content import Content, ContentType
+from core.models.content import Content
 from core.models.download_data import DownloadData
 from core.models.download_state import DownloadState
 from core.models.download_task import InvalidStateTransitionError
@@ -40,11 +44,6 @@ logger = logging.getLogger(__name__)
 
 # Content를 받아 m3u8 플레이리스트 URL을 반환한다. 실패는 예외로 던진다.
 BaseUrlResolver = Callable[[Content], str]
-
-# 서비스가 다운로드를 수행할 수 있는 컨텐츠 타입 (라이브 녹화는 Phase 5 소관)
-_SUPPORTED_TYPES = frozenset(
-    {ContentType.CHZZK_VIDEO, ContentType.CHZZK_VIDEO_M3U8, ContentType.CHZZK_CLIP}
-)
 
 
 class _NullDownloadLogger:
@@ -83,6 +82,7 @@ class DownloadHandle:
         self.data = data
         self.logger = task_logger
         self.engine = None
+        self.engine_cls = None  # 서비스가 supports() 판정으로 채운다 (#82)
         self.thread: threading.Thread | None = None
         self.on_progress = on_progress
         self.on_finished = on_finished
@@ -200,10 +200,9 @@ class DownloadService:
             on_merge_start: m3u8 병합 시작 콜백
 
         Raises:
-            ValueError: 지원하지 않는 컨텐츠 타입이거나 data가 content와 불일치
+            ValueError: 지원하는 다운로더가 없는 컨텐츠이거나 data가 content와 불일치
         """
-        if content.content_type not in _SUPPORTED_TYPES:
-            raise ValueError(f"지원하지 않는 컨텐츠 타입: {content.content_type}")
+        engine_cls = self._select_downloader(content)
         if data is None:
             data = DownloadData.from_content(content)
         elif data.content is not content:
@@ -222,10 +221,27 @@ class DownloadService:
             on_failed=on_failed,
             on_merge_start=on_merge_start,
         )
+        handle.engine_cls = engine_cls
         with self._lock:
             self._pending.append(handle)
             self._dispatch_locked()
         return handle
+
+    def _select_downloader(self, content: Content):
+        """supports()로 컨텐츠를 처리할 다운로더 클래스를 고른다 (#82).
+
+        서비스는 구체 클래스의 타입 분기를 알지 않는다 — 각 다운로더가
+        supports()로 답하고, 워커 스레드 이름·base_url 해석 필요 여부도
+        클래스 속성(run_thread_name·requires_base_url_resolution)에서 읽는다.
+
+        Raises:
+            ValueError: 어떤 다운로더도 지원하지 않는 컨텐츠 (예: 라이브)
+        """
+        # 모듈 전역을 호출 시점에 참조한다 (테스트에서 대역으로 교체 가능)
+        for downloader_cls in (FileDownloader, M3U8Downloader):
+            if downloader_cls.supports(content):
+                return downloader_cls
+        raise ValueError(f"지원하지 않는 컨텐츠 타입: {content.content_type}")
 
     @property
     def active_count(self) -> int:
@@ -247,13 +263,11 @@ class DownloadService:
             handle = self._pending.popleft()
             self._active.add(handle)
             # 스레드 이름은 구 QThread 어댑터와 동일하게 유지한다 (다운로드 로그 형식 보존)
-            name = (
-                "DownloadM3U8Thread"
-                if handle.content.content_type is ContentType.CHZZK_VIDEO_M3U8
-                else "DownloadThread"
-            )
             handle.thread = threading.Thread(
-                target=self._run_handle, args=(handle,), name=name, daemon=True
+                target=self._run_handle,
+                args=(handle,),
+                name=handle.engine_cls.run_thread_name,
+                daemon=True,
             )
             handle.thread.start()
 
@@ -279,8 +293,8 @@ class DownloadService:
             engine = self._create_engine(handle)
             handle.engine = engine
 
-            if handle.content.content_type is ContentType.CHZZK_VIDEO_M3U8:
-                # m3u8은 시작 시점에 플레이리스트 URL을 해석한다 (구 어댑터와 동일).
+            if handle.engine_cls.requires_base_url_resolution:
+                # m3u8 등은 시작 시점에 플레이리스트 URL을 해석한다 (구 어댑터와 동일).
                 # 실패는 엔진 실패와 같은 형식으로 콜백 통지·로깅한다
                 try:
                     handle.data.base_url = self._resolve_base_url(handle.content)
@@ -298,22 +312,19 @@ class DownloadService:
                 self._dispatch_locked()
 
     def _create_engine(self, handle: DownloadHandle):
-        """컨텐츠 타입에 맞는 다운로더 엔진을 만들고 콜백을 배선한다."""
-        if handle.content.content_type is ContentType.CHZZK_VIDEO_M3U8:
-            return M3U8Downloader(
-                data=handle.data,
-                logger=handle.logger,
-                on_progress=handle._relay_progress,
-                on_finished=lambda: self._handle_finished(handle),
-                on_failed=handle._relay_failed,
-                on_merge_start=handle._relay_merge_start,
-            )
-        return FileDownloader(
+        """선택된 다운로더 클래스로 엔진을 만들고 콜백을 배선한다.
+
+        생성자 시그니처는 BaseDownloader가 통일한다(#82) — 서비스는 구체
+        클래스를 구분하지 않는다. 후처리(병합) 콜백은 후처리가 없는
+        다운로더에서는 호출되지 않을 뿐 배선은 동일하다.
+        """
+        return handle.engine_cls(
             data=handle.data,
             logger=handle.logger,
             on_progress=handle._relay_progress,
             on_finished=lambda: self._handle_finished(handle),
             on_failed=handle._relay_failed,
+            on_merge_start=handle._relay_merge_start,
         )
 
     def _resolve_base_url(self, content: Content) -> str:

--- a/tests/unit/core/test_download_service.py
+++ b/tests/unit/core/test_download_service.py
@@ -48,11 +48,26 @@ class FakeEngine:
 
 
 class FakeEngineFactory:
-    """서비스 모듈의 엔진 심볼을 대체해 생성된 페이크 엔진을 수집한다."""
+    """서비스 모듈의 엔진 심볼을 대체해 생성된 페이크 엔진을 수집한다.
 
-    def __init__(self):
+    #82 이후 서비스는 BaseDownloader 계약(supports/run_thread_name/
+    requires_base_url_resolution)만 참조하므로 그 계약을 함께 흉내 낸다.
+    """
+
+    def __init__(
+        self,
+        supported: set[ContentType],
+        requires_base_url_resolution: bool = False,
+        run_thread_name: str = "DownloadThread",
+    ):
+        self.supported = supported
+        self.requires_base_url_resolution = requires_base_url_resolution
+        self.run_thread_name = run_thread_name
         self.instances: list[FakeEngine] = []
         self.created = threading.Event()
+
+    def supports(self, content: Content) -> bool:
+        return content.content_type in self.supported
 
     def __call__(self, **kwargs):
         engine = FakeEngine(**kwargs)
@@ -86,14 +101,18 @@ def _make_content(content_type: ContentType = ContentType.CHZZK_VIDEO) -> Conten
 
 @pytest.fixture
 def file_factory(monkeypatch):
-    factory = FakeEngineFactory()
+    factory = FakeEngineFactory({ContentType.CHZZK_VIDEO, ContentType.CHZZK_CLIP})
     monkeypatch.setattr(download_service_module, "FileDownloader", factory)
     return factory
 
 
 @pytest.fixture
 def m3u8_factory(monkeypatch):
-    factory = FakeEngineFactory()
+    factory = FakeEngineFactory(
+        {ContentType.CHZZK_VIDEO_M3U8},
+        requires_base_url_resolution=True,
+        run_thread_name="DownloadM3U8Thread",
+    )
     monkeypatch.setattr(download_service_module, "M3U8Downloader", factory)
     return factory
 
@@ -169,6 +188,24 @@ class TestDownloaderSelection:
     def test_unsupported_type_raises(self, file_factory):
         with pytest.raises(ValueError):
             DownloadService().submit(_make_content(ContentType.CHZZK_LIVE))
+
+    @pytest.mark.parametrize(
+        ("content_type", "file_ok", "m3u8_ok"),
+        [
+            (ContentType.CHZZK_VIDEO, True, False),
+            (ContentType.CHZZK_CLIP, True, False),
+            (ContentType.CHZZK_VIDEO_M3U8, False, True),
+            (ContentType.CHZZK_LIVE, False, False),
+        ],
+    )
+    def test_real_downloader_supports_matrix(self, content_type, file_ok, m3u8_ok):
+        """실제 다운로더의 supports() 판정 매트릭스 (#82) — 서비스 선택 규칙의 근거."""
+        from core.downloaders.file_downloader import FileDownloader
+        from core.downloaders.m3u8_downloader import M3U8Downloader
+
+        content = _make_content(content_type)
+        assert FileDownloader.supports(content) is file_ok
+        assert M3U8Downloader.supports(content) is m3u8_ok
 
     def test_mismatched_data_raises(self, file_factory):
         from core.models.download_data import DownloadData


### PR DESCRIPTION
## 관련 이슈

Closes #82

## 변경 내용

**1. `core/downloaders/base.py` 신설 — BaseDownloader 공통 실행 엔진**

file(#73)·m3u8(#74)이 평행 중복으로 갖고 있던 실행 엔진을 베이스 한 곳으로 흡수했다:
- 워커 풀 관리·작업 큐잉·실패/저속 재큐잉(`run` 스케줄 루프, `_download_completed_callback`, `_requeue_failed`/`_requeue_slow`)
- 적응형 스레드 스케일링(`_adjust_threads` — 기준 속도는 `_get_standard_speed()` 훅으로 매개변수화: 기본 4 MB/s = 구 파일 엔진의 고정 임계 4/2, m3u8은 해상도별 테이블 오버라이드)와 관측 스레드(`_monitor_loop`, `measure_speed`)
- 일시정지/재개 `threading.Event` 처리 (DownloadTaskModel 공유, 변경 없음)
- 진행률 집계 → `ProgressEvent` 콜백 보고(`emit_progress` — `_progress_total_size()` 훅: file은 총 크기, m3u8은 None)

`run()`은 템플릿 메서드다: `prepare()` → 공통 카운터 세팅 → `_prepare_output()` → 스케줄 루프 → (RUNNING이면) `postprocess()` → 완료 통지 → 정리. 로직·수식·순서는 두 엔진에서 식 그대로 옮겼다.

**2. 하위 구현 재작성 — 각자 남긴 것**
- `FileDownloader`: `supports()`(video/clip), `prepare()`(HEAD 총 크기 → `ranges.py` 범위 분할), `_download_part`(파트 단위 동작, 무변경), 재개용 `_initial_queue`, postprocess 없음(베이스 no-op). **402줄 → 174줄**
- `M3U8Downloader`: `supports()`(m3u8), `prepare()`(플레이리스트 → 세그먼트 목록, base_url resolver 주입 유지 — `requires_base_url_resolution=True`), `_download_segment`(세그먼트 단위 동작, 무변경), `postprocess()`(순서 보장 병합, 현행 동작 그대로), 해상도별 기준 속도. **457줄 → 220줄**

**3. `DownloadService` 선택 로직 — `supports()` 기반**

서비스의 `if content_type is M3U8` 분기를 전부 제거했다. 다운로더 선택은 `_select_downloader()`가 각 클래스의 `supports()`에 묻고, 워커 스레드 이름(`run_thread_name`)·base_url 해석 필요 여부(`requires_base_url_resolution`)도 BaseDownloader 계약의 클래스 속성에서 읽는다. 엔진 생성도 단일 시그니처(베이스 `__init__`이 `on_merge_start`까지 통일)로 구체 클래스 무관.

**4. 범위 밖 준수**: 후처리 중 모니터 동작·병합 꼬리 등 동작 개선 없음(구조 그대로 이식), AES·부분 재개·구간 선택 없음. 앱 계층·UI 무변경.

## 중복 제거 근거 (완료 조건)

| | 이전 | 이후 |
|---|---|---|
| file_downloader.py | 402줄 | 174줄 |
| m3u8_downloader.py | 457줄 | 220줄 |
| base.py (공통 엔진 1벌) | — | 379줄 |
| 합계 | 859줄 | 773줄 |

구체 다운로더 두 파일 diff: **+184 / −636**. 이전에는 스케줄 루프·완료 콜백·스케일링·관측 루프·속도 계산·진행 집계·재큐잉(~250줄 상당)이 양쪽에 거의 동일하게 2벌 존재했고, 이제 베이스에 1벌이다. base.py 379줄 중 ~100줄은 추상 계약 정의·hook 문서(docstring)로, 실행 코드 순증가는 없다.

## 진행률 계산 책임 판단 (이슈 3번 — 어댑터 분기 유지, 근거)

`qt_bridge`의 `_file_progress_args` / `_m3u8_progress_args` 분기를 **유지**한다. 근거:
- `ProgressEvent`(events.py, frozen)는 core가 아는 **사실**(누적 바이트·전체 크기·속도·활성 스레드)만 담는 계약이고, %·남은 시간 환산은 **표시 정책**이다. m3u8의 세그먼트 수 기반 %와 병합 단계 표시는 UI 상태(`item.post_process`)와 결합돼 있어 core로 내리면 계약 확장(이벤트 스키마 변경)이 필요하고, file/m3u8 분기가 제거되는 게 아니라 core로 이동할 뿐이다.
- 단, 차이의 **원인**은 추상에 반영했다: `_progress_total_size()` 훅으로 "전체 크기를 미리 아는가"가 다운로더 계약에 명시되며, 어댑터는 `total_size=None` 여부로도 이 사실을 알 수 있다. UI 표시 결과는 무변경이다(브리지 코드 자체를 건드리지 않음).

## "새 다운로더 추가 시 prepare/postprocess만 구현하면 되는가" (완료 조건)

실행 엔진(워커 풀·스케일링·관측·일시정지·재큐잉·진행 통지)은 재구현이 필요 없다. 다만 정확히는 필수 훅이 이슈 구상(prepare/postprocess)보다 많다 — **supports / prepare / `_download_item`(작업 1건 다운로드) / `_log_item_start` / `_download_start_log_args` / `_prepare_output` / `_cleanup_partial`** 7개. 로그 형식·산출물 정리 경로·작업 단위 재시도가 타입 고유이기 때문이며, 현행 동작을 바이트 수준으로 보존하기 위해 억지로 공통화하지 않았다. 목록은 base.py 모듈 docstring에 "새 다운로더를 추가할 때 보는 목록"으로 정리했다. 라이브 녹화(Phase 5)는 이 7개 + postprocess만 구현하면 된다.

## 검증

- [x] `uv run ruff check .` 통과, core 순수성 가드(`test_no_qt_import`) 통과
- [x] `uv run pytest` 전체 통과 — **197 passed** (Windows 로컬이라 xvfb 없이 실행)
- [x] **기존 박제 테스트 시나리오·단언 무수정 통과**: `test_file_downloader_rules.py`·`test_m3u8_downloader_rules.py`·`test_file_downloader_run.py`·`test_m3u8_downloader_run.py` 4개 파일은 커밋에 포함되지 않았다(무변경). 팩토리 대상 클래스도 이미 core 클래스라 교체 불필요였다.
- [x] 신규 테스트: supports() 판정 매트릭스(4타입 × 2클래스), 서비스 페이크를 BaseDownloader 계약(supports/run_thread_name/requires_base_url_resolution)에 맞게 갱신

**헤드리스 실검증 (완료 조건 — 파일·m3u8 각 1건 완주)**

| 경로 | 결과 |
|---|---|
| 파일(클립 SdIwKua8bb) | exit 0, **26,281,935 bytes — #75(통합 전) 실행과 동일 크기** |
| m3u8(VOD 14348487, 144p, 6996세그먼트) | exit 0, **348,770,581 bytes — #75(통합 전) 실행과 바이트 단위 동일 크기**, 소요 2:20 |

m3u8 궤적 구조 비교(#74 기준선 판정 기준 — 구조적 특징만): +4 계단 증가(8→12→16→20→24→28→32→36…) 유지, 병합 꼬리(정점→16→8→4→2→1, speed 0.00) 유지.

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — base.py는 core 내부만 참조
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #82 (`core/downloaders/base.py` 신설은 이슈 승인 범위)

## 리뷰어에게

- **파일명**: CLAUDE.local.md의 확장 규칙에는 `core/downloaders/base_downloader.py`로 언급돼 있으나(미존재 파일), 이슈 #82가 지정한 `core/downloaders/base.py`를 따랐다. 문서 갱신이 필요하면 말씀 주세요 (CLAUDE.local.md는 수정 금지 구역이라 건드리지 않았다).
- **의도된 미세 구조 변화 2건** (동작 등가, 관찰 결과 무변화): ① m3u8 병합이 구 코드에서는 executor `with` 블록 안에서 실행됐으나 통합 후 블록 종료 직후 실행된다 — 병합 시점에 활성 future가 0이므로 등가. ② 내부 재큐잉 헬퍼(`_download_failed_callback`/`_download_stop_callback`)를 `_requeue_failed`/`_requeue_slow`로 통합했다 — 카운터·재큐 항목·경고 문구 동일.
- **오너 스모크 요청 (완료 조건)**: 일반 VOD(대용량) / m3u8 / 클립 각 1건 + 일시정지·재개. 요약 스크립트로 궤적 모양·병합 꼬리 구조 비교 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
