### PR TITLE
feat: DownloadPlan 도입 - 구간 리스트 기반 계획 모델 (#83)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -12,9 +12,10 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
 필수 (추상):
 - ``supports(content)``: 이 다운로더가 처리할 컨텐츠 타입 판정 — 서비스의
   선택 로직이 구체 클래스 분기 없이 이 답을 따른다
-- ``prepare(content)``: "무엇을 받을지" 작업 목록 생성 (file: 바이트 범위,
-  m3u8: (index, 세그먼트) 목록). 총 크기 조회·매니페스트 파싱 등 타입 고유
-  사전 조회는 여기서 한다
+- ``prepare(content)``: "무엇을 받을지"를 DownloadPlan으로 만든다 (#83 —
+  items는 file: 바이트 범위, m3u8: (index, 세그먼트) 튜플). 총 크기 조회·
+  매니페스트 파싱 등 타입 고유 사전 조회는 여기서 한다. 계획의 총 크기·
+  후처리 필요 여부는 run()이 계획에서 읽는다 — 실행 중 추측하지 않는다
 - ``_download_item(item, part_num)``: 작업 1건의 다운로드 (재시도 판정 포함)
 - ``_log_item_start(part_num, item)`` / ``_download_start_log_args()``:
   타입별 로그 형식 유지용
@@ -22,7 +23,8 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
 - ``_cleanup_partial()``: 실패·중단 시 부분 산출물 정리
 
 선택 (기본 구현 있음):
-- ``postprocess()``: 다운로드 완료 후 마무리 (기본 no-op, m3u8: 병합)
+- ``postprocess()``: 다운로드 완료 후 마무리 (m3u8: 병합). 계획의
+  requires_postprocess가 참일 때만 run()이 호출한다 (#83)
 - ``_initial_queue(items)``: 시작 시 작업 큐 구성 (기본: 목록 그대로)
 - ``_cleanup_after_run()``: 정상 경로 종료 후 정리 (기본 no-op)
 - ``_get_standard_speed()``: 스레드 스케일링 기준 속도 (기본 4 MB/s — 구 파일
@@ -60,6 +62,7 @@ from core.models.events import (
     ProgressCallback,
     ProgressEvent,
 )
+from core.models.plan import DownloadPlan
 
 
 class BaseDownloader(ABC):
@@ -122,10 +125,11 @@ class BaseDownloader(ABC):
         """이 다운로더가 해당 컨텐츠를 처리할 수 있는지 판정한다."""
 
     @abstractmethod
-    def prepare(self, content: Content) -> list:
-        """다운로드할 작업 목록을 만든다 (타입 고유 사전 조회 포함).
+    def prepare(self, content: Content) -> DownloadPlan:
+        """다운로드 계획(DownloadPlan)을 만든다 (타입 고유 사전 조회 포함).
 
-        반환한 목록의 길이가 max_threads·total_ranges·진행 배열의 기준이 된다.
+        계획의 part_count가 max_threads·total_ranges·진행 배열의 기준이 되고,
+        total_size·requires_postprocess도 run()이 계획에서 읽는다 (#83).
         """
 
     @abstractmethod
@@ -154,10 +158,13 @@ class BaseDownloader(ABC):
     # ============ 하위 다운로더가 선택적으로 오버라이드 ============
 
     def postprocess(self) -> None:
-        """다운로드 완료 후 마무리 (기본 no-op). m3u8은 여기서 병합한다."""
+        """다운로드 완료 후 마무리. m3u8은 여기서 병합한다.
+
+        계획(DownloadPlan)의 requires_postprocess가 참일 때만 run()이 호출한다.
+        """
 
     def _initial_queue(self, items: list) -> list:
-        """시작 시 작업 큐를 구성한다 (기본: prepare 결과 그대로)."""
+        """시작 시 작업 큐를 구성한다 (기본: 계획의 items 그대로)."""
         return list(items)
 
     def _cleanup_after_run(self) -> None:
@@ -178,9 +185,16 @@ class BaseDownloader(ABC):
         monitor = threading.Thread(target=self._monitor_loop, name="DownloadMonitor", daemon=True)
         try:
             self.s.start_time = tm.time()
-            items = self.prepare(self.s.content)
+            plan = self.prepare(self.s.content)
+            if plan.selections:
+                # 구간 해석은 #83 범위 밖 — 모양만 정의하고 명시적으로 거부한다
+                raise NotImplementedError("구간 선택 다운로드(selections)는 아직 지원하지 않는다")
+            if plan.total_size is not None:
+                # 총 크기는 계획에서 읽는다 — 진행 통지·파트 로그가 참조한다
+                self.s.total_size = plan.total_size
+            items = list(plan.items)
 
-            self.s.max_threads = self.s.total_ranges = len(items)
+            self.s.max_threads = self.s.total_ranges = plan.part_count
             self.s.adjust_threads = min(self.s.adjust_threads, self.s.max_threads)
             self.s.threads_progress = [0] * self.s.total_ranges
             self.logger.log_download_start(*self._download_start_log_args())
@@ -222,8 +236,10 @@ class BaseDownloader(ABC):
                         break
 
             if self.state == DownloadState.RUNNING:
-                # (4) 다운로드 완료 후 타입별 마무리(병합 등) 후 완료 통지
-                self.postprocess()
+                # (4) 다운로드 완료 후 타입별 마무리(병합 등) 후 완료 통지 —
+                # 후처리 필요 여부는 실행 중 추측하지 않고 계획이 답한다 (#83)
+                if plan.requires_postprocess:
+                    self.postprocess()
                 self.s.end_time = tm.time()
                 total_time = self.s.end_time - self.s.start_time
                 self.logger.log_download_complete(total_time)

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -5,7 +5,8 @@ core/downloaders/base.py의 BaseDownloader로 이주했다(#82). 이 클래스�
 파일 경로 고유 부분만 남는다:
 
 - prepare: HEAD로 총 크기 조회 → 해상도별 part_size 결정 → 바이트 범위 분할
-  (ranges.py 사용). 총 크기를 미리 알므로 ProgressEvent.total_size를 채운다
+  (ranges.py 사용)을 DownloadPlan으로 반환한다 (#83). 총 크기를 미리 알므로
+  계획의 total_size를 채우고, ProgressEvent.total_size로 이어진다
 - _download_part: 파트(바이트 구간) 단위 다운로드 — 저속 재시도·일시정지·
   중단 핸들링 포함. 규칙은 tests/unit/core/test_file_downloader_rules.py가 박제한다
 - postprocess 없음 (베이스 기본 no-op)
@@ -24,6 +25,7 @@ from core.downloaders.base import BaseDownloader
 from core.downloaders.ranges import decide_part_size, split_ranges
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
+from core.models.plan import DownloadPlan
 
 
 class FileDownloader(BaseDownloader):
@@ -45,15 +47,18 @@ class FileDownloader(BaseDownloader):
 
     # ============ 작업 목록·수신 준비 (구 run의 파일 고유 부분) ============
 
-    def prepare(self, content: Content) -> list[tuple[int, int]]:
-        """총 크기를 조회하고 해상도별 part_size로 바이트 범위 목록을 만든다."""
-        total_size = self.s.total_size = self._get_total_size()
+    def prepare(self, content: Content) -> DownloadPlan:
+        """총 크기를 조회하고 해상도별 part_size의 바이트 범위 계획을 만든다."""
+        total_size = self._get_total_size()
 
         # part_size 결정(해상도별 가중 적용)
         self._part_size = decide_part_size(self.s.content_type, self.s.resolution)
 
-        # 다운로드할 구간 분할
-        return split_ranges(total_size, self._part_size)
+        # 다운로드할 구간 분할 — 총 크기를 미리 아는 경로이므로 계획에 싣는다
+        return DownloadPlan(
+            items=tuple(split_ranges(total_size, self._part_size)),
+            total_size=total_size,
+        )
 
     def _download_start_log_args(self) -> tuple:
         return (self.s.total_size, self._part_size, self.s.total_ranges, self.s.adjust_threads)

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -4,7 +4,9 @@
 core/downloaders/base.py의 BaseDownloader로 이주했다(#82). 이 클래스에는
 m3u8 고유 부분만 남는다:
 
-- prepare: 플레이리스트를 받아 세그먼트 목록 생성. base_url은 m3u8
+- prepare: 플레이리스트를 받아 세그먼트 목록의 DownloadPlan 생성 (#83 —
+  총 크기 미상이라 total_size=None, 병합이 필요해 requires_postprocess=True).
+  base_url은 m3u8
   플레이리스트 URL이며 **호출 전에 해석이 끝나 있어야 한다** —
   requires_base_url_resolution=True로 서비스가 주입된 resolver를 시작
   시점에 실행한다 (쿠키·치지직 API 조회는 아직 앱 영역)
@@ -28,6 +30,7 @@ from core.api.session import get_thread_session
 from core.downloaders.base import BaseDownloader
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
+from core.models.plan import DownloadPlan
 
 
 class M3U8Downloader(BaseDownloader):
@@ -56,8 +59,8 @@ class M3U8Downloader(BaseDownloader):
 
     # ============ 작업 목록·수신 준비 (구 run의 m3u8 고유 부분) ============
 
-    def prepare(self, content: Content) -> list[tuple[int, str]]:
-        """플레이리스트를 받아 (index, 세그먼트) 목록을 만든다."""
+    def prepare(self, content: Content) -> DownloadPlan:
+        """플레이리스트를 받아 (index, 세그먼트) 목록의 계획을 만든다."""
         response = get_thread_session().get(self.s.base_url)
         response.raise_for_status()
         lines = response.text.splitlines()
@@ -67,7 +70,12 @@ class M3U8Downloader(BaseDownloader):
         self.s.merged_segments = 0
         # 세그먼트 임시 파일명 0채움 자릿수 — sorted() 병합 순서의 전제
         self.width = len(str(len(segments)))
-        return list(enumerate(segments))
+        # 총 바이트 크기는 미리 알 수 없고(total_size=None), 병합 후처리가 필요하다
+        return DownloadPlan(
+            items=tuple(enumerate(segments)),
+            total_size=None,
+            requires_postprocess=True,
+        )
 
     def _download_start_log_args(self) -> tuple:
         # m3u8은 전체 크기·파트 크기를 미리 알 수 없다 (구 코드와 동일하게 0)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -3,12 +3,15 @@
 from core.models.content import Content, ContentType, VideoInfo
 from core.models.download_state import DownloadState
 from core.models.download_task import DownloadTaskModel, InvalidStateTransitionError
+from core.models.plan import DownloadPlan, TimeRange
 
 __all__ = [
     "Content",
     "ContentType",
     "VideoInfo",
+    "DownloadPlan",
     "DownloadState",
     "DownloadTaskModel",
     "InvalidStateTransitionError",
+    "TimeRange",
 ]

--- a/core/models/plan.py
+++ b/core/models/plan.py
@@ -1,0 +1,56 @@
+"""다운로드 계획 모델 — prepare()의 반환 계약 (#83, SPEC §5).
+
+"무엇을 받을지"를 다운로더 타입과 무관한 계획 객체 하나로 감싼다.
+prepare()의 반환 형태가 다운로더마다 다르면(바이트 범위 목록 vs 세그먼트
+목록) 구간 선택·부분 재개·AES 키 같은 계획 정보가 추가될 때마다 시그니처가
+깨진다 — 계획 객체에 필드를 더하는 방식이면 기존 호출부가 흔들리지 않는다.
+
+items의 표현은 다운로더별 튜플을 그대로 담는다:
+- file: ``(start, end)`` 바이트 범위 (양 끝 포함)
+- m3u8: ``(index, 세그먼트 상대 경로)``
+
+공통 아이템 타입으로 묶지 않는 이유: 실행 규칙 박제 테스트
+(test_file_downloader_rules / test_m3u8_downloader_rules)가 재큐잉 표현을
+이 튜플 형태로 고정하고 있고, 베이스 엔진은 items를 순회해 하위 다운로더의
+_download_item에 되돌려줄 뿐 내용을 해석하지 않는다. 아이템 타입화는
+구간 해석이 실제로 필요해지는 시점에 계획 필드 추가로 얹는다.
+
+selections는 처음부터 튜플(리스트 형태)로 모델링한다 — 단일 구간으로
+두면 다중 구간 지원 시 데이터 모델부터 소비자까지 다시 뜯어야 하지만,
+튜플이면 다중 구간이 자연히 따라온다. 빈 튜플 = 전체 다운로드가 기본
+케이스다. 구간 해석(비어 있지 않은 selections)은 아직 구현하지 않으며,
+베이스 엔진이 명시적 미지원 예외(NotImplementedError)로 거부한다 (#83).
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    """영상 내 시간 구간(초). start ≤ end를 전제한다."""
+
+    start: float
+    end: float
+
+
+@dataclass(frozen=True)
+class DownloadPlan:
+    """다운로드 한 건의 실행 계획 — prepare()가 만들고 베이스 엔진이 소비한다.
+
+    계획 단계에서 알 수 있는 정보(전송 단위 목록, 총 크기, 후처리 필요 여부)를
+    모두 담아, 실행 중에 추측이 필요 없게 한다.
+    """
+
+    # 전송 단위 목록 — file: (start, end) 바이트 범위, m3u8: (index, 세그먼트)
+    items: tuple
+    # 총 바이트 크기. 계획 시점에 알 수 없으면 None (m3u8)
+    total_size: int | None = None
+    # 다운로드 완료 후 후처리(postprocess — m3u8 병합)가 필요한지
+    requires_postprocess: bool = False
+    # 선택 다운로드 구간 목록. 빈 튜플 = 전체 다운로드 (#83에서는 빈 값만 지원)
+    selections: tuple[TimeRange, ...] = ()
+
+    @property
+    def part_count(self) -> int:
+        """전송 단위 수 — 워커 상한·진행 배열 크기의 기준."""
+        return len(self.items)

--- a/tests/unit/core/test_download_plan.py
+++ b/tests/unit/core/test_download_plan.py
@@ -1,0 +1,192 @@
+"""DownloadPlan 계약 검증 — prepare()의 계획 반환과 베이스의 소비 (#83).
+
+검증 범위:
+- DownloadPlan 모델: 불변(frozen), 기본값(빈 selections = 전체 다운로드), part_count
+- 두 다운로더의 prepare()가 DownloadPlan을 반환하고, 계획 필드가 현행
+  실행에 필요한 정보(items·total_size·requires_postprocess)를 담는다
+- selections가 비어 있지 않으면 베이스 run()이 명시적 미지원 예외를 낸다
+  (#83은 모양만 정의 — 구간 해석 미구현)
+
+selections가 빈 값일 때 현행과 동일 동작인 것은 기존 실행 테스트
+(test_file_downloader_run / test_m3u8_downloader_run)와 규칙 박제 테스트가
+무수정으로 통과하는 것으로 확인한다.
+"""
+
+import dataclasses
+
+import pytest
+
+import core.downloaders.file_downloader as fd_module
+import core.downloaders.m3u8_downloader as m3u8_module
+from core.downloaders.file_downloader import FileDownloader
+from core.downloaders.m3u8_downloader import M3U8Downloader
+from core.downloaders.ranges import split_ranges
+from core.models.plan import DownloadPlan, TimeRange
+from download.data import DownloadData
+
+MB = 1024 * 1024
+
+
+class RecordingLogger:
+    """호출된 로그 메서드 이름만 기록하는 DownloadLogger 호환 페이크."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def __getattr__(self, name):
+        def record(*args, **kwargs):
+            self.calls.append(name)
+
+        return record
+
+
+# ================================================================ 모델 계약
+
+
+def test_plan_is_frozen_and_defaults_to_full_download():
+    """계획은 불변이고, selections 기본값(빈 튜플)은 전체 다운로드를 뜻한다."""
+    plan = DownloadPlan(items=((0, 9), (10, 19)), total_size=20)
+
+    assert plan.selections == ()
+    assert plan.requires_postprocess is False
+    assert plan.part_count == 2
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        plan.total_size = 999
+
+
+def test_time_range_holds_seconds():
+    """TimeRange는 초 단위 (start, end) 구간을 담는다 — 다중 구간은 튜플로 나열한다."""
+    plan = DownloadPlan(items=(), selections=(TimeRange(0.0, 10.0), TimeRange(30.0, 45.5)))
+
+    assert plan.selections[1].end == pytest.approx(45.5)
+    assert plan.part_count == 0
+
+
+# ================================================================ file prepare
+
+
+class HeadSession:
+    """HEAD로 content-length만 답하는 가짜 세션 (_get_total_size 최소 인터페이스)."""
+
+    def __init__(self, size: int):
+        self.headers = {"content-length": str(size)}
+
+    def head(self, url, **kwargs):
+        return self
+
+    def raise_for_status(self):
+        pass
+
+
+def _make_file_data() -> DownloadData:
+    return DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path="unused.mp4",
+        resolution=144,  # 파트 1MB
+        content_type="video",
+    )
+
+
+def test_file_prepare_returns_plan_with_ranges_and_total_size(monkeypatch):
+    """file 계획: items는 바이트 범위 튜플, 총 크기를 미리 알아 total_size를 채운다."""
+    total = 3 * MB + 512
+    data = _make_file_data()
+    engine = FileDownloader(data, RecordingLogger())
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: HeadSession(total))
+
+    plan = engine.prepare(data.content)
+
+    assert isinstance(plan, DownloadPlan)
+    assert plan.items == tuple(split_ranges(total, MB))
+    assert plan.total_size == total
+    assert plan.part_count == 4
+    assert plan.requires_postprocess is False  # file은 후처리(병합) 없음
+    assert plan.selections == ()  # 전체 다운로드가 기본 케이스
+
+
+# ================================================================ m3u8 prepare
+
+
+class PlaylistSession:
+    """플레이리스트 텍스트만 답하는 가짜 세션 (prepare 최소 인터페이스)."""
+
+    def __init__(self, text: str):
+        self._text = text
+
+    def get(self, url, **kwargs):
+        class _Response:
+            text = self._text
+
+            def raise_for_status(self):
+                pass
+
+        return _Response()
+
+
+def _make_m3u8_data() -> DownloadData:
+    return DownloadData(
+        base_url="https://example.invalid/hls/video.m3u8",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path="unused.mp4",
+        resolution=1080,
+        content_type="m3u8",
+    )
+
+
+def test_m3u8_prepare_returns_plan_with_segments(monkeypatch):
+    """m3u8 계획: items는 (index, 세그먼트), 총 크기 미상(None), 병합 후처리 필요."""
+    playlist = "\n".join(
+        ["#EXTM3U", '#EXT-X-MAP:URI="init.m4s"']
+        + [line for i in range(3) for line in ("#EXTINF:2.000,", f"seg_{i}.m4v")]
+        + ["#EXT-X-ENDLIST"]
+    )
+    data = _make_m3u8_data()
+    engine = M3U8Downloader(data, RecordingLogger())
+    monkeypatch.setattr(m3u8_module, "get_thread_session", lambda: PlaylistSession(playlist))
+
+    plan = engine.prepare(data.content)
+
+    assert isinstance(plan, DownloadPlan)
+    assert plan.items == ((0, "seg_0.m4v"), (1, "seg_1.m4v"), (2, "seg_2.m4v"))
+    assert plan.total_size is None  # 총 바이트 크기는 미리 알 수 없다
+    assert plan.part_count == 3
+    assert plan.requires_postprocess is True  # 병합 필요
+    assert plan.selections == ()
+
+
+# ================================================================ selections 거부
+
+
+def _selection_plan() -> DownloadPlan:
+    return DownloadPlan(items=((0, MB - 1),), total_size=MB, selections=(TimeRange(0.0, 10.0),))
+
+
+def test_file_run_rejects_selections_with_explicit_error(tmp_path, monkeypatch):
+    """selections가 비어 있지 않으면 run()은 미지원 예외를 낸다 (file: 전파)."""
+    data = _make_file_data()
+    data.output_path = str(tmp_path / "out.mp4")
+    engine = FileDownloader(data, RecordingLogger())
+    monkeypatch.setattr(engine, "prepare", lambda content: _selection_plan())
+
+    data.model.start()
+    with pytest.raises(NotImplementedError):
+        engine.run()
+
+    assert not (tmp_path / "out.mp4").exists()  # 수신 준비 전에 거부된다
+
+
+def test_m3u8_run_rejects_selections_via_failure_callback(tmp_path, monkeypatch):
+    """m3u8은 모든 예외를 실패로 환원하므로 미지원 예외가 실패 콜백으로 통지된다."""
+    failures: list[BaseException] = []
+    data = _make_m3u8_data()
+    data.output_path = str(tmp_path / "out.mp4")
+    engine = M3U8Downloader(data, RecordingLogger(), on_failed=failures.append)
+    monkeypatch.setattr(engine, "prepare", lambda content: _selection_plan())
+
+    data.model.start()
+    engine.run()
+
+    assert len(failures) == 1
+    assert isinstance(failures[0], NotImplementedError)
+    assert not (tmp_path / "out.mp4").exists()


### PR DESCRIPTION
## 관련 이슈

Closes #83

## 변경 내용

`prepare()`의 반환을 다운로더별 목록에서 **계획 객체 하나(`DownloadPlan`)로 통일**했다. 이후 구간 선택·부분 재개·AES 키 같은 계획 정보는 이 객체에 필드를 더하는 방식으로 얹는다 — `prepare()` 시그니처와 호출부는 흔들리지 않는다.

- **`core/models/plan.py` 신설** — `TimeRange`(초 단위 구간) + `DownloadPlan`(frozen 데이터클래스, 표준 라이브러리 타입만).
  - `items`: 전송 단위 튜플 (file: `(start, end)` 바이트 범위 / m3u8: `(index, 세그먼트)`)
  - `total_size`: 계획 시점에 알면 채움 (m3u8은 `None`)
  - `requires_postprocess`: 병합 등 후처리 필요 여부 (file `False` / m3u8 `True`)
  - `selections`: **처음부터 튜플(리스트 형태)** — 빈 값 = 전체 다운로드. 다중 구간이 자연히 따라오도록 단일 `(start, end)`가 아닌 시퀀스로 모델링했다
  - `part_count`: 워커 상한·진행 배열 크기의 기준
- **두 다운로더의 `prepare()`가 `DownloadPlan`을 반환**하고, 베이스 `run()`은 계획만으로 실행한다:
  - `total_size`는 계획에서 읽어 베이스가 상태 모델에 반영 (file `prepare()`의 `self.s.total_size` 직접 대입 제거)
  - `postprocess()`는 `plan.requires_postprocess`가 참일 때만 호출 — 실행 중 추측 제거
  - `selections`가 비어 있지 않으면 **명시적 미지원 예외**(`NotImplementedError`) — 구간 해석은 이번 이슈 범위 밖(모양만 정의)

### items 표현 판단 근거 (이슈 항목 3)

공통 아이템 타입으로 묶지 않고 **다운로더별 튜플을 유지**했다:

1. 박제 테스트(`test_file_downloader_rules` / `test_m3u8_downloader_rules`)가 재큐잉 표현을 `(start, end)` / `(index, segment)` 튜플로 단언하고 있어, 아이템 타입화는 박제 무수정 통과 조건과 충돌한다.
2. 베이스 엔진은 items를 순회해 `_download_item(item, part_num)`으로 되돌려줄 뿐 내용을 해석하지 않는다 — 공통 타입이 지금 시점에 사주는 것이 없다.
3. 구간 해석이 실제 구현될 때 아이템에 필요한 정보(시간 매핑 등)가 확정되므로, 타입화는 그 시점에 계획 필드 추가로 얹는 편이 재작업이 적다.

근거는 `core/models/plan.py` 모듈 docstring에도 기록했다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — **203 passed** (기존 197 + 신규 6), 박제 4파일 시나리오·단언 무수정
- [x] 새 로직에 대한 테스트 추가됨 — `tests/unit/core/test_download_plan.py` 6건: 모델 불변·기본값(빈 selections = 전체), 두 다운로더 `prepare()`의 계획 필드, selections 비어 있지 않을 때의 거부(file: 예외 전파 / m3u8: 실패 콜백)
- [x] selections가 빈 값일 때 현행과 동일 동작 — 기존 실행 테스트(`test_*_downloader_run`)와 박제 테스트가 무수정 통과하는 것으로 확인
- [x] 헤드리스 완주 (통합 전 #84 검증과 동일 대상·동일 크기):
  - file(클립 SdIwKua8bb): **26,281,935 bytes** — 동일
  - m3u8(VOD 14348487, 144p): **348,770,581 bytes** — 동일
- [x] 오너 GUI 스모크 (일반 VOD·m3u8·클립, 궤적 모양 비교) — 머지 전 확인 부탁드립니다

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지, `test_no_qt_import` 통과)
- [x] view에서 core 직접 호출 없음 (앱 계층·UI 무변경)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — `core/models/` 안 신규 모듈 추가는 이슈 #83에서 지정된 범위

## 리뷰어에게

- **미지원 selections의 실패 형태가 다운로더별로 다르다**: file은 `_failure_exceptions`가 `RequestException`뿐이라 `NotImplementedError`가 그대로 전파되고, m3u8은 모든 예외를 실패로 환원하므로 실패 콜백으로 통지된다. 둘 다 "명시적 미지원 예외" 요건을 만족하며, 구 동작 보존을 위해 `_failure_exceptions`는 건드리지 않았다. 구간 선택이 실제 구현될 때 통일하면 된다.
- `postprocess()` 호출이 무조건 호출(기본 no-op)에서 `plan.requires_postprocess` 게이트로 바뀌었다 — 현행 두 다운로더 기준 동작 차이는 없다 (file은 원래 no-op, m3u8은 `True`로 호출됨).
- `ruff format --check`는 이번 변경 파일 전부 통과하나, 기존 파일 23개가 미포맷 상태다(이번 PR 범위 밖이라 건드리지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
