### PR TITLE
feat: AES(SEA) 암호화 VOD 다운로드 지원 (#57)

### DIFF
--- a/content/data.py
+++ b/content/data.py
@@ -1,5 +1,10 @@
 from download.state import DownloadState
 
+# 세그먼트 단위로 받는 타입 — 전체 크기를 미리 알 수 없어 진행률·표시가
+# 세그먼트 수 기반이다 (m3u8: 라이브 다시보기, hls_aes: AES 암호화 VOD #57)
+SEGMENT_BASED_TYPES = ("m3u8", "hls_aes")
+
+
 class ContentItem:
     # 메타데이터 카드 리스트 아이템 데이터(DTO)
 
@@ -35,6 +40,11 @@ class ContentItem:
         self.download_time = ""
 
         self.downloadState = DownloadState.WAITING  # 초기 상태
+
+    @property
+    def is_segment_based(self) -> bool:
+        """세그먼트 단위 다운로드 타입인지 (전체 크기 미상 → 표시 방식이 다르다)."""
+        return self.content_type in SEGMENT_BASED_TYPES
 
     def setDownloadState(self, state: DownloadState):
         if self.downloadState != state:

--- a/content/network.py
+++ b/content/network.py
@@ -2,7 +2,7 @@ import re
 import json
 from urllib.parse import urljoin
 
-from core.api.dash import parse_dash_manifest
+from core.api.dash import is_supported_sea, parse_dash_manifest, parse_sea_manifest
 from core.api.url_parser import extract_content_no
 from core.models.content import VideoInfo
 
@@ -87,7 +87,40 @@ class NetworkManager:
         response.raise_for_status()
 
         return parse_dash_manifest(response.text)
-    
+
+    @staticmethod
+    def get_video_sea_manifest(video_id: str, in_key: str, cookies: dict | None = None):
+        """AES(SEA) 암호화 VOD의 매니페스트를 요청해 비디오 Representation을 파싱한다 (#57).
+
+        암호화 비디오 Representation은 BaseURL 없이 nvod:m3u(HLS 미디어
+        플레이리스트)만 가지므로 전용 파서를 쓴다. 지원 대상(AES-128-CBC +
+        HTTP 키 시스템)이 아니면 빈 결과를 돌려줘 호출부가 기존 "지원하지
+        않음" 안내로 떨어지게 한다 — 라이선스 서버형 DRM은 여기서 걸러진다.
+        """
+        manifest_url = f"{NAVER_API}/neonplayer/vodplay/v2/playback/{video_id}?key={in_key}"
+        headers = {"Accept": "application/dash+xml"}
+        response = _session.get(manifest_url, cookies=cookies, headers=headers)
+        response.raise_for_status()
+
+        if not is_supported_sea(response.text):
+            return [], None, None
+        return parse_sea_manifest(response.text)
+
+    @staticmethod
+    def get_aes_key(key_uri: str, cookies: dict) -> bytes:
+        """세그먼트 복호화 키를 취득한다 (#57).
+
+        유저 본인의 쿠키로 인증된 요청이며, 쿠키가 없거나 권한이 없으면
+        서버가 403으로 거절해 아무것도 받아지지 않는다(실측). 앱은 권한을
+        만들어내지 않는다.
+
+        **키 값은 로그·예외 메시지에 싣지 않는다.**
+        """
+        headers = {"User-Agent": "Mozilla/5.0"}
+        response = _session.get(key_uri, cookies=cookies, headers=headers, timeout=30)
+        response.raise_for_status()
+        return response.content
+
     @staticmethod
     def get_video_m3u8_manifest(json_str: str):
         """

--- a/content/widget.py
+++ b/content/widget.py
@@ -79,7 +79,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
         def update_button_text():
             try:
-                if self.item.content_type != "m3u8":
+                if not self.item.is_segment_based:
                     resp = get_thread_session().head(base_url)
                     resp.raise_for_status()
                     size = int(resp.headers.get('content-length', 0))
@@ -109,8 +109,8 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
                 button.setDisabled(True)
             self.item.resolution = resolution
             self.item.base_url = base_url
-            # m3u8인 경우, base_url과 total_size가 None이므로 처리하지 않음
-            if self.item.content_type != "m3u8" and index is not None:
+            # 세그먼트 기반(m3u8·hls_aes)은 total_size를 미리 알 수 없어 처리하지 않음
+            if not self.item.is_segment_based and index is not None:
                 self.item.total_size = self.item.unique_reps[index][-1]
                 self.fileSizeLabel.setText(f" {self.item.unique_reps[index][-1]}")
 
@@ -167,7 +167,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
         if self.item.downloadState == DownloadState.WAITING:
             self.statusLabel.setText(self.tr("Download waiting"))
-            if self.item.content_type == "m3u8":
+            if self.item.is_segment_based:
                 self.fileSizeLabel.setText(f" {strftime('%H:%M:%S', gmtime(item.duration))}")
             else:
                 self.fileSizeLabel.setText(f" {item.total_size}")
@@ -175,7 +175,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
         elif self.item.downloadState == DownloadState.RUNNING:
             self.statusLabel.setText(f"{item.download_remain_time}  {item.download_speed}")
-            if self.item.content_type == "m3u8":
+            if self.item.is_segment_based:
                 if self.item.post_process:
                     self.statusLabel.setText("Post-processing")
                 self.fileSizeLabel.setText(f"  {self.setSize(item.download_size)}")
@@ -185,7 +185,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
         elif self.item.downloadState == DownloadState.PAUSED:
             self.statusLabel.setText(self.tr("Download paused"))
-            if self.item.content_type == "m3u8":
+            if self.item.is_segment_based:
                 self.fileSizeLabel.setText(f"  {self.setSize(item.download_size)}")
             else:
                 self.fileSizeLabel.setText(f"  {self.setSize(item.download_size)} / {item.total_size}")

--- a/content/worker.py
+++ b/content/worker.py
@@ -42,11 +42,16 @@ class ContentWorker(QObject):
             self.error.emit(self._user_message(e))
 
     def fetchVideo(self, video_no: str) -> tuple:
-        """VOD 조회를 core 서비스에 위임한다 (기존 시그니처·예외 형식 유지)."""
+        """VOD 조회를 core 서비스에 위임한다 (기존 시그니처·예외 형식 유지).
+
+        core의 fetch_video는 (result, 암호화 여부)를 돌려주지만(#57), 이 어댑터의
+        반환 계약은 result tuple 그대로다 — 암호화 타입 분기는 fetch_content가 한다.
+        """
         try:
-            return metadata_service.fetch_video(
+            result, _encrypted = metadata_service.fetch_video(
                 self.vod_url, video_no, self.cookies, self.downloadPath, api=NetworkManager
             )
+            return result
         except MetadataError as e:
             raise ValueError(self._user_message(e)) from e
 

--- a/core/api/dash.py
+++ b/core/api/dash.py
@@ -2,9 +2,26 @@
 
 content/network.py의 NetworkManager.get_video_dash_manifest에서 HTTP를 떼어 내고
 파싱만 이동한 순수 함수 (#51). 동작은 기존과 완전 동일하다.
+
+AES(SEA) 암호화 매니페스트는 parse_sea_manifest가 따로 다룬다 (#57) —
+평문 경로의 parse_dash_manifest는 기존 방어 동작(BaseURL 없는 항목 스킵)을
+그대로 유지한다.
 """
 
 import xml.etree.ElementTree as ET
+
+NS = {
+    "mpd": "urn:mpeg:dash:schema:mpd:2011",
+    "nvod": "urn:naver:vod:2020",
+    "sea": "urn:mpeg:dash:schema:sea:2012",
+}
+
+# MPEG-DASH SEA (ISO/IEC 23009-4) — 세그먼트 단위 암호화 스킴
+SEA_SCHEME_ID = "urn:mpeg:dash:sea:2012"
+# 지원하는 암호화 방식: AES-128-CBC (HLS METHOD=AES-128과 동형)
+SEA_AES_128_CBC = "urn:mpeg:dash:sea:aes128-cbc:2013"
+# 지원하는 키 시스템: 인증된 세션에 평문 HTTP로 키를 내주는 방식
+SEA_KEYSYS_HTTP = "urn:mpeg:dash:sea:keysys:http:2013"
 
 
 def parse_dash_manifest(xml_text: str) -> tuple[list[list], int, str]:
@@ -52,3 +69,62 @@ def parse_dash_manifest(xml_text: str) -> tuple[list[list], int, str]:
     auto_base_url = sorted_reps[-1][1]
 
     return sorted_reps, auto_resolution, auto_base_url
+
+
+def is_supported_sea(xml_text: str) -> bool:
+    """이 매니페스트가 **지원하는** SEA 암호화(AES-128-CBC + HTTP 키)인지 판정한다 (#57).
+
+    라이선스 서버형 DRM(cenc:pssh, Widevine·PlayReady UUID)은 여기서 False가
+    되어 기존의 "지원하지 않음" 안내로 떨어진다 — 그런 보호조치의 우회는
+    구현하지 않는다.
+    """
+    root = ET.fromstring(xml_text)
+    found = False
+    for cp in root.findall(".//mpd:ContentProtection", namespaces=NS):
+        if cp.get("schemeIdUri") != SEA_SCHEME_ID:
+            # SEA 외의 ContentProtection(=DRM 계열)이 하나라도 있으면 지원 대상이 아니다
+            return False
+        enc = cp.find("sea:SegmentEncryption", namespaces=NS)
+        keysys = cp.find("sea:KeySystem", namespaces=NS)
+        if enc is None or keysys is None:
+            return False
+        if enc.get("encryptionSystemUrn") != SEA_AES_128_CBC:
+            return False
+        if keysys.get("keySystemUrn") != SEA_KEYSYS_HTTP:
+            return False
+        found = True
+    return found
+
+
+def parse_sea_manifest(xml_text: str) -> tuple[list[list], int | None, str | None]:
+    """SEA 암호화 매니페스트에서 비디오 Representation 목록을 파싱한다 (#57).
+
+    암호화된 비디오 Representation은 BaseURL 없이 ``nvod:m3u``(HLS 미디어
+    플레이리스트 URL)만 갖는다 — 세그먼트 목록과 키 위치가 그 플레이리스트에
+    있기 때문이다. 따라서 평문 경로와 달리 nvod:m3u를 base_url로 삼는다.
+
+    반환 형식은 parse_dash_manifest와 동일해 호출부가 같은 모양으로 쓴다.
+
+    Returns:
+        tuple: ([해상도, media.m3u8 URL] 목록(오름차순), auto 해상도, auto URL).
+            암호화 비디오 Representation이 없으면 ([], None, None)
+    """
+    root = ET.fromstring(xml_text)
+    reps = []
+    for rep in root.findall(".//mpd:Representation", namespaces=NS):
+        if rep.find("mpd:ContentProtection", namespaces=NS) is None:
+            # 오디오 등 비암호화 트랙은 이 경로의 대상이 아니다
+            continue
+        width, height = rep.get("width"), rep.get("height")
+        if width is None or height is None:
+            continue
+        m3u = rep.get(f"{{{NS['nvod']}}}m3u")
+        if not m3u:
+            continue
+        reps.append([min(int(width), int(height)), m3u])
+
+    if not reps:
+        return [], None, None
+
+    sorted_reps = sorted(reps, key=lambda x: x[0])
+    return sorted_reps, sorted_reps[-1][0], sorted_reps[-1][1]

--- a/core/api/hls.py
+++ b/core/api/hls.py
@@ -1,0 +1,108 @@
+"""HLS 미디어 플레이리스트 파싱 — 세그먼트 목록과 암호화 키 정보 (#57, SPEC §8.1).
+
+AES(SEA) VOD의 비디오 Representation은 DASH 매니페스트에 BaseURL 없이
+``nvod:m3u``(HLS 미디어 플레이리스트)만 갖는다. 실제 세그먼트 목록과 복호화
+키의 위치는 그 플레이리스트의 태그에 있으므로 여기서 파싱한다.
+
+HTTP는 하지 않는다 — 텍스트를 받아 파싱만 하는 순수 함수다(테스트 용이성,
+core 순수성). 요청·쿠키 처리는 호출부(다운로더·리졸버)의 몫이다.
+
+IV 규칙 (RFC 8216 §5.2): ``#EXT-X-KEY``에 ``IV`` 속성이 있으면 그 값을 쓰고,
+없으면 **각 세그먼트의 미디어 시퀀스 번호**를 128비트 빅엔디언으로 쓴다.
+치지직 실측(videoId 54D17299…)은 IV 속성이 없어 후자에 해당한다.
+"""
+
+import re
+from dataclasses import dataclass
+
+# #EXT-X-KEY:METHOD=AES-128,URI="...",IV=0x... 의 속성 추출용
+_ATTR_RE = re.compile(r'([A-Z0-9-]+)=("[^"]*"|[^,]*)')
+
+
+def _parse_attributes(tag_value: str) -> dict[str, str]:
+    """태그 속성 목록(``KEY=VALUE,KEY="VALUE"``)을 dict로 만든다."""
+    return {m.group(1): m.group(2).strip('"') for m in _ATTR_RE.finditer(tag_value)}
+
+
+@dataclass(frozen=True)
+class HlsKey:
+    """``#EXT-X-KEY``가 기술하는 세그먼트 암호화 정보.
+
+    iv가 None이면 세그먼트의 미디어 시퀀스 번호를 IV로 쓴다(RFC 8216 §5.2).
+    """
+
+    method: str
+    uri: str
+    iv: bytes | None = None
+
+    @property
+    def is_aes_128(self) -> bool:
+        """AES-128 (HLS 표준 세그먼트 암호화)인지."""
+        return self.method == "AES-128"
+
+
+@dataclass(frozen=True)
+class HlsPlaylist:
+    """HLS 미디어 플레이리스트의 파싱 결과."""
+
+    # 세그먼트 상대/절대 경로 목록 (플레이리스트 등장 순서 = 재생 순서)
+    segments: tuple[str, ...]
+    # 첫 세그먼트의 미디어 시퀀스 번호 (#EXT-X-MEDIA-SEQUENCE, 없으면 0)
+    media_sequence: int = 0
+    # 암호화 정보. 평문 플레이리스트면 None
+    key: HlsKey | None = None
+    # 초기화 세그먼트(#EXT-X-MAP URI). TS 플레이리스트에는 없다
+    init_uri: str | None = None
+
+    def sequence_of(self, index: int) -> int:
+        """index번째 세그먼트의 미디어 시퀀스 번호 (IV 유도에 쓰인다)."""
+        return self.media_sequence + index
+
+
+def parse_media_playlist(text: str) -> HlsPlaylist:
+    """HLS 미디어 플레이리스트 텍스트에서 세그먼트·키·시퀀스 정보를 뽑는다.
+
+    ``#EXT-X-KEY``가 여러 번 나오면 마지막 것을 쓴다 — 치지직 SEA는 비디오당
+    키 1개(로테이션 없음)라 실질적으로 하나뿐이다. METHOD=NONE은 암호화
+    해제 지시이므로 키 없음으로 처리한다.
+
+    Args:
+        text: 플레이리스트 본문
+
+    Returns:
+        HlsPlaylist: 세그먼트 목록과 암호화 정보
+    """
+    segments: list[str] = []
+    media_sequence = 0
+    key: HlsKey | None = None
+    init_uri: str | None = None
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if not line.startswith("#"):
+            segments.append(line)
+        elif line.startswith("#EXT-X-MEDIA-SEQUENCE:"):
+            media_sequence = int(line.split(":", 1)[1].strip())
+        elif line.startswith("#EXT-X-KEY:"):
+            attrs = _parse_attributes(line.split(":", 1)[1])
+            method = attrs.get("METHOD", "NONE")
+            if method == "NONE":
+                key = None
+            else:
+                iv_text = attrs.get("IV")
+                key = HlsKey(
+                    method=method,
+                    uri=attrs.get("URI", ""),
+                    iv=bytes.fromhex(iv_text[2:]) if iv_text else None,
+                )
+        elif line.startswith("#EXT-X-MAP:"):
+            init_uri = _parse_attributes(line.split(":", 1)[1]).get("URI")
+
+    return HlsPlaylist(
+        segments=tuple(segments),
+        media_sequence=media_sequence,
+        key=key,
+        init_uri=init_uri,
+    )

--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -74,6 +74,9 @@ class BaseDownloader(ABC):
     worker_pool_prefix: str = "DownloadWorker"
     # 다운로드 시작 전 base_url 해석(resolver 주입·실행)이 필요한지 — 서비스가 참조
     requires_base_url_resolution: bool = False
+    # 복호화 키 리졸버 주입이 필요한지 — 서비스가 참조해 set_key_resolver를 호출한다 (#57).
+    # 키 취득은 유저 쿠키가 필요해 core가 직접 할 수 없다(core→app 의존 금지)
+    requires_key_resolution: bool = False
     # run()이 실패 콜백으로 환원할 예외 타입 — 그 외 예외는 전파한다
     _failure_exceptions: tuple[type[BaseException], ...] = (Exception,)
 
@@ -107,6 +110,8 @@ class BaseDownloader(ABC):
         self._on_finished: FinishedCallback = on_finished or (lambda: None)
         self._on_failed: FailedCallback = on_failed or (lambda exc: None)
         self._on_merge_start: Callable[[], None] = on_merge_start or (lambda: None)
+        # requires_key_resolution인 다운로더에 서비스가 주입한다 (#57)
+        self._key_resolver = None
 
     @property
     def state(self) -> DownloadState:
@@ -116,6 +121,14 @@ class BaseDownloader(ABC):
     def set_on_progress(self, callback: ProgressCallback) -> None:
         """진행 이벤트 콜백을 등록한다 (어댑터가 생성 후 연결하는 경우용)."""
         self._on_progress = callback
+
+    def set_key_resolver(self, resolver) -> None:
+        """복호화 키 리졸버를 등록한다 (requires_key_resolution인 다운로더용, #57).
+
+        리졸버는 ``(content, key_uri) -> bytes``다. 쿠키 로드·인증 요청은 앱
+        계층이 수행하며 core는 호출만 한다.
+        """
+        self._key_resolver = resolver
 
     # ============ 하위 다운로더의 책임 (추상) ============
 

--- a/core/downloaders/decrypt.py
+++ b/core/downloaders/decrypt.py
@@ -1,0 +1,81 @@
+"""세그먼트 복호화 — HLS/SEA AES-128-CBC (#57, SPEC §8.1).
+
+치지직의 암호화 VOD는 MPEG-DASH SEA(``aes128-cbc:2013``) = HLS
+``METHOD=AES-128``과 동형인 **표준 세그먼트 암호화**다. 세그먼트 전체가
+AES-128-CBC로 암호화되어 있고, 키는 플레이리스트의 ``#EXT-X-KEY URI``가
+가리키는 치지직 API가 **인증된 세션에** 평문 HTTP로 내준다
+(``keysys:http:2013``). CDM·라이선스 챌린지·PSSH는 없다.
+
+이 모듈은 바이트 변환만 한다 — 키를 어떻게 얻는지는 모른다. 키 취득은
+쿠키(=유저 본인 인증)가 필요해 앱 계층 리졸버가 주입한다
+(core/services/download_service.py의 key_resolver).
+
+**키 값은 로그·예외 메시지에 절대 싣지 않는다.**
+"""
+
+from Crypto.Cipher import AES
+
+AES_BLOCK_SIZE = 16
+# MPEG-TS 패킷은 188바이트이며 항상 0x47 동기 바이트로 시작한다 (ISO/IEC 13818-1)
+TS_SYNC_BYTE = 0x47
+TS_PACKET_SIZE = 188
+
+
+def sequence_iv(sequence_number: int) -> bytes:
+    """미디어 시퀀스 번호를 IV로 변환한다 (RFC 8216 §5.2).
+
+    ``#EXT-X-KEY``에 IV 속성이 없을 때 쓰는 규칙 — 시퀀스 번호를 128비트
+    빅엔디언으로 표현한 값이 그 세그먼트의 IV다.
+    """
+    return sequence_number.to_bytes(AES_BLOCK_SIZE, "big")
+
+
+def _strip_pkcs7(data: bytes) -> bytes:
+    """PKCS#7 패딩을 제거한다. 패딩이 유효하지 않으면 원본을 그대로 돌려준다.
+
+    유효하지 않은 패딩은 대개 키가 틀렸다는 뜻이지만, 여기서 예외를 던지면
+    패딩을 쓰지 않는 스트림까지 막게 되므로 판정은 호출부(looks_like_ts)에
+    맡기고 이 함수는 손상 없이 통과시킨다.
+    """
+    if not data:
+        return data
+    pad = data[-1]
+    if 1 <= pad <= AES_BLOCK_SIZE and len(data) >= pad and data[-pad:] == bytes([pad]) * pad:
+        return data[:-pad]
+    return data
+
+
+def decrypt_segment(data: bytes, key: bytes, iv: bytes) -> bytes:
+    """AES-128-CBC 세그먼트 하나를 복호화하고 PKCS#7 패딩을 제거한다.
+
+    Args:
+        data: 암호화된 세그먼트 바이트 (블록 크기의 배수여야 한다)
+        key: 16바이트 AES-128 키
+        iv: 16바이트 초기화 벡터
+
+    Returns:
+        bytes: 복호화된 세그먼트
+
+    Raises:
+        ValueError: 키·IV 길이가 16바이트가 아니거나 데이터가 블록 배수가 아닌 경우
+    """
+    if len(key) != AES_BLOCK_SIZE:
+        raise ValueError(f"AES-128 키는 {AES_BLOCK_SIZE}바이트여야 한다 (받은 길이: {len(key)})")
+    if len(iv) != AES_BLOCK_SIZE:
+        raise ValueError(f"IV는 {AES_BLOCK_SIZE}바이트여야 한다 (받은 길이: {len(iv)})")
+    if len(data) % AES_BLOCK_SIZE:
+        raise ValueError(f"암호문 길이가 블록 배수가 아니다 (길이: {len(data)})")
+
+    return _strip_pkcs7(AES.new(key, AES.MODE_CBC, iv).decrypt(data))
+
+
+def looks_like_ts(data: bytes) -> bool:
+    """복호화 결과가 MPEG-TS로 보이는지 검사한다 (키·IV 판정용).
+
+    첫 바이트와 두 번째 패킷 경계의 동기 바이트를 확인한다. 키가 틀리면
+    출력이 난수라 이 검사를 통과할 확률이 사실상 없으므로, 첫 세그먼트에서
+    한 번 확인해 **수 GB짜리 쓰레기 파일을 만들기 전에** 실패시킬 수 있다.
+    """
+    if len(data) < TS_PACKET_SIZE + 1:
+        return False
+    return data[0] == TS_SYNC_BYTE and data[TS_PACKET_SIZE] == TS_SYNC_BYTE

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -1,0 +1,306 @@
+"""AES(SEA) 암호화 VOD 다운로드 엔진 — BaseDownloader 하위 구현 (#57, SPEC §6·§8.1).
+
+치지직의 암호화 VOD는 HLS(MPEG-TS) 세그먼트에 AES-128-CBC가 걸려 있고, 키는
+플레이리스트의 ``#EXT-X-KEY URI``가 가리키는 치지직 API가 **인증된 세션에**
+평문 HTTP로 내준다. 즉 이 경로는 유저 본인의 쿠키로 유저 본인이 볼 권한이
+있는 컨텐츠를 받는 것이며, 쿠키가 없으면 키 요청이 403으로 실패해 아무것도
+받아지지 않는다(실측). 권한을 만들어내지 않는다.
+
+m3u8(라이브 다시보기) 경로와의 차이:
+- 컨테이너가 MPEG-TS(.ts)다 — fMP4가 아니므로 ``EXT-X-MAP`` 초기화 세그먼트가
+  없고, 병합 대상은 세그먼트 파일 그 자체뿐이다
+- 세그먼트마다 복호화 단계가 있다. IV는 ``#EXT-X-KEY``에 명시되면 그 값을,
+  없으면 미디어 시퀀스 번호를 쓴다(RFC 8216 §5.2 — 치지직 실측은 후자)
+
+키 취득은 쿠키가 필요해 core가 직접 할 수 없다(core→app 의존 금지).
+``requires_key_resolution=True``로 선언하고 서비스가 주입한 리졸버를 쓴다 —
+base_url 해석(#75)과 같은 주입 방식이다.
+
+**키 값은 로그·예외 메시지·커밋에 절대 싣지 않는다.**
+"""
+
+import os
+import shutil
+import time as tm
+from urllib.parse import urljoin
+
+import requests
+
+from core.api.hls import parse_media_playlist
+from core.api.session import get_thread_session
+from core.downloaders.base import BaseDownloader
+from core.downloaders.decrypt import decrypt_segment, looks_like_ts, sequence_iv
+from core.models.content import Content, ContentType
+from core.models.download_state import DownloadState
+from core.models.plan import DownloadPlan
+
+
+class DecryptionError(Exception):
+    """복호화 결과가 유효한 미디어가 아닐 때 — 키·IV 규칙 불일치 신호."""
+
+
+class HlsAesDownloader(BaseDownloader):
+    """AES-128-CBC로 암호화된 HLS(TS) VOD를 세그먼트 단위로 받아 복호화·병합하는 엔진.
+
+    호출 규약: 소유자(서비스·스크립트)가 data.base_url에 HLS 미디어 플레이리스트
+    URL을 채우고 DownloadTaskModel.start()로 RUNNING 전이를 마친 뒤 run()을
+    호출한다. run()은 완료·중단·실패까지 블로킹한다.
+    """
+
+    run_thread_name = "DownloadHlsAesThread"
+    worker_pool_prefix = "DownloadHlsAesWorker"
+    # base_url(HLS 미디어 플레이리스트 URL)은 SEA 매니페스트 파싱 시점에 해상도별로
+    # 확정되어 Content에 실려 온다 — m3u8(라이브 다시보기)처럼 재해석하지 않는다
+    requires_base_url_resolution = False
+    requires_key_resolution = True
+    # m3u8 경로와 동일하게 모든 예외를 실패로 처리한다 (플레이리스트·키 취득 실패 포함)
+    _failure_exceptions = (Exception,)
+
+    def __init__(self, data, logger, **callbacks):
+        super().__init__(data, logger, **callbacks)
+        # 세그먼트 저장용 임시 폴더 (실패 정리 경로가 참조하므로 실행 전에 확정)
+        self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
+        self._key: bytes | None = None
+        self._playlist = None
+
+    @classmethod
+    def supports(cls, content: Content) -> bool:
+        """AES(SEA) 암호화 VOD를 처리한다."""
+        return content.content_type is ContentType.CHZZK_VIDEO_HLS_AES
+
+    # ============ 작업 목록·수신 준비 ============
+
+    def prepare(self, content: Content) -> DownloadPlan:
+        """플레이리스트를 받아 세그먼트 목록을 만들고 복호화 키를 취득한다."""
+        response = get_thread_session().get(self.s.base_url)
+        response.raise_for_status()
+        playlist = parse_media_playlist(response.text)
+
+        if playlist.key is None:
+            raise DecryptionError("암호화 정보(#EXT-X-KEY)가 없는 플레이리스트다")
+        if not playlist.key.is_aes_128:
+            # AES-128 외의 방식은 지원하지 않는다 — 우회를 시도하지 않고 실패시킨다
+            raise DecryptionError(f"지원하지 않는 암호화 방식: {playlist.key.method}")
+
+        key_uri = urljoin(self.s.base_url, playlist.key.uri)
+        self._key = self._resolve_key(content, key_uri)
+        self._playlist = playlist
+        self.s.merged_segments = 0
+        # 세그먼트 임시 파일명 0채움 자릿수 — sorted() 병합 순서의 전제
+        self.width = len(str(len(playlist.segments)))
+
+        # 워커 풀을 띄우기 전에 키·IV 규칙을 첫 세그먼트로 검증한다.
+        # 여기서 실패하면 run()의 실패 경로로 깔끔히 빠져 수 GB짜리 쓰레기
+        # 파일을 만들지 않는다 (풀 안에서 터지면 정리 경로가 복잡해진다)
+        if playlist.segments:
+            self._verify_key(playlist)
+
+        # 전체 바이트 크기는 미리 알 수 없고(total_size=None), 병합 후처리가 필요하다
+        return DownloadPlan(
+            items=tuple(enumerate(playlist.segments)),
+            total_size=None,
+            requires_postprocess=True,
+        )
+
+    def _download_start_log_args(self) -> tuple:
+        # 전체 크기·파트 크기를 미리 알 수 없다 (m3u8 경로와 동일하게 0)
+        return (0, 0, self.s.total_ranges, self.s.adjust_threads)
+
+    def _prepare_output(self) -> None:
+        """임시 폴더를 재생성한다 (TS 경로에는 초기화 세그먼트가 없다)."""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+        os.makedirs(self.temp_dir)
+
+    def _log_item_start(self, part_num: int, item) -> None:
+        _index, segment = item
+        self.logger.log_m3u8_thread_start(part_num, segment)
+
+    def _download_item(self, item, part_num: int):
+        index, segment = item
+        return self._download_segment(
+            index=index, segment=segment, part_num=part_num, total_ranges=self.s.total_ranges
+        )
+
+    def _cleanup_partial(self) -> None:
+        """실패·중단 시 임시 폴더와 다운로드 파일 삭제."""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+        if os.path.exists(self.s.output_path):
+            os.remove(self.s.output_path)
+
+    def _cleanup_after_run(self) -> None:
+        """임시 폴더 삭제 (병합 후에는 빈 폴더만 남는다)."""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _progress_total_size(self) -> int | None:
+        # 전체 바이트 크기를 미리 알 수 없다 — 세그먼트 수 기반 계산은 어댑터가 한다
+        return None
+
+    def _get_standard_speed(self) -> float:
+        """해상도별 기준 속도 — m3u8 경로와 동일 테이블(같은 세그먼트 전송 특성)."""
+        if self.s.resolution == 144:
+            return 0.2
+        elif self.s.resolution in [360, 480]:
+            return 0.5
+        elif self.s.resolution == 720:
+            return 1.2
+        else:
+            return 3
+
+    # ============ 키 취득 ============
+
+    def _resolve_key(self, content: Content, key_uri: str) -> bytes:
+        """주입된 리졸버로 복호화 키를 취득한다 (쿠키가 필요해 앱 계층이 수행).
+
+        Raises:
+            DecryptionError: 리졸버 미주입이거나 키 길이가 AES-128이 아닌 경우
+        """
+        if self._key_resolver is None:
+            raise DecryptionError("암호화 VOD 다운로드에는 key_resolver 주입이 필요하다")
+        key = self._key_resolver(content, key_uri)
+        if len(key) != 16:
+            # 값은 싣지 않고 길이만 보고한다
+            raise DecryptionError(f"AES-128 키 길이가 올바르지 않다 (길이: {len(key)})")
+        return key
+
+    def _verify_key(self, playlist) -> None:
+        """첫 세그먼트를 받아 복호화 결과가 MPEG-TS인지 확인한다 (prepare 단계).
+
+        키가 틀리면 출력이 난수라 이 검사를 통과할 수 없다. 실행 전에 확인해
+        잘못된 결과 파일을 만들지 않는 것이 목적이다.
+
+        Raises:
+            DecryptionError: 복호화 결과가 유효한 미디어가 아닌 경우
+        """
+        url = urljoin(self.s.base_url, playlist.segments[0])
+        response = get_thread_session().get(url, timeout=30)
+        response.raise_for_status()
+        plain = decrypt_segment(response.content, self._key, self._segment_iv(0))
+        if not looks_like_ts(plain):
+            raise DecryptionError(
+                "복호화 결과가 MPEG-TS가 아니다 — 키 또는 IV 규칙이 맞지 않는다"
+            )
+
+    def _segment_iv(self, index: int) -> bytes:
+        """세그먼트의 IV — 명시 IV가 있으면 그 값, 없으면 미디어 시퀀스 번호."""
+        explicit = self._playlist.key.iv
+        return explicit if explicit is not None else sequence_iv(self._playlist.sequence_of(index))
+
+    # ============ 후처리: 순서 보장 병합 ============
+
+    def postprocess(self) -> None:
+        """복호화된 세그먼트 파일들을 인덱스 순서대로 결과 파일에 병합한다."""
+        self._on_merge_start()
+        with open(self.s.output_path, "wb") as final_f:
+            for seg_file in sorted(os.listdir(self.temp_dir)):
+                # 다운로드 중지 상태라면 중단
+                if self.state == DownloadState.RUNNING:
+                    seg_path = os.path.join(self.temp_dir, seg_file)
+                    with open(seg_path, "rb") as seg_f:
+                        while True:
+                            chunk = seg_f.read(8192)
+                            if not chunk:
+                                break
+                            final_f.write(chunk)
+                            # 일시정지 상태라면 대기
+                            if self.state == DownloadState.PAUSED:
+                                self.s._pause_event.wait()
+                    self.safe_remove(seg_path)
+                    self.s.merged_segments += 1
+
+    # ============ 다운로드 동작 ============
+
+    def _download_segment(self, index: int, segment: str, part_num: int, total_ranges: int):
+        """개별 세그먼트를 받아 복호화해 임시 파일로 저장한다 (재시도 포함).
+
+        저속 재시도·일시정지·중단 판정 규칙은 m3u8 경로와 동일하다. 차이는
+        세그먼트 전체를 메모리에 모은 뒤 CBC 복호화해서 쓴다는 점이다 —
+        CBC는 앞 블록에 의존하므로 스트리밍 중 부분 기록을 할 수 없다.
+        """
+        slow_count = 0
+        downloaded_size = 0
+        segment_url = urljoin(self.s.base_url, segment)
+        while not self.state == DownloadState.WAITING:
+            try:
+                # 스레드로컬 세션으로 같은 워커의 세그먼트 요청 간 연결을 재사용한다 (#31)
+                response = get_thread_session().get(segment_url, stream=True, timeout=30)
+                response.raise_for_status()
+                part_start_time = tm.time()
+
+                buffer = bytearray()
+                for chunk in response.iter_content(chunk_size=8192):
+                    if self.state == DownloadState.WAITING:
+                        return part_num
+                    if self.state == DownloadState.PAUSED:
+                        self.s._pause_event.wait()
+
+                    if chunk:
+                        buffer.extend(chunk)
+                        downloaded_size += len(chunk)
+                        elapsed = tm.time() - part_start_time
+
+                        if elapsed > 0:
+                            speed_kb_s = downloaded_size / elapsed / 1024
+                            self._check_speed_and_update_progress(
+                                part_num, downloaded_size, total_ranges, speed_kb_s
+                            )
+                            if speed_kb_s < 100:
+                                slow_count += 1
+                                if slow_count > 5:
+                                    # 속도가 너무 느리면 스레드 재시작
+                                    with self.lock:
+                                        self._requeue_slow((index, segment), part_num)
+                                    return part_num
+                            else:
+                                slow_count = 0
+
+                try:
+                    plain = decrypt_segment(bytes(buffer), self._key, self._segment_iv(index))
+                except (ValueError, DecryptionError) as e:
+                    # 복호화 실패는 재시도해도 낫지 않는다(키·정렬 문제). 재큐잉하면
+                    # 무한 루프가 되고, 그대로 전파하면 future_dict가 정리되지 않아
+                    # 실행 루프가 끝나지 않는다 — 다운로드 전체를 중단시킨다
+                    self._fail_fatally(e)
+                    return part_num
+
+                temp_file = os.path.join(self.temp_dir, f"{index:0{self.width}d}.ts")
+                with open(temp_file, "wb") as f:
+                    f.write(plain)
+
+                # 성공적으로 마무리된 경우
+                with self.lock:
+                    self.s.completed_threads += 1
+                    self.s.completed_progress += downloaded_size
+                    self.s.threads_progress[part_num] = 0
+                self.logger.log_thread_complete(part_num, downloaded_size)
+                return part_num
+
+            except (requests.RequestException, requests.Timeout) as e:
+                with self.lock:
+                    self._requeue_failed((index, segment), part_num)
+                self.logger.log_error(f"Part {part_num} download failed", e)
+                return part_num
+
+    def _fail_fatally(self, exc: BaseException) -> None:
+        """워커에서 회복 불가능한 오류가 났을 때 다운로드 전체를 중단시킨다.
+
+        상태를 중단으로 돌려 실행 루프·관측 루프가 빠져나오게 하고, 실패를
+        통지한다. 부분 산출물 정리는 run()의 중단 경로가 수행한다.
+        """
+        self.logger.log_error("Segment decryption failed", exc)
+        self._on_failed(exc)
+        self.model.stop()
+
+    # ============ 유틸 ============
+
+    def safe_remove(self, path: str, retries: int = 5, delay: float = 0.2) -> None:
+        """파일 삭제 시도 (PermissionError 방지용 재시도 포함)."""
+        for _ in range(int(retries)):
+            try:
+                os.remove(path)
+                return
+            except PermissionError:  # [WinError 32]
+                tm.sleep(delay)
+        raise PermissionError(f"Failed to remove {path} after {retries} attempts")

--- a/core/models/content.py
+++ b/core/models/content.py
@@ -16,6 +16,9 @@ class ContentType(Enum):
 
     CHZZK_VIDEO = "video"
     CHZZK_VIDEO_M3U8 = "m3u8"
+    # AES(SEA) 암호화 VOD — HLS(MPEG-TS) 세그먼트 + AES-128-CBC 복호화 (#57).
+    # m3u8(라이브 다시보기)과는 컨테이너·초기화 세그먼트 유무가 달라 별도 타입이다
+    CHZZK_VIDEO_HLS_AES = "hls_aes"
     CHZZK_CLIP = "clip"
     CHZZK_LIVE = "live"
 

--- a/core/services/download_service.py
+++ b/core/services/download_service.py
@@ -33,6 +33,7 @@ from collections import deque
 from collections.abc import Callable
 
 from core.downloaders.file_downloader import FileDownloader
+from core.downloaders.hls_aes_downloader import HlsAesDownloader
 from core.downloaders.m3u8_downloader import M3U8Downloader
 from core.models.content import Content
 from core.models.download_data import DownloadData
@@ -44,6 +45,9 @@ logger = logging.getLogger(__name__)
 
 # Content를 받아 m3u8 플레이리스트 URL을 반환한다. 실패는 예외로 던진다.
 BaseUrlResolver = Callable[[Content], str]
+# (Content, 키 URI)를 받아 세그먼트 복호화 키(bytes)를 반환한다 (#57).
+# 인증 쿠키가 필요해 앱 계층이 구현한다 — 권한이 없으면 서버가 거절해 예외가 된다.
+KeyResolver = Callable[[Content, str], bytes]
 
 
 class _NullDownloadLogger:
@@ -159,17 +163,20 @@ class DownloadService:
         *,
         max_concurrent: int = DEFAULT_MAX_CONCURRENT,
         base_url_resolver: BaseUrlResolver | None = None,
+        key_resolver: KeyResolver | None = None,
     ):
         """서비스를 생성한다.
 
         Args:
             max_concurrent: 동시 실행 수 상한 (1 이상)
             base_url_resolver: m3u8 플레이리스트 URL 해석 콜러블 (m3u8 다운로드 시 필수)
+            key_resolver: 세그먼트 복호화 키 취득 콜러블 (암호화 VOD 다운로드 시 필수, #57)
         """
         if max_concurrent < 1:
             raise ValueError("max_concurrent는 1 이상이어야 한다")
         self._max_concurrent = max_concurrent
         self._base_url_resolver = base_url_resolver
+        self._key_resolver = key_resolver
         self._lock = threading.Lock()
         self._pending: deque[DownloadHandle] = deque()
         self._active: set[DownloadHandle] = set()
@@ -238,7 +245,7 @@ class DownloadService:
             ValueError: 어떤 다운로더도 지원하지 않는 컨텐츠 (예: 라이브)
         """
         # 모듈 전역을 호출 시점에 참조한다 (테스트에서 대역으로 교체 가능)
-        for downloader_cls in (FileDownloader, M3U8Downloader):
+        for downloader_cls in (FileDownloader, M3U8Downloader, HlsAesDownloader):
             if downloader_cls.supports(content):
                 return downloader_cls
         raise ValueError(f"지원하지 않는 컨텐츠 타입: {content.content_type}")
@@ -292,6 +299,11 @@ class DownloadService:
 
             engine = self._create_engine(handle)
             handle.engine = engine
+
+            if handle.engine_cls.requires_key_resolution:
+                # 복호화 키 취득은 유저 쿠키가 필요해 앱 계층 리졸버가 수행한다 (#57).
+                # 실제 호출은 엔진의 prepare() 안에서 일어난다 — 여기서는 주입만 한다
+                engine.set_key_resolver(self._key_resolver)
 
             if handle.engine_cls.requires_base_url_resolution:
                 # m3u8 등은 시작 시점에 플레이리스트 URL을 해석한다 (구 어댑터와 동일).

--- a/core/services/metadata_service.py
+++ b/core/services/metadata_service.py
@@ -29,6 +29,10 @@ class MetadataApi(Protocol):
         self, video_id: str, in_key: str, cookies: dict | None = None
     ) -> tuple: ...
 
+    def get_video_sea_manifest(
+        self, video_id: str, in_key: str, cookies: dict | None = None
+    ) -> tuple: ...
+
     def get_clip_info(self, clip_no: str, cookies: dict) -> tuple: ...
 
     def get_clip_manifest(self, clip_id: str, cookies: dict) -> tuple: ...
@@ -54,7 +58,8 @@ def fetch_content(
 
     result는 기존 ContentWorker.finished 시그널 페이로드와 동일한 tuple이다:
     (vod_url, metadata, unique_reps, resolution, base_url, download_path,
-    live_rewind_playback_json). content_type은 "video" / "m3u8" / "clip".
+    live_rewind_playback_json). content_type은 "video" / "m3u8" / "hls_aes" /
+    "clip"이며, "hls_aes"는 AES(SEA) 암호화 VOD다 (#57).
 
     Raises:
         MetadataError: URL 형식 오류·권한 부족·암호화·매니페스트 실패 등 조회 실패
@@ -64,9 +69,12 @@ def fetch_content(
         raise MetadataError("Invalid VOD URL", vod_url)
 
     if content_type == "video":
-        result = fetch_video(vod_url, content_no, cookies, download_path, api)
+        result, encrypted = fetch_video(vod_url, content_no, cookies, download_path, api)
         if result[6]:
             content_type = "m3u8"
+        elif encrypted:
+            # AES(SEA) 암호화 VOD — HLS(TS) 세그먼트 + 복호화 경로 (#57)
+            content_type = "hls_aes"
     elif content_type == "clips":
         content_type = "clip"
         result = fetch_clip(vod_url, content_no, cookies, download_path, api)
@@ -76,19 +84,33 @@ def fetch_content(
 
 def fetch_video(
     vod_url: str, video_no: str, cookies: dict, download_path: str, api: MetadataApi
-) -> tuple:
+) -> tuple[tuple, bool]:
     """VOD 메타데이터·매니페스트를 조회한다 (구 ContentWorker.fetchVideo와 동일 로직).
 
+    Returns:
+        tuple[tuple, bool]: (result 7-tuple, AES(SEA) 암호화 VOD 여부).
+            result의 형식·항목은 기존과 동일하다 — 암호화 여부만 따로 알린다(#57).
+
     Raises:
-        MetadataError: 쿠키 무효(성인)·암호화·멤버십 필요·매니페스트 실패
+        MetadataError: 쿠키 무효(성인)·미지원 암호화·멤버십 필요·매니페스트 실패
     """
     info = api.get_video_info(video_no, cookies)
+    encrypted = False
     if info.adult and not info.video_id:
         raise MetadataError("Invalid cookies value", vod_url)
     elif info.encryption_type:
-        # 암호화(AES/SEA) VOD는 세그먼트를 복호화할 수 없어 다운로드 불가.
-        # 권한(멤버십) 유무와 무관하므로 매니페스트 요청 전에 조기 안내한다 (#55)
-        raise MetadataError("Encrypted content is not supported", vod_url)
+        # AES(SEA) 암호화 VOD (#57). 세그먼트 암호화는 유저 본인 쿠키로 키를
+        # 받아 복호화할 수 있으므로 지원한다 — 지원 대상 판정(AES-128-CBC +
+        # HTTP 키 시스템)은 매니페스트를 보고 하며, 라이선스 서버형 DRM은
+        # 빈 결과로 떨어져 아래 "지원하지 않음" 안내로 간다.
+        if not info.in_key and info.membership_benefit_type == "MEMBER_ONLY":
+            raise MetadataError("Channel membership required", vod_url)
+        encrypted = True
+        unique_reps, resolution, base_url = api.get_video_sea_manifest(
+            info.video_id, info.in_key, cookies
+        )
+        if not unique_reps:
+            raise MetadataError("Encrypted content is not supported", vod_url)
     elif info.live_rewind_playback_json:
         unique_reps, resolution, base_url = api.get_video_m3u8_manifest(
             info.live_rewind_playback_json
@@ -105,7 +127,7 @@ def fetch_video(
         raise MetadataError("Failed to get DASH manifest", vod_url)
 
     # 네트워크 작업 결과를 tuple 형태로 묶어서 전달
-    return (
+    result = (
         vod_url,
         info.metadata,
         unique_reps,
@@ -114,6 +136,7 @@ def fetch_video(
         download_path,
         info.live_rewind_playback_json,
     )
+    return result, encrypted
 
 
 def fetch_clip(

--- a/download/qt_bridge.py
+++ b/download/qt_bridge.py
@@ -28,7 +28,7 @@ from core.models.events import ProgressEvent
 from core.services.download_service import DownloadService
 from download.data import DownloadData
 from download.logger import DownloadLogger
-from download.resolvers import resolve_m3u8_base_url
+from download.resolvers import resolve_aes_key, resolve_m3u8_base_url
 from download.task import DownloadTask
 
 
@@ -50,7 +50,9 @@ class QtDownloadBridge(QObject):
 
     def __init__(self, service: DownloadService | None = None, parent=None):
         super().__init__(parent)
-        self._service = service or DownloadService(base_url_resolver=resolve_m3u8_base_url)
+        self._service = service or DownloadService(
+            base_url_resolver=resolve_m3u8_base_url, key_resolver=resolve_aes_key
+        )
         self.handle = None
         self.task: DownloadTask | None = None
         self.item: ContentItem | None = None
@@ -118,11 +120,11 @@ class QtDownloadBridge(QObject):
         데이터·아이템을 클로저로 캡처해 제출 직후 첫 콜백과의 레이스를 없앤다.
         엔진 관측 스레드에서 호출되므로 계산과 Signal emit까지만 수행한다.
         """
-        is_m3u8 = item.content_type == "m3u8"
+        is_segment_based = item.is_segment_based
 
         def relay(event: ProgressEvent) -> None:
-            if is_m3u8:
-                args = _m3u8_progress_args(event, data, item)
+            if is_segment_based:
+                args = _segment_progress_args(event, data, item)
             else:
                 args = _file_progress_args(event)
             self.progress.emit(*args, item)
@@ -182,23 +184,23 @@ def _file_progress_args(event: ProgressEvent) -> tuple[str, str, str, int]:
     return remaining_time_str, str(event.downloaded_size), f"{speed_mb:.1f} MB/s", progress
 
 
-def _m3u8_progress_args(
+def _segment_progress_args(
     event: ProgressEvent, data: DownloadData, item: ContentItem
 ) -> tuple[str, str, str, int]:
-    """m3u8 진행 변환 — 계산식은 구 MonitorM3U8Thread.update_progress와 동일.
+    """세그먼트 기반(m3u8·hls_aes) 진행 변환 — 구 MonitorM3U8Thread.update_progress와 동일.
 
     전체 크기를 미리 알 수 없어 진행률은 세그먼트 수 기반이다. 병합 단계
     (item.post_process)에서는 병합된 세그먼트 수, 그 전에는 완료된 세그먼트 수를
     쓰고, 남은 시간은 평균 세그먼트 크기로 추정한다.
+
+    병합 분모는 m3u8이 초기화 세그먼트(EXT-X-MAP) 1개를 더 병합하므로 +1이고,
+    hls_aes(TS)는 초기화 세그먼트가 없어 세그먼트 수 그대로다 (#57).
     """
     speed_mb = event.speed or 0.0
+    merge_total = data.max_threads + (1 if item.content_type == "m3u8" else 0)
 
     if item.post_process:
-        progress = (
-            int((data.merged_segments / (data.max_threads + 1)) * 100)
-            if data.max_threads > 0
-            else 0
-        )
+        progress = int((data.merged_segments / merge_total) * 100) if merge_total > 0 else 0
     else:
         progress = (
             int((data.completed_threads / data.max_threads) * 100) if data.max_threads > 0 else 0

--- a/download/resolvers.py
+++ b/download/resolvers.py
@@ -1,4 +1,4 @@
-"""m3u8 플레이리스트 URL 해석 — DownloadService 주입용 (#75, Qt 무의존).
+"""다운로드 시작 시점의 해석 콜러블 — DownloadService 주입용 (#75·#57, Qt 무의존).
 
 구 download/download_m3u8.py의 DownloadM3U8Thread._resolve_base_url을 함수로
 옮겼다. 쿠키 로드(config)·치지직 API 조회(NetworkManager)는 네트워크 계층이
@@ -14,6 +14,31 @@ from content.network import NetworkManager
 from core.models.content import Content
 
 
+def _load_cookies() -> dict:
+    """설정에 저장된 유저 본인의 쿠키를 읽는다 (미설정이면 빈 값)."""
+    data = config.load_config().get("cookies", {})
+    return {
+        "NID_AUT": data.get("NID_AUT", ""),
+        "NID_SES": data.get("NID_SES", ""),
+    }
+
+
+def resolve_aes_key(content: Content, key_uri: str) -> bytes:
+    """AES(SEA) 세그먼트 복호화 키를 취득한다 (#57).
+
+    다운로드 시작 시점(워커 스레드)에 호출된다 — 최신 쿠키를 반영한다.
+    유저 본인의 쿠키로 인증된 요청이며, 쿠키가 없거나 해당 컨텐츠 권한이
+    없으면 서버가 403으로 거절해 예외가 되고 다운로드는 실패한다.
+    앱은 권한을 만들어내지 않는다.
+
+    **키 값은 로그·예외 메시지에 싣지 않는다.**
+
+    Raises:
+        Exception: 키 취득 실패 (권한 없음·네트워크 등. 서비스가 실패 콜백으로 환원한다)
+    """
+    return NetworkManager.get_aes_key(key_uri, _load_cookies())
+
+
 def resolve_m3u8_base_url(content: Content) -> str:
     """쿠키를 읽고 치지직 API로 선택 해상도의 m3u8 플레이리스트 URL을 해석한다.
 
@@ -22,11 +47,7 @@ def resolve_m3u8_base_url(content: Content) -> str:
     Raises:
         Exception: 조회 실패 (네트워크·권한 등. 서비스가 실패 콜백으로 환원한다)
     """
-    data = config.load_config().get("cookies", {})
-    cookies = {
-        "NID_AUT": data.get("NID_AUT", ""),
-        "NID_SES": data.get("NID_SES", ""),
-    }
+    cookies = _load_cookies()
     content_type, content_no = NetworkManager.extract_content_no(content.url)
     info = NetworkManager.get_video_info(content_no, cookies)
     return NetworkManager.get_video_m3u8_base_url(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "2.8.3"
 description = "Chzzk VOD Downloader v2"
 requires-python = ">=3.13"
 dependencies = [
+    "pycryptodome>=3.20",
     "PySide6>=6.8.1.1",
     "requests>=2.32.5",
 ]

--- a/scripts/headless_download.py
+++ b/scripts/headless_download.py
@@ -51,7 +51,7 @@ from core.services.download_service import DownloadService  # noqa: E402
 from core.services.metadata_service import MetadataError  # noqa: E402
 from download.data import DownloadData  # noqa: E402
 from download.logger import DownloadLogger  # noqa: E402
-from download.resolvers import resolve_m3u8_base_url  # noqa: E402
+from download.resolvers import resolve_aes_key, resolve_m3u8_base_url  # noqa: E402
 from download.task import DownloadTask  # noqa: E402
 
 logger = logging.getLogger("headless")
@@ -140,7 +140,9 @@ class _HeadlessRunner:
         self.item = item
         self.timeout = timeout
         self.exit_code = 1  # 완료 신호를 받기 전까지는 실패로 간주
-        self.service = DownloadService(base_url_resolver=resolve_m3u8_base_url)
+        self.service = DownloadService(
+            base_url_resolver=resolve_m3u8_base_url, key_resolver=resolve_aes_key
+        )
         self.task: DownloadTask | None = None
 
     def run(self) -> int:
@@ -219,13 +221,11 @@ def _format_progress(
     speed_mb = event.speed or 0.0
     remaining_time_str = "N/A"
 
-    if item.content_type == "m3u8":
+    if item.is_segment_based:
+        # 병합 분모: m3u8은 초기화 세그먼트(EXT-X-MAP) 1개를 더 병합한다 (hls_aes는 없음)
+        merge_total = data.max_threads + (1 if item.content_type == "m3u8" else 0)
         if item.post_process:
-            progress = (
-                int((data.merged_segments / (data.max_threads + 1)) * 100)
-                if data.max_threads > 0
-                else 0
-            )
+            progress = int((data.merged_segments / merge_total) * 100) if merge_total > 0 else 0
         else:
             progress = (
                 int((data.completed_threads / data.max_threads) * 100)

--- a/tests/unit/core/test_download_service.py
+++ b/tests/unit/core/test_download_service.py
@@ -30,6 +30,7 @@ class FakeEngine:
         self.on_progress = on_progress
         self.on_finished = on_finished
         self.on_failed = on_failed
+        self.key_resolver = None
         self.started = threading.Event()
         self.release = threading.Event()
         self.fail_with: BaseException | None = None
@@ -46,6 +47,10 @@ class FakeEngine:
     def emit_progress(self):
         self.final_progress_calls += 1
 
+    def set_key_resolver(self, resolver):
+        """BaseDownloader의 키 리졸버 주입 계약을 흉내 낸다 (#57)."""
+        self.key_resolver = resolver
+
 
 class FakeEngineFactory:
     """서비스 모듈의 엔진 심볼을 대체해 생성된 페이크 엔진을 수집한다.
@@ -58,10 +63,12 @@ class FakeEngineFactory:
         self,
         supported: set[ContentType],
         requires_base_url_resolution: bool = False,
+        requires_key_resolution: bool = False,
         run_thread_name: str = "DownloadThread",
     ):
         self.supported = supported
         self.requires_base_url_resolution = requires_base_url_resolution
+        self.requires_key_resolution = requires_key_resolution
         self.run_thread_name = run_thread_name
         self.instances: list[FakeEngine] = []
         self.created = threading.Event()
@@ -184,6 +191,36 @@ class TestDownloaderSelection:
         )
         assert handle.wait(WAIT)
         assert failures == [boom]
+
+    def test_hls_aes_uses_aes_downloader_and_injects_key_resolver(self, monkeypatch):
+        """암호화 VOD는 AES 다운로더가 선택되고 키 리졸버가 주입돼야 한다 (#57)."""
+        factory = FakeEngineFactory(
+            {ContentType.CHZZK_VIDEO_HLS_AES},
+            requires_key_resolution=True,
+            run_thread_name="DownloadHlsAesThread",
+        )
+        monkeypatch.setattr(download_service_module, "HlsAesDownloader", factory)
+
+        def key_resolver(content, key_uri):
+            return bytes(16)
+
+        service = DownloadService(key_resolver=key_resolver)
+        handle = service.submit(_make_content(ContentType.CHZZK_VIDEO_HLS_AES))
+
+        assert factory.created.wait(WAIT)
+        engine = factory.instances[0]
+        assert engine.started.wait(WAIT)
+        # 키 취득은 엔진의 prepare()가 수행하므로 여기서는 주입만 확인한다
+        assert engine.key_resolver is key_resolver
+        _finish(engine)
+        assert handle.wait(WAIT)
+
+    def test_real_hls_aes_downloader_declares_key_resolution(self):
+        """실제 다운로더가 키 리졸버 주입 계약을 선언한다 — 서비스 배선의 근거."""
+        from core.downloaders.hls_aes_downloader import HlsAesDownloader
+
+        assert HlsAesDownloader.supports(_make_content(ContentType.CHZZK_VIDEO_HLS_AES)) is True
+        assert HlsAesDownloader.requires_key_resolution is True
 
     def test_unsupported_type_raises(self, file_factory):
         with pytest.raises(ValueError):

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -1,0 +1,316 @@
+"""AES(SEA) 경로 검증 — 매니페스트 판정·파싱과 HlsAesDownloader 실행 (#57).
+
+- SEA 매니페스트: 지원 판정(AES-128-CBC + HTTP 키 시스템)과 Representation 파싱.
+  실제 멤버십 VOD 매니페스트 박제본(dash_manifest_sea_*.xml)을 쓴다
+- 다운로더: 키 취득 주입, 미지원 방식 거부, 전체 파이프라인(다운로드 →
+  복호화 → 순서 병합)을 가짜 세션으로 검증
+
+키 값은 테스트에서도 의미 없는 더미를 쓴다 — 실제 키는 어디에도 두지 않는다.
+"""
+
+import threading
+
+import pytest
+from Crypto.Cipher import AES
+
+import core.downloaders.hls_aes_downloader as aes_module
+from core.api.dash import is_supported_sea, parse_sea_manifest
+from core.downloaders.decrypt import AES_BLOCK_SIZE, TS_PACKET_SIZE, sequence_iv
+from core.downloaders.hls_aes_downloader import DecryptionError, HlsAesDownloader
+from core.models.content import Content, ContentType
+from download.data import DownloadData
+
+KEY = bytes(range(16))  # 테스트용 더미 키
+KEY_URI = "https://api.chzzk.naver.com/service/v1/encryption/videos/VID/aes_key"
+BASE_URL = "https://example.invalid/hls-aes/rep/media.m3u8"
+SEGMENT_COUNT = 5
+
+
+# ================================================================ SEA 매니페스트
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["dash_manifest_sea_13714380.xml", "dash_manifest_sea_14283698.xml"]
+)
+def test_real_sea_manifest_is_supported(load_mock_response, fixture_name):
+    """실제 매니페스트는 지원 대상(AES-128-CBC + keysys:http)으로 판정돼야 한다."""
+    assert is_supported_sea(load_mock_response(fixture_name)) is True
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["dash_manifest_sea_13714380.xml", "dash_manifest_sea_14283698.xml"]
+)
+def test_parse_sea_manifest_uses_nvod_m3u_as_base_url(load_mock_response, fixture_name):
+    """암호화 비디오 Representation은 BaseURL이 없어 nvod:m3u를 base_url로 쓴다."""
+    reps, auto_resolution, auto_base_url = parse_sea_manifest(load_mock_response(fixture_name))
+
+    assert [rep[0] for rep in reps] == [144, 720, 1080]  # 해상도 오름차순
+    assert auto_resolution == 1080
+    for _, url in reps:
+        assert "/hls-aes/" in url and url.endswith("media.m3u8")
+    assert auto_base_url == reps[-1][1]
+    # 오디오 Representation(비암호화)은 이 경로의 대상이 아니다
+    assert all("cmaf" not in url for _, url in reps)
+
+
+def test_drm_manifest_is_not_supported():
+    """라이선스 서버형 DRM(Widevine 등)은 지원 대상이 아니다 — 우회하지 않는다."""
+    drm_xml = (
+        '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><AdaptationSet><Representation '
+        'width="1920" height="1080"><ContentProtection '
+        'schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"/>'
+        "</Representation></AdaptationSet></Period></MPD>"
+    )
+
+    assert is_supported_sea(drm_xml) is False
+
+
+def test_plain_manifest_is_not_sea(load_mock_response):
+    """ContentProtection이 없는 평문 매니페스트는 SEA가 아니다."""
+    assert is_supported_sea(load_mock_response("dash_manifest.xml")) is False
+
+
+# ================================================================ 다운로더 계약
+
+
+def _make_content(content_type=ContentType.CHZZK_VIDEO_HLS_AES) -> Content:
+    return Content(
+        content_type=content_type,
+        url="https://chzzk.naver.com/video/13714380",
+        output_path="out.mp4",
+        resolution=144,
+        base_url=BASE_URL,
+    )
+
+
+@pytest.mark.parametrize(
+    ("content_type", "expected"),
+    [
+        (ContentType.CHZZK_VIDEO_HLS_AES, True),
+        (ContentType.CHZZK_VIDEO_M3U8, False),
+        (ContentType.CHZZK_VIDEO, False),
+        (ContentType.CHZZK_CLIP, False),
+    ],
+)
+def test_supports_matrix(content_type, expected):
+    """암호화 VOD 타입만 이 다운로더가 처리한다."""
+    assert HlsAesDownloader.supports(_make_content(content_type)) is expected
+
+
+def test_requires_key_resolution_is_declared():
+    """서비스가 키 리졸버를 주입하도록 계약을 선언해야 한다."""
+    assert HlsAesDownloader.requires_key_resolution is True
+    # base_url은 매니페스트 조회 시점에 확정되므로 재해석하지 않는다
+    assert HlsAesDownloader.requires_base_url_resolution is False
+
+
+# ================================================================ 가짜 서버
+
+
+def _segment_body(index: int, packets: int = 2) -> bytes:
+    """세그먼트별로 구별되는 가짜 TS 본문 — 각 188바이트 패킷이 0x47로 시작한다."""
+    return b"".join(
+        bytes([0x47]) + bytes([index + 1]) * (TS_PACKET_SIZE - 1) for _ in range(packets)
+    )
+
+
+def _encrypt(plain: bytes, iv: bytes) -> bytes:
+    pad = AES_BLOCK_SIZE - (len(plain) % AES_BLOCK_SIZE)
+    return AES.new(KEY, AES.MODE_CBC, iv).encrypt(plain + bytes([pad]) * pad)
+
+
+def _playlist_text(method: str = "AES-128") -> str:
+    lines = ["#EXTM3U", "#EXT-X-VERSION:3", "#EXT-X-MEDIA-SEQUENCE:0"]
+    if method == "NONE":
+        lines.append("#EXT-X-KEY:METHOD=NONE")
+    else:
+        lines.append(f'#EXT-X-KEY:METHOD={method},URI="{KEY_URI}"')
+    for i in range(SEGMENT_COUNT):
+        lines += ["#EXTINF:3.840,", f"segment-{i:06d}.ts"]
+    lines.append("#EXT-X-ENDLIST")
+    return "\n".join(lines)
+
+
+class _Response:
+    def __init__(self, text: str = "", body: bytes = b""):
+        self.text = text
+        self._body = body
+
+    @property
+    def content(self) -> bytes:
+        """비스트리밍 요청용 본문 (prepare의 키 검증이 쓴다)."""
+        return self._body
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i : i + chunk_size]
+
+
+class FakeSession:
+    """플레이리스트와 암호화 세그먼트를 URL로 분기해 돌려주는 가짜 세션."""
+
+    def __init__(self, playlist: str):
+        self._playlist = playlist
+
+    def get(self, url, **kwargs):
+        if url.endswith("media.m3u8"):
+            return _Response(text=self._playlist)
+        index = int(url.rsplit("segment-", 1)[1].removesuffix(".ts"))
+        return _Response(body=_encrypt(_segment_body(index), sequence_iv(index)))
+
+
+class RunLogger:
+    """run() 경로가 쓰는 로거 인터페이스를 기록만 하며 흉내 낸다."""
+
+    def __init__(self):
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+        self.completed_times: list[float] = []
+        self.closed = 0
+
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+    def log_download_complete(self, total_time):
+        self.completed_times.append(total_time)
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def log_exception(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def save_and_close(self):
+        self.closed += 1
+
+
+def _make_engine(tmp_path, monkeypatch, playlist=None, key_resolver=None):
+    """가짜 세션이 연결된 RUNNING 이전 상태의 엔진을 준비한다."""
+    data = DownloadData(
+        base_url=BASE_URL,
+        vod_url="https://chzzk.naver.com/video/13714380",
+        output_path=str(tmp_path / "out.mp4"),
+        resolution=144,
+        content_type="hls_aes",
+    )
+    logger = RunLogger()
+    monkeypatch.setattr(
+        aes_module, "get_thread_session", lambda: FakeSession(playlist or _playlist_text())
+    )
+
+    finished = threading.Event()
+    failures: list[BaseException] = []
+    merge_starts: list[bool] = []
+
+    def on_finished():
+        data.model.finish()
+        finished.set()
+
+    engine = HlsAesDownloader(
+        data,
+        logger,
+        on_finished=on_finished,
+        on_failed=failures.append,
+        on_merge_start=lambda: merge_starts.append(True),
+    )
+    if key_resolver is not None:
+        engine.set_key_resolver(key_resolver)
+    return engine, data, logger, finished, failures, merge_starts
+
+
+# ================================================================ prepare·키 취득
+
+
+def test_prepare_fetches_key_through_injected_resolver(tmp_path, monkeypatch):
+    """키는 주입된 리졸버로 취득하고, 계획은 세그먼트 목록·후처리 필요를 담는다."""
+    calls: list[tuple] = []
+
+    def resolver(content, key_uri):
+        calls.append((content, key_uri))
+        return KEY
+
+    engine, data, *_ = _make_engine(tmp_path, monkeypatch, key_resolver=resolver)
+    plan = engine.prepare(data.content)
+
+    assert [uri for _, uri in calls] == [KEY_URI]  # 플레이리스트의 키 URI를 그대로 쓴다
+    assert plan.part_count == SEGMENT_COUNT
+    assert plan.total_size is None
+    assert plan.requires_postprocess is True
+    assert plan.items[0] == (0, "segment-000000.ts")
+
+
+def test_prepare_without_resolver_fails(tmp_path, monkeypatch):
+    """키 리졸버가 없으면 명확히 실패해야 한다 (임의 우회 없음)."""
+    engine, data, *_ = _make_engine(tmp_path, monkeypatch)
+
+    with pytest.raises(DecryptionError, match="key_resolver"):
+        engine.prepare(data.content)
+
+
+def test_prepare_rejects_unsupported_method(tmp_path, monkeypatch):
+    """AES-128이 아닌 방식은 우회를 시도하지 않고 거부한다."""
+    engine, data, *_ = _make_engine(
+        tmp_path,
+        monkeypatch,
+        playlist=_playlist_text(method="SAMPLE-AES"),
+        key_resolver=lambda c, u: KEY,
+    )
+
+    with pytest.raises(DecryptionError, match="지원하지 않는 암호화 방식"):
+        engine.prepare(data.content)
+
+
+def test_prepare_rejects_playlist_without_key(tmp_path, monkeypatch):
+    """암호화 정보가 없는 플레이리스트는 이 경로의 대상이 아니다."""
+    engine, data, *_ = _make_engine(
+        tmp_path, monkeypatch, playlist=_playlist_text(method="NONE"), key_resolver=lambda c, u: KEY
+    )
+
+    with pytest.raises(DecryptionError, match="#EXT-X-KEY"):
+        engine.prepare(data.content)
+
+
+def test_wrong_key_fails_fast_instead_of_writing_garbage(tmp_path, monkeypatch):
+    """키가 틀리면 첫 세그먼트에서 즉시 실패하고 결과 파일을 남기지 않는다."""
+    wrong_key = bytes([0xFF]) * 16
+    engine, data, logger, finished, failures, _ = _make_engine(
+        tmp_path, monkeypatch, key_resolver=lambda c, u: wrong_key
+    )
+
+    data.model.start()
+    engine.run()
+
+    assert not finished.is_set()
+    assert any(isinstance(e, DecryptionError) for e in failures)
+    assert not (tmp_path / "out.mp4").exists()
+
+
+# ================================================================ 전체 파이프라인
+
+
+def test_run_downloads_decrypts_and_merges_in_order(tmp_path, monkeypatch):
+    """전체 파이프라인이 복호화된 세그먼트를 순서대로 이어붙인 파일을 만든다."""
+    engine, data, logger, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch, key_resolver=lambda c, u: KEY
+    )
+
+    data.model.start()
+    thread = threading.Thread(target=engine.run, daemon=True)
+    thread.start()
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    expected = b"".join(_segment_body(i) for i in range(SEGMENT_COUNT))
+    assert (tmp_path / "out.mp4").read_bytes() == expected
+    assert merge_starts == [True]
+    assert failures == [] and logger.errors == [] and logger.warnings == []
+    assert data.completed_threads == SEGMENT_COUNT
+    # TS 경로에는 초기화 세그먼트가 없어 병합 수 = 세그먼트 수다
+    assert data.merged_segments == SEGMENT_COUNT
+    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제

--- a/tests/unit/core/test_hls_playlist.py
+++ b/tests/unit/core/test_hls_playlist.py
@@ -1,0 +1,144 @@
+"""HLS 미디어 플레이리스트 파싱·세그먼트 복호화 규칙 검증 (#57).
+
+core/api/hls.py(순수 파서)와 core/downloaders/decrypt.py(AES-128-CBC)의 계약을
+고정한다. 실제 치지직 응답에서 확인된 형태를 기준으로 삼는다:
+``#EXT-X-KEY:METHOD=AES-128,URI="..."`` — **IV 속성 없음**, ``EXT-X-MAP`` 없음,
+``EXT-X-MEDIA-SEQUENCE`` 0, 세그먼트 확장자 .ts.
+"""
+
+import pytest
+from Crypto.Cipher import AES
+
+from core.api.hls import HlsKey, parse_media_playlist
+from core.downloaders.decrypt import (
+    AES_BLOCK_SIZE,
+    TS_PACKET_SIZE,
+    decrypt_segment,
+    looks_like_ts,
+    sequence_iv,
+)
+
+KEY_URI = "https://api.chzzk.naver.com/service/v1/encryption/videos/VID/aes_key"
+
+# 치지직 실응답과 같은 형태의 최소 플레이리스트 (IV 속성 없음)
+CHZZK_STYLE = "\n".join(
+    [
+        "#EXTM3U",
+        "#EXT-X-VERSION:3",
+        "#EXT-X-TARGETDURATION:4",
+        "#EXT-X-MEDIA-SEQUENCE:0",
+        f'#EXT-X-KEY:METHOD=AES-128,URI="{KEY_URI}"',
+        "#EXTINF:3.840,",
+        "segment-000000.ts",
+        "#EXTINF:3.840,",
+        "segment-000001.ts",
+        "#EXT-X-ENDLIST",
+    ]
+)
+
+
+# ================================================================ 플레이리스트 파싱
+
+
+def test_parses_chzzk_style_playlist():
+    """치지직 실응답 형태: AES-128 키(IV 없음), TS 세그먼트, 초기화 세그먼트 없음."""
+    pl = parse_media_playlist(CHZZK_STYLE)
+
+    assert pl.segments == ("segment-000000.ts", "segment-000001.ts")
+    assert pl.media_sequence == 0
+    assert pl.init_uri is None
+    assert pl.key == HlsKey(method="AES-128", uri=KEY_URI, iv=None)
+    assert pl.key.is_aes_128 is True
+
+
+def test_sequence_of_offsets_by_media_sequence():
+    """세그먼트의 시퀀스 번호는 EXT-X-MEDIA-SEQUENCE부터 센다 (IV 유도의 근거)."""
+    pl = parse_media_playlist(CHZZK_STYLE.replace("MEDIA-SEQUENCE:0", "MEDIA-SEQUENCE:100"))
+
+    assert pl.media_sequence == 100
+    assert (pl.sequence_of(0), pl.sequence_of(1)) == (100, 101)
+
+
+def test_explicit_iv_is_parsed_as_bytes():
+    """IV 속성이 있으면 16진 문자열을 바이트로 파싱한다."""
+    iv_hex = "0x000102030405060708090a0b0c0d0e0f"
+    pl = parse_media_playlist(
+        CHZZK_STYLE.replace(f'URI="{KEY_URI}"', f'URI="{KEY_URI}",IV={iv_hex}')
+    )
+
+    assert pl.key.iv == bytes(range(16))
+
+
+def test_method_none_means_unencrypted():
+    """METHOD=NONE은 암호화 해제 지시이므로 키 없음으로 다룬다."""
+    pl = parse_media_playlist(CHZZK_STYLE.replace(f'METHOD=AES-128,URI="{KEY_URI}"', "METHOD=NONE"))
+
+    assert pl.key is None
+    assert pl.segments  # 세그먼트 목록 자체는 그대로 파싱된다
+
+
+def test_ext_x_map_is_parsed_when_present():
+    """fMP4 플레이리스트의 초기화 세그먼트(EXT-X-MAP)도 파싱한다."""
+    pl = parse_media_playlist(CHZZK_STYLE.replace("#EXTM3U", '#EXTM3U\n#EXT-X-MAP:URI="init.m4s"'))
+
+    assert pl.init_uri == "init.m4s"
+
+
+def test_plain_playlist_has_no_key():
+    """평문 플레이리스트는 키 없이 세그먼트만 나온다."""
+    pl = parse_media_playlist("#EXTM3U\n#EXTINF:2.0,\na.ts\n#EXT-X-ENDLIST")
+
+    assert pl.key is None
+    assert pl.segments == ("a.ts",)
+
+
+# ================================================================ 복호화
+
+
+def _encrypt(plain: bytes, key: bytes, iv: bytes) -> bytes:
+    """테스트용 암호화 — PKCS#7 패딩 후 AES-128-CBC."""
+    pad = AES_BLOCK_SIZE - (len(plain) % AES_BLOCK_SIZE)
+    padded = plain + bytes([pad]) * pad
+    return AES.new(key, AES.MODE_CBC, iv).encrypt(padded)
+
+
+def _fake_ts(packets: int = 3) -> bytes:
+    """동기 바이트가 붙은 가짜 MPEG-TS 바이트열."""
+    return b"".join(bytes([0x47]) + bytes(TS_PACKET_SIZE - 1) for _ in range(packets))
+
+
+def test_decrypt_round_trip_strips_padding():
+    """암호화 → 복호화가 원본과 정확히 일치해야 한다 (PKCS#7 패딩 제거 포함)."""
+    key, iv = bytes(range(16)), sequence_iv(7)
+    plain = _fake_ts()
+
+    assert decrypt_segment(_encrypt(plain, key, iv), key, iv) == plain
+
+
+def test_sequence_iv_is_big_endian_128bit():
+    """IV는 시퀀스 번호의 128비트 빅엔디언 표현이다 (RFC 8216 §5.2)."""
+    assert sequence_iv(0) == bytes(16)
+    assert sequence_iv(1) == bytes(15) + b"\x01"
+    assert sequence_iv(258) == bytes(14) + b"\x01\x02"
+
+
+@pytest.mark.parametrize(
+    ("key", "iv", "data"),
+    [
+        (bytes(8), bytes(16), bytes(16)),  # 키 길이 오류
+        (bytes(16), bytes(8), bytes(16)),  # IV 길이 오류
+        (bytes(16), bytes(16), bytes(17)),  # 블록 배수 아님
+    ],
+)
+def test_decrypt_rejects_malformed_input(key, iv, data):
+    """키·IV 길이와 블록 정렬이 어긋나면 ValueError로 실패해야 한다."""
+    with pytest.raises(ValueError):
+        decrypt_segment(data, key, iv)
+
+
+def test_looks_like_ts_detects_sync_bytes():
+    """TS 판정은 첫 바이트와 다음 패킷 경계의 동기 바이트(0x47)로 한다."""
+    assert looks_like_ts(_fake_ts()) is True
+    # 키가 틀리면 난수가 되어 통과할 수 없다
+    assert looks_like_ts(bytes(TS_PACKET_SIZE * 2)) is False
+    assert looks_like_ts(b"\x47" * 10) is False  # 너무 짧다

--- a/tests/unit/core/test_metadata_service.py
+++ b/tests/unit/core/test_metadata_service.py
@@ -46,12 +46,21 @@ def _video_info(**overrides) -> VideoInfo:
 class FakeApi:
     """MetadataApi 프로토콜을 구현하는 가짜 api. 필요한 메서드만 주입해 쓴다."""
 
-    def __init__(self, video_info=None, clip_info=None, clip_manifest=None, dash_manifest=None):
+    def __init__(
+        self,
+        video_info=None,
+        clip_info=None,
+        clip_manifest=None,
+        dash_manifest=None,
+        sea_manifest=None,
+    ):
         self._video_info = video_info
         self._clip_info = clip_info
         self._clip_manifest = clip_manifest
         self._dash_manifest = dash_manifest
+        self._sea_manifest = sea_manifest
         self.dash_calls: list[tuple] = []
+        self.sea_calls: list[tuple] = []
 
     def get_video_info(self, video_no, cookies):
         return self._video_info
@@ -59,6 +68,10 @@ class FakeApi:
     def get_video_dash_manifest(self, video_id, in_key, cookies=None):
         self.dash_calls.append((video_id, in_key, cookies))
         return self._dash_manifest
+
+    def get_video_sea_manifest(self, video_id, in_key, cookies=None):
+        self.sea_calls.append((video_id, in_key, cookies))
+        return self._sea_manifest
 
     def get_video_m3u8_manifest(self, json_str):
         return [[720, None]], 720, None
@@ -128,32 +141,85 @@ def test_fetch_content_maps_clips_to_clip():
 @pytest.mark.parametrize(
     "fixture_name",
     [
-        # 멤버십 권한 있는 상태(inKey 발급됨)의 실응답 박제 — 그래도 암호화라 다운로드 불가
+        # 멤버십 권한 있는 상태(inKey 발급됨)의 실응답 박제
         "video_encrypted_member_13714380.json",
         "video_encrypted_member_14283698.json",
-        # 권한 없는 상태(inKey null)의 실응답 박제 — 암호화 안내가 멤버십 안내보다 우선
-        "video_member_only_13714380.json",
     ],
 )
-def test_encrypted_vod_raises_early_encryption_error(monkeypatch, load_mock_response, fixture_name):
-    """encryptionType이 AES인 실응답이면 권한 유무와 무관하게 조기 안내해야 한다.
+def test_encrypted_vod_with_entitlement_takes_sea_path(
+    monkeypatch, load_mock_response, fixture_name
+):
+    """AES(SEA) 암호화 VOD는 권한이 있으면 SEA 경로로 조회된다 (#57).
 
-    실제 응답 픽스처를 NetworkManager 파싱까지 그대로 통과시켜 전체 경로를 검증한다.
-    매니페스트 요청 없이 실패해야 하므로 get_video_dash_manifest 호출도 감시한다.
+    #55에서는 여기서 조기 거부했지만, SEA는 유저 본인 쿠키로 키를 받아
+    복호화할 수 있는 표준 세그먼트 암호화이므로 지원 대상이 됐다.
+    실제 응답 픽스처를 NetworkManager 파싱까지 통과시켜 전체 경로를 검증한다.
     """
     body = load_mock_response(fixture_name)
     monkeypatch.setattr(network._session, "get", lambda url, **kwargs: MockResponse(text=body))
-    manifest_calls = []
+    sea_calls = []
     monkeypatch.setattr(
         NetworkManager,
-        "get_video_dash_manifest",
-        lambda *args, **kwargs: manifest_calls.append(args),
+        "get_video_sea_manifest",
+        lambda *args, **kwargs: (
+            sea_calls.append(args) or ([[144, "https://example.invalid/media.m3u8"]], 144, "https://example.invalid/media.m3u8")
+        ),
+    )
+
+    result, encrypted = fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=NetworkManager)
+
+    assert encrypted is True
+    assert len(sea_calls) == 1  # 평문 경로가 아니라 SEA 매니페스트를 조회한다
+    assert result[4] == "https://example.invalid/media.m3u8"
+
+
+def test_encrypted_vod_without_entitlement_raises_membership_error(
+    monkeypatch, load_mock_response
+):
+    """암호화 VOD라도 권한이 없으면(inKey null) 멤버십 안내가 나와야 한다 (#57).
+
+    #55에서는 암호화 안내가 우선이었으나, 이제 암호화 자체는 지원되므로
+    실제 막고 있는 원인(권한 없음)을 안내하는 편이 정확하다.
+    """
+    body = load_mock_response("video_member_only_13714380.json")
+    monkeypatch.setattr(network._session, "get", lambda url, **kwargs: MockResponse(text=body))
+
+    with pytest.raises(MetadataError, match="Channel membership required"):
+        fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=NetworkManager)
+
+
+def test_unsupported_encryption_still_raises_encryption_error():
+    """지원 대상이 아닌 암호화(라이선스 서버형 DRM 등)는 기존 안내로 실패해야 한다 (#57).
+
+    NetworkManager.get_video_sea_manifest가 지원 판정에 실패하면 빈 결과를
+    돌려주고, 그것이 "Encrypted content is not supported"로 이어진다 —
+    DRM 우회는 구현하지 않는다.
+    """
+    api = FakeApi(
+        video_info=_video_info(encryption_type="AES"),
+        sea_manifest=([], None, None),
     )
 
     with pytest.raises(MetadataError, match="Encrypted content is not supported"):
-        fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=NetworkManager)
-    # 조기 감지: 매니페스트 요청까지 가지 않아야 한다
-    assert manifest_calls == []
+        fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=api)
+
+
+def test_fetch_content_maps_encrypted_video_to_hls_aes():
+    """암호화 VOD는 content_type이 hls_aes로 매핑돼야 한다 (#57)."""
+    api = FakeApi(
+        video_info=_video_info(encryption_type="AES"),
+        sea_manifest=(
+            [[144, "https://example.invalid/media.m3u8"]],
+            144,
+            "https://example.invalid/media.m3u8",
+        ),
+    )
+
+    result, content_type = fetch_content(VOD_URL, COOKIES, DOWNLOAD_PATH, api=api)
+
+    assert content_type == "hls_aes"
+    assert result[4] == "https://example.invalid/media.m3u8"
+    assert result[6] is None  # 라이브 다시보기가 아니다
 
 
 def test_member_only_without_in_key_raises_membership_error():
@@ -193,8 +259,9 @@ def test_dash_path_passes_cookies_to_manifest_request():
         ),
     )
 
-    result = fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=api)
+    result, encrypted = fetch_video(VOD_URL, "13714380", COOKIES, DOWNLOAD_PATH, api=api)
 
+    assert encrypted is False
     assert api.dash_calls == [("video-id", "in-key", COOKIES)]
     # 반환 tuple 형식 유지: (vod_url, metadata, reps, resolution, base_url, path, liveRewindPlaybackJson)
     assert result[0] == VOD_URL

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -31,34 +31,50 @@ def _make_worker() -> ContentWorker:
 @pytest.mark.parametrize(
     "fixture_name",
     [
-        # 멤버십 권한 있는 상태(inKey 발급됨)의 실응답 박제 — 그래도 암호화라 다운로드 불가
+        # 멤버십 권한 있는 상태(inKey 발급됨)의 실응답 박제
         "video_encrypted_member_13714380.json",
         "video_encrypted_member_14283698.json",
-        # 권한 없는 상태(inKey null)의 실응답 박제 — 암호화 안내가 멤버십 안내보다 우선
-        "video_member_only_13714380.json",
     ],
 )
-def test_encrypted_vod_raises_early_encryption_error(monkeypatch, load_mock_response, fixture_name):
-    """encryptionType이 AES인 실응답이면 권한 유무와 무관하게 조기 안내해야 한다 (#55).
+def test_encrypted_vod_with_entitlement_takes_sea_path(
+    monkeypatch, load_mock_response, fixture_name
+):
+    """AES(SEA) 암호화 VOD는 권한이 있으면 SEA 경로로 조회된다 (#57).
 
-    실제 응답 픽스처를 network 파싱까지 그대로 통과시켜 전체 경로를 검증한다.
-    매니페스트 요청 없이 실패해야 하므로 get_video_dash_manifest 호출도 감시한다.
+    #55에서는 조기 거부했지만 SEA는 유저 본인 쿠키로 키를 받아 복호화할 수
+    있는 표준 세그먼트 암호화라 지원 대상이 됐다. 어댑터의 반환 계약(result
+    tuple)은 그대로여야 한다.
     """
     body = load_mock_response(fixture_name)
     monkeypatch.setattr(network._session, "get", lambda url, **kwargs: MockResponse(text=body))
-    manifest_calls = []
     monkeypatch.setattr(
         NetworkManager,
-        "get_video_dash_manifest",
-        lambda *args, **kwargs: manifest_calls.append(args),
+        "get_video_sea_manifest",
+        lambda *args, **kwargs: (
+            [[144, "https://example.invalid/media.m3u8"]],
+            144,
+            "https://example.invalid/media.m3u8",
+        ),
     )
 
     worker = _make_worker()
+    result = worker.fetchVideo("13714380")
 
-    with pytest.raises(ValueError, match="Encrypted content is not supported"):
+    assert result[0] == VOD_URL
+    assert result[4] == "https://example.invalid/media.m3u8"
+
+
+def test_encrypted_vod_without_entitlement_raises_membership_error(
+    monkeypatch, load_mock_response
+):
+    """암호화 VOD라도 권한이 없으면(inKey null) 멤버십 안내가 나와야 한다 (#57)."""
+    body = load_mock_response("video_member_only_13714380.json")
+    monkeypatch.setattr(network._session, "get", lambda url, **kwargs: MockResponse(text=body))
+
+    worker = _make_worker()
+
+    with pytest.raises(ValueError, match="Channel membership required"):
         worker.fetchVideo("13714380")
-    # 조기 감지: 매니페스트 요청까지 가지 않아야 한다
-    assert manifest_calls == []
 
 
 def test_member_only_without_in_key_raises_membership_error(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,7 @@ name = "cvdv2"
 version = "2.8.3"
 source = { virtual = "." }
 dependencies = [
+    { name = "pycryptodome" },
     { name = "pyside6" },
     { name = "requests" },
 ]
@@ -87,6 +88,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pycryptodome", specifier = ">=3.20" },
     { name = "pyside6", specifier = ">=6.8.1.1" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
@@ -144,6 +146,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 관련 이슈

Closes #57

## 변경 내용

AES(SEA) 암호화 VOD를 **유저 본인의 쿠키로 인증된 세션**이 받아 복호화·병합하는 경로를 추가했습니다.

### 접근 권한에 대하여

이 기능은 접근 권한을 확장하지 않습니다. 실측으로 확인한 서버 동작:

| 요청 | 쿠키 있음 | 쿠키 없음 |
|---|---|---|
| `aes_key` 엔드포인트 | `200`, `application/octet-stream`, **16바이트** | **`403`** |

키는 치지직 API가 인증된 요청에 정상 응답으로 내주며(`keysys:http:2013`), 쿠키가 없거나 해당 컨텐츠 권한이 없으면 서버가 거절해 다운로드가 실패합니다. 성인 인증 컨텐츠가 이미 동일한 구조(`Invalid cookies value`)로 동작하고 있고, 쿠키는 유저가 설정 창에 직접 입력합니다(`config/dialog.py:48`, 기본값 빈 문자열). **라이선스 서버형 DRM 우회는 구현하지 않았으며**, DRM 스킴은 지원 판정에서 걸러져 기존 "지원하지 않음" 안내로 떨어집니다.

### 착수 전 확인 항목 (이슈 체크박스) — 실측 해소

- [x] **`aes_key` 쿠키 접근성**: 위 표대로 쿠키만으로 200 + 16바이트 raw key, 쿠키 없으면 403
- [x] **IV 표기**: `#EXT-X-KEY:METHOD=AES-128,URI="..."` — **IV 속성 없음** → RFC 8216 §5.2대로 미디어 시퀀스 번호를 IV로 사용

부수 확인: 세그먼트는 `.ts`(MPEG-TS, A/V 먹싱), `EXT-X-MAP` 없음, `EXT-X-MEDIA-SEQUENCE` 0, 키 1개로 전체 커버(로테이션 없음), 144p 기준 2732 세그먼트.

### 구현

- **`core/api/hls.py`** — HLS 미디어 플레이리스트 순수 파서(세그먼트·`EXT-X-KEY`·시퀀스·`EXT-X-MAP`)
- **`core/downloaders/decrypt.py`** — AES-128-CBC 복호화, PKCS#7 제거, 시퀀스 IV, TS 판정
- **`core/downloaders/hls_aes_downloader.py`** — `BaseDownloader` 하위 실행 엔진. m3u8 경로와 달리 TS라 초기화 세그먼트가 없고, 세그먼트마다 복호화 단계가 있습니다
- **`core/api/dash.py`** — SEA 지원 판정(`is_supported_sea`)과 전용 파서(`parse_sea_manifest`). 암호화 비디오 Representation은 BaseURL 없이 `nvod:m3u`만 가지므로 그것을 base_url로 씁니다. 평문 경로의 `parse_dash_manifest`는 기존 방어 동작 그대로입니다(박제 테스트 무수정 통과)
- **키 취득 주입** — 쿠키가 필요해 core가 직접 하지 않습니다. `requires_key_resolution` 클래스 속성으로 선언하고 서비스가 앱 계층 리졸버(`download/resolvers.py:resolve_aes_key`)를 주입합니다 — base_url 해석(#75)과 같은 방식이라 core→app 의존이 생기지 않습니다

### 동작 변경 1건

권한 없는 암호화 VOD(`inKey` null)의 안내가 "Encrypted content is not supported" → **"Channel membership required"** 로 바뀝니다. 암호화 자체는 이제 지원되므로 실제로 막고 있는 원인을 안내하는 편이 정확합니다. 기존 테스트의 해당 단언을 이 정책으로 갱신했습니다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 — **236 passed** (기존 205 + 신규 31). 다운로더 규칙 박제 4파일 시나리오·단언 **무수정** 통과
- [x] 새 로직에 대한 테스트 추가됨 — `test_hls_playlist.py`(파서·복호화 규칙), `test_hls_aes_downloader.py`(SEA 판정·파싱, 키 주입, 미지원 방식 거부, 잘못된 키 조기 실패, 전체 파이프라인 바이트 대조), `test_download_service.py`(선택·리졸버 주입)
- [x] **실제 암호화 VOD 완주** (videoNo 13714380, 144p, 2732 세그먼트): **277,062,744 bytes / 65초**, 종료 코드 0
- [x] **산출물 전수 구조 검증**: 1,473,738 패킷 — **싱크 오류 0, 연속성 카운터 오류 0**, PID 5종(PAT 0 / SDT 17 / 비디오 256 / 오디오 257 / PMT 4096) 정상. 연속성 카운터는 손상이 있으면 즉시 깨지므로 전 구간 복호화가 정확함을 뜻합니다
- [x] 오너 GUI 스모크(암호화 VOD 카드 표시·해상도 선택·일시정지/재개, 재생 확인) — 머지 전 확인 부탁드립니다

## 아키텍처 체크

- [x] core → app import 없음 (`test_no_qt_import` 통과, 키 취득은 리졸버 주입)
- [x] view에서 core 직접 호출 없음
- [x] **제안 구역 변경 있음 — 의존성 추가 `pycryptodome`** (승인 이슈 #57). 표준 라이브러리에 AES가 없고, 순수 파이썬 구현은 GB 단위에 실용 속도가 안 나오며, ffmpeg에 복호화를 맡기면 멀티스레드 엔진·진행률·일시정지를 잃습니다. `cryptography`(Rust 백엔드 + cffi)보다 바이너리 증가가 작아 Nuitka onefile에 유리하다고 판단했습니다

## 리뷰어에게

- **`docs/SPEC.md` 갱신이 필요합니다** — §8.1의 "구현은 v2.9.0 예약"과 §9 표의 "AES(SEA) 복호화 착수" 항목이 이 PR로 해소됩니다. SPEC은 금지 구역이라 건드리지 않았으니 오너가 반영해 주세요.
- **워커 예외로 인한 실행 루프 무한 대기를 발견해 막았습니다.** 복호화 예외가 워커에서 전파되면 `future_dict` 항목이 정리되지 않아 `run()`의 루프가 끝나지 않습니다(기존 file/m3u8 엔진에도 있는 잠재 경로지만, 복호화는 실제로 예외가 날 수 있는 경로라 대응했습니다). 대응은 두 겹입니다: ①`prepare()`에서 풀을 띄우기 전에 첫 세그먼트로 키를 검증 ②워커에서 복호화 예외를 잡아 다운로드 전체를 중단(`_fail_fatally`). 재큐잉하지 않는 이유는 복호화 실패가 재시도로 낫지 않아 무한 루프가 되기 때문입니다.
- 진행률 표시는 `content_type in ("m3u8", "hls_aes")`를 `ContentItem.is_segment_based`로 묶었습니다. 병합 분모는 m3u8만 초기화 세그먼트 1개를 더하므로 타입별로 갈립니다.
- 키·쿠키 값은 코드·로그·테스트·이 PR 어디에도 넣지 않았습니다. 검증에 쓴 프로브는 커밋하지 않았습니다.
- 오디오는 비디오 TS에 먹싱되어 있어 별도 트랙 처리가 필요 없었습니다(조사 시점 추정과 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
