### PR TITLE
feat: m3u8·hls_aes 병합 산출물을 ffmpeg remux로 재포장 (#88)

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -104,6 +104,16 @@ uv run python main.py    # run the app
 
 ---
 
+## 📄 License
+
+- This program is distributed under the [GPL-3.0](LICENSE) license.
+- Distributions include an [FFmpeg](https://ffmpeg.org) executable used to remux merged segment outputs
+  — a GPL-build binary bundled by the pip package [imageio-ffmpeg](https://github.com/imageio/imageio-ffmpeg) (BSD-2-Clause).
+  FFmpeg is a product of the FFmpeg project; its source code is available from the
+  [official FFmpeg repository](https://github.com/FFmpeg/FFmpeg) and the respective build providers.
+
+---
+
 ## 📚 References
 - This project was developed with reference to [chzzk-vod-downloader](https://github.com/24802/chzzk-vod-downloader).
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ uv run python main.py    # 앱 실행
 
 ---
 
+## 📄 라이선스
+
+- 본 프로그램은 [GPL-3.0](LICENSE) 라이선스로 배포됩니다.
+- 배포본에는 세그먼트 병합 산출물의 재포장(remux)에 사용하는 [FFmpeg](https://ffmpeg.org) 실행 파일이 포함됩니다
+  — pip 패키지 [imageio-ffmpeg](https://github.com/imageio/imageio-ffmpeg)(BSD-2-Clause)가 동봉하는 GPL 빌드 바이너리입니다.
+  FFmpeg는 FFmpeg 프로젝트의 저작물이며, 소스 코드는 [FFmpeg 공식 저장소](https://github.com/FFmpeg/FFmpeg)와
+  각 빌드 제공처에서 구할 수 있습니다.
+
+---
+
 ## 📚 참고 자료
 - 본 프로그램은 [chzzk-vod-downloader](https://github.com/24802/chzzk-vod-downloader)를 참고하여 개발되었습니다.
 

--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -48,6 +48,7 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
 data·logger는 DownloadData/DownloadLogger 호환 객체를 주입받는다.
 """
 
+import os
 import threading
 import time as tm
 from abc import ABC, abstractmethod
@@ -63,6 +64,7 @@ from core.models.events import (
     ProgressEvent,
 )
 from core.models.plan import DownloadPlan
+from core.utils.ffmpeg import FFmpegError, remux
 
 
 class BaseDownloader(ABC):
@@ -175,6 +177,27 @@ class BaseDownloader(ABC):
 
         계획(DownloadPlan)의 requires_postprocess가 참일 때만 run()이 호출한다.
         """
+
+    def _remux_with_fallback(self, merged_path: str) -> None:
+        """병합본을 ffmpeg remux(스트림 복사)로 산출물에 재포장한다 (#88).
+
+        바이트 연결 병합본은 라이브 원본 타임라인을 그대로 보유하고 전역
+        인덱스가 없어 편집 프로그램이 읽지 못한다. remux가 실패하면 병합본을
+        그대로 산출물로 옮겨 최악의 경우에도 현행(바이트 연결) 수준을
+        보장한다 — 폴백 시 경고를 남기고, 무음으로 실패하지 않는다.
+
+        세그먼트 기반 postprocess()에서 병합 직후에 호출한다.
+        """
+        # 일시정지 중이면 재개를 기다린 뒤 remux를 시작한다 (세그먼트 병합과
+        # 같은 규칙). 시작된 remux는 원자적으로 끝까지 수행된다
+        if self.state == DownloadState.PAUSED:
+            self.s._pause_event.wait()
+        try:
+            remux(merged_path, self.s.output_path)
+            os.remove(merged_path)
+        except FFmpegError as e:
+            self.logger.warning(f"ffmpeg remux failed, falling back to byte concat: {e}")
+            os.replace(merged_path, self.s.output_path)
 
     def _initial_queue(self, items: list) -> list:
         """시작 시 작업 큐를 구성한다 (기본: 계획의 items 그대로)."""

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -191,10 +191,20 @@ class HlsAesDownloader(BaseDownloader):
     # ============ 후처리: 순서 보장 병합 ============
 
     def postprocess(self) -> None:
-        """복호화된 세그먼트 파일들을 인덱스 순서대로 결과 파일에 병합한다."""
+        """복호화 세그먼트들을 순서대로 병합한 뒤 ffmpeg remux로 재포장한다 (#88).
+
+        바이트 연결만으로는 MPEG-TS 스트림이 .mp4 이름으로 저장되는 컨테이너
+        불일치에 더해, 라이브 원본 타임라인(시작 오프셋≠0)과 전역 인덱스
+        부재가 그대로다 — m3u8(fMP4) 경로와 같은 제약이라 같은 처리를 한다.
+        remux가 실패하면 병합본(TS 바이트 연결)을 그대로 산출물로 옮긴다.
+        """
         self._on_merge_start()
-        with open(self.s.output_path, "wb") as final_f:
-            for seg_file in sorted(os.listdir(self.temp_dir)):
+        # 병합본은 임시 폴더 안에 만든다 — 목록 스냅샷 이후에 생성하므로
+        # 병합 대상에 섞이지 않고, 실패·중단 정리 경로(temp_dir 삭제)에 덮인다
+        segment_files = sorted(os.listdir(self.temp_dir))
+        merged_path = os.path.join(self.temp_dir, "_merged.part")
+        with open(merged_path, "wb") as final_f:
+            for seg_file in segment_files:
                 # 다운로드 중지 상태라면 중단
                 if self.state == DownloadState.RUNNING:
                     seg_path = os.path.join(self.temp_dir, seg_file)
@@ -209,6 +219,10 @@ class HlsAesDownloader(BaseDownloader):
                                 self.s._pause_event.wait()
                     self.safe_remove(seg_path)
                     self.s.merged_segments += 1
+        if self.state == DownloadState.WAITING:
+            # 중단 — 부분 산출물 정리는 run()의 중단 경로가 수행한다
+            return
+        self._remux_with_fallback(merged_path)
 
     # ============ 다운로드 동작 ============
 

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -13,7 +13,8 @@ m3u8 고유 부분만 남는다:
 - _prepare_output: 임시 폴더 재생성 + EXT-X-MAP 초기화 세그먼트 다운로드
 - _download_segment: 세그먼트 단위 다운로드 — 저속 재시도·일시정지·중단
   핸들링 포함. 규칙은 tests/unit/core/test_m3u8_downloader_rules.py가 박제한다
-- postprocess: 순서 보장 병합 — 시작은 on_merge_start 콜백으로 알린다
+- postprocess: 순서 보장 병합 + ffmpeg remux 재포장 (#88) — 시작은
+  on_merge_start 콜백으로 알리고, remux 실패 시 바이트 연결로 폴백한다
 - 스레드 스케일링 기준 속도는 해상도별 테이블(_get_standard_speed)
 - 전체 크기를 미리 알 수 없어 ProgressEvent.total_size는 None이다.
   진행률 계산(세그먼트 수 기반)은 어댑터의 몫이다.
@@ -126,10 +127,18 @@ class M3U8Downloader(BaseDownloader):
     # ============ 후처리: 순서 보장 병합 (구 run의 (4)) ============
 
     def postprocess(self) -> None:
-        """세그먼트 파일들을 인덱스 순서대로 결과 파일에 병합한다."""
+        """세그먼트들을 인덱스 순서로 병합한 뒤 ffmpeg remux로 재포장한다 (#88).
+
+        바이트 연결만으로는 fMP4 조각 구조(전역 인덱스 없음·라이브 타임라인
+        보유)가 그대로라 편집 프로그램이 읽지 못한다. 병합본을 스트림 복사로
+        재포장하고, remux가 실패하면 병합본을 그대로 산출물로 옮긴다.
+        """
         self._on_merge_start()
-        with open(self.s.output_path, "wb") as final_f:
-            segment_files = sorted(os.listdir(self.temp_dir))
+        # 병합본은 임시 폴더 안에 만든다 — 목록 스냅샷 이후에 생성하므로
+        # 병합 대상에 섞이지 않고, 실패·중단 정리 경로(temp_dir 삭제)에 덮인다
+        segment_files = sorted(os.listdir(self.temp_dir))
+        merged_path = os.path.join(self.temp_dir, "_merged.part")
+        with open(merged_path, "wb") as final_f:
             for seg_file in segment_files:
                 # 다운로드 중지 상태라면 중단
                 if self.state == DownloadState.RUNNING:
@@ -146,6 +155,10 @@ class M3U8Downloader(BaseDownloader):
                     # 세그먼트 파일 합친 후 삭제
                     self.safe_remove(seg_path)
                     self.s.merged_segments += 1
+        if self.state == DownloadState.WAITING:
+            # 중단 — 부분 산출물 정리는 run()의 중단 경로가 수행한다
+            return
+        self._remux_with_fallback(merged_path)
 
     # ============ 다운로드 동작 관련 메서드들 ============
 

--- a/core/utils/ffmpeg.py
+++ b/core/utils/ffmpeg.py
@@ -1,0 +1,102 @@
+"""ffmpeg 실행 파일 탐색·remux 유틸 (#88, SPEC §6.5).
+
+세그먼트 병합 산출물은 바이트 연결이라 편집 프로그램이 읽지 못한다 —
+라이브 원본 타임라인(시작 오프셋≠0)을 그대로 보유하고, 전역 인덱스(moov)가
+없기 때문이다. ffmpeg 스트림 복사(remux)로 재포장해 이를 해소한다.
+
+**실행 파일 경로 탐색은 이 모듈 하나에 격리한다** (SPEC §6.5 설계 요건).
+현재 배포 방식은 pip 패키지 imageio-ffmpeg(휠 안에 정적 바이너리 동봉,
+Nuitka가 표준 패키지 설정으로 번들링)이며, 커스텀 빌드 등으로 바뀌어도
+``get_ffmpeg_exe()``만 고치면 된다. 못 찾으면 명확한 예외를 던진다 —
+무음 실패 금지. remux 실패 시의 폴백(바이트 연결 유지)은 호출자
+(다운로더 postprocess)의 책임이다.
+"""
+
+import os
+import subprocess
+import sys
+
+# GUI 앱의 서브프로세스가 콘솔 창을 띄우지 않게 한다 (Windows 전용 플래그)
+_CREATE_NO_WINDOW = 0x08000000
+
+
+class FFmpegError(Exception):
+    """ffmpeg 관련 실패의 공통 상위 예외 — 폴백 판단은 이것 하나로 잡는다."""
+
+
+class FFmpegNotFoundError(FFmpegError):
+    """ffmpeg 실행 파일을 찾지 못했다 — 배포(의존성 설치·번들링) 문제 신호."""
+
+
+class RemuxError(FFmpegError):
+    """remux 실행이 실패했다 — 입력 손상·미지원 컨테이너·디스크 부족 등."""
+
+
+def get_ffmpeg_exe() -> str:
+    """ffmpeg 실행 파일 경로를 반환한다.
+
+    Raises:
+        FFmpegNotFoundError: 패키지 미설치·바이너리 미동봉 등으로 찾지 못한 경우
+    """
+    try:
+        import imageio_ffmpeg
+    except ImportError as e:
+        raise FFmpegNotFoundError(
+            "imageio-ffmpeg 패키지가 설치되어 있지 않다 — 의존성 설치(uv sync)를 확인하라"
+        ) from e
+    try:
+        # imageio_ffmpeg은 휠에 동봉된 바이너리를 찾지 못하면 RuntimeError를 던진다
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception as e:
+        raise FFmpegNotFoundError(f"ffmpeg 실행 파일을 찾지 못했다: {e}") from e
+
+
+def remux(src_path: str, dst_path: str) -> None:
+    """src를 재인코딩 없이(스트림 복사) dst 컨테이너로 재포장한다.
+
+    옵션 근거 (#88 실측 — 치지직 실스트림으로 확인):
+    - ``-c copy``: 재인코딩 금지(이슈 요건). 화질 무손실·수 초 내 완료
+    - 타임스탬프 0 정규화는 ffmpeg 기본 동작이다(-copyts를 주지 않는 한
+      입력 시작 오프셋을 빼고 기록) — 별도 옵션 불필요함을 실측으로 확인
+    - ``-movflags +faststart``: 전역 인덱스(moov)를 파일 선두로 이동.
+      기본값이면 moov가 꼬리에 남아 순차 읽기 도구가 인덱스를 늦게 만난다
+    - 출력 포맷은 dst 확장자로 결정된다. 확장자를 인식하지 못하면 실패가
+      명확히 반환되고 호출자가 폴백한다
+
+    Raises:
+        FFmpegNotFoundError: ffmpeg 실행 파일을 찾지 못한 경우
+        RemuxError: ffmpeg가 0이 아닌 코드로 종료했거나 실행 자체가 실패한 경우
+    """
+    exe = get_ffmpeg_exe()
+    cmd = [
+        exe,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        src_path,
+        "-c",
+        "copy",
+        "-movflags",
+        "+faststart",
+        dst_path,
+    ]
+    creationflags = _CREATE_NO_WINDOW if sys.platform == "win32" else 0
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            creationflags=creationflags,
+        )
+    except OSError as e:
+        raise RemuxError(f"ffmpeg 실행 실패: {e}") from e
+
+    if proc.returncode != 0:
+        # 실패한 부분 산출물을 남기지 않는다 — 폴백이 같은 경로에 쓴다
+        if os.path.exists(dst_path):
+            os.remove(dst_path)
+        stderr_tail = proc.stderr.strip()[-500:]
+        raise RemuxError(f"ffmpeg remux 실패 (exit {proc.returncode}): {stderr_tail}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "2.8.3"
 description = "Chzzk VOD Downloader v2"
 requires-python = ">=3.13"
 dependencies = [
+    "imageio-ffmpeg>=0.6.0",
     "pycryptodome>=3.20",
     "PySide6>=6.8.1.1",
     "requests>=2.32.5",

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -1,17 +1,22 @@
-"""core/utils/ffmpeg.py 검증 (#88) — 경로 탐색·remux 실행.
+"""core/utils/ffmpeg.py 검증 (#88) — 경로 탐색·remux 실행·폴백 정책.
 
 remux 성공 검증은 실제 ffmpeg 바이너리(imageio-ffmpeg 동봉)를 실행한다 —
 입력은 ffmpeg 내장 lavfi 소스로 즉석 생성한 초소형 파일이라 네트워크·외부
-픽스처가 없다.
+픽스처가 없다. 다운로더의 폴백 정책(_remux_with_fallback)은 remux를 스텁으로
+바꿔 단위 수준에서 검증한다.
 """
 
 import os
 import struct
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
-from core.utils.ffmpeg import RemuxError, get_ffmpeg_exe, remux
+import core.downloaders.base as base_module
+from core.downloaders.base import BaseDownloader
+from core.models.download_state import DownloadState
+from core.utils.ffmpeg import FFmpegError, RemuxError, get_ffmpeg_exe, remux
 
 
 def _top_level_boxes(path) -> list[str]:
@@ -92,3 +97,52 @@ def test_remux_invalid_input_raises_and_leaves_no_output(tmp_path):
     with pytest.raises(RemuxError):
         remux(str(src), str(dst))
     assert not dst.exists()  # 무음 실패 금지·쓰레기 산출물 금지
+
+
+# ================================================================ 폴백 정책
+
+
+def _fake_downloader(tmp_path, state=DownloadState.RUNNING):
+    """_remux_with_fallback이 참조하는 최소 속성만 가진 가짜 다운로더."""
+    warnings: list[str] = []
+    fake = SimpleNamespace(
+        state=state,
+        s=SimpleNamespace(output_path=str(tmp_path / "out.mp4")),
+        logger=SimpleNamespace(warning=warnings.append),
+    )
+    return fake, warnings
+
+
+def test_fallback_moves_merged_file_when_remux_fails(tmp_path, monkeypatch):
+    """remux 실패 시 병합본이 그대로 산출물이 되고 경고 1건을 남긴다."""
+    fake, warnings = _fake_downloader(tmp_path)
+    merged = tmp_path / "_merged.part"
+    merged.write_bytes(b"concat-bytes")
+
+    def broken_remux(src, dst):
+        raise FFmpegError("가짜 실패")
+
+    monkeypatch.setattr(base_module, "remux", broken_remux)
+    BaseDownloader._remux_with_fallback(fake, str(merged))
+
+    assert (tmp_path / "out.mp4").read_bytes() == b"concat-bytes"
+    assert not merged.exists()
+    assert len(warnings) == 1 and "remux" in warnings[0]
+
+
+def test_remux_success_removes_merged_file(tmp_path, monkeypatch):
+    """remux 성공 시 병합본은 지우고 산출물만 남긴다."""
+    fake, warnings = _fake_downloader(tmp_path)
+    merged = tmp_path / "_merged.part"
+    merged.write_bytes(b"concat-bytes")
+
+    def fake_remux(src, dst):
+        with open(dst, "wb") as f:
+            f.write(b"remuxed")
+
+    monkeypatch.setattr(base_module, "remux", fake_remux)
+    BaseDownloader._remux_with_fallback(fake, str(merged))
+
+    assert (tmp_path / "out.mp4").read_bytes() == b"remuxed"
+    assert not merged.exists()
+    assert warnings == []

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -1,0 +1,94 @@
+"""core/utils/ffmpeg.py 검증 (#88) — 경로 탐색·remux 실행.
+
+remux 성공 검증은 실제 ffmpeg 바이너리(imageio-ffmpeg 동봉)를 실행한다 —
+입력은 ffmpeg 내장 lavfi 소스로 즉석 생성한 초소형 파일이라 네트워크·외부
+픽스처가 없다.
+"""
+
+import os
+import struct
+import subprocess
+
+import pytest
+
+from core.utils.ffmpeg import RemuxError, get_ffmpeg_exe, remux
+
+
+def _top_level_boxes(path) -> list[str]:
+    """MP4 최상위 박스 이름 목록 — moov(전역 인덱스) 위치 검증용."""
+    boxes = []
+    with open(path, "rb") as f:
+        while True:
+            header = f.read(8)
+            if len(header) < 8:
+                break
+            size, box_type = struct.unpack(">I4s", header)
+            if size < 8:
+                break
+            boxes.append(box_type.decode("latin1"))
+            f.seek(size - 8, os.SEEK_CUR)
+    return boxes
+
+
+def _make_tiny_mp4(path) -> None:
+    """ffmpeg 내장 lavfi·네이티브 mpeg4 인코더로 0.2초짜리 검증용 입력을 만든다.
+
+    외부 코덱 라이브러리(libx264 등) 유무에 좌우되지 않도록 네이티브
+    인코더만 쓴다 — 이 테스트의 대상은 인코딩이 아니라 remux다.
+    """
+    subprocess.run(
+        [
+            get_ffmpeg_exe(),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=duration=0.2:size=64x64:rate=10",
+            "-c:v",
+            "mpeg4",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+# ================================================================ 경로 탐색
+
+
+def test_get_ffmpeg_exe_returns_existing_executable():
+    """탐색 결과는 실재하는 실행 파일 경로여야 한다 (배포 방식 검증의 로컬 관문)."""
+    exe = get_ffmpeg_exe()
+    assert os.path.isfile(exe)
+    assert os.access(exe, os.X_OK)
+
+
+# ================================================================ remux 실행
+
+
+def test_remux_produces_mp4_with_leading_moov(tmp_path):
+    """remux 산출물은 mp4이고 전역 인덱스(moov)가 mdat보다 앞(선두)에 있어야 한다."""
+    src = tmp_path / "src.mp4"
+    dst = tmp_path / "dst.mp4"
+    _make_tiny_mp4(src)
+
+    remux(str(src), str(dst))
+
+    boxes = _top_level_boxes(dst)
+    assert "moov" in boxes and "mdat" in boxes
+    # -movflags +faststart의 목적 그 자체 — moov가 mdat보다 앞이다
+    assert boxes.index("moov") < boxes.index("mdat")
+
+
+def test_remux_invalid_input_raises_and_leaves_no_output(tmp_path):
+    """미디어가 아닌 입력이면 RemuxError를 던지고 부분 산출물을 남기지 않는다."""
+    src = tmp_path / "garbage.bin"
+    dst = tmp_path / "dst.mp4"
+    src.write_bytes(b"this is not media data" * 100)
+
+    with pytest.raises(RemuxError):
+        remux(str(src), str(dst))
+    assert not dst.exists()  # 무음 실패 금지·쓰레기 산출물 금지

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -8,11 +8,13 @@
 키 값은 테스트에서도 의미 없는 더미를 쓴다 — 실제 키는 어디에도 두지 않는다.
 """
 
+import shutil
 import threading
 
 import pytest
 from Crypto.Cipher import AES
 
+import core.downloaders.base as base_module
 import core.downloaders.hls_aes_downloader as aes_module
 from core.api.dash import is_supported_sea, parse_sea_manifest
 from core.downloaders.decrypt import AES_BLOCK_SIZE, TS_PACKET_SIZE, sequence_iv
@@ -203,6 +205,10 @@ def _make_engine(tmp_path, monkeypatch, playlist=None, key_resolver=None):
     monkeypatch.setattr(
         aes_module, "get_thread_session", lambda: FakeSession(playlist or _playlist_text())
     )
+    # remux(#88)는 성공 시 스트림 복사 재포장이다 — 이 파일의 검증 대상은
+    # 복호화·병합(순서·바이트)이므로 파일 복사 스텁으로 대체한다.
+    # 실제 ffmpeg 실행은 test_ffmpeg_utils.py가 검증한다
+    monkeypatch.setattr(base_module, "remux", shutil.copyfile)
 
     finished = threading.Event()
     failures: list[BaseException] = []

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -10,9 +10,11 @@
 - 중단(stop): 결과 파일·임시 폴더 삭제, 완료 콜백 없음
 """
 
+import shutil
 import threading
 import time
 
+import core.downloaders.base as base_module
 import core.downloaders.m3u8_downloader as m3u8_module
 from core.downloaders.m3u8_downloader import M3U8Downloader
 from core.models.download_state import DownloadState
@@ -144,6 +146,10 @@ def _make_engine(tmp_path, monkeypatch, chunks_per_segment: int = 3, throttle: f
     logger = RunLogger()
     session = M3U8Session(chunks_per_segment, throttle)
     monkeypatch.setattr(m3u8_module, "get_thread_session", lambda: session)
+    # remux(#88)는 성공 시 스트림 복사 재포장이다 — 이 파일의 검증 대상은
+    # 병합(순서·바이트)이므로 파일 복사 스텁으로 대체해 가짜 세션과 같은 수준으로
+    # 히메틱하게 유지한다. 실제 ffmpeg 실행은 test_ffmpeg_utils.py가 검증한다
+    monkeypatch.setattr(base_module, "remux", shutil.copyfile)
 
     finished = threading.Event()
     failures: list[BaseException] = []
@@ -191,6 +197,31 @@ def test_run_merges_segments_in_index_order_byte_exact(tmp_path, monkeypatch):
     assert data.completed_threads == SEGMENT_COUNT  # 세그먼트 전부 정상 완료
     assert data.merged_segments == SEGMENT_COUNT + 1  # 초기화 세그먼트 포함 병합
     assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+
+
+def test_remux_failure_falls_back_to_byte_concat(tmp_path, monkeypatch):
+    """remux가 실패하면 경고를 남기고 바이트 연결 병합본을 그대로 산출물로 쓴다 (#88)."""
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    def broken_remux(src, dst):
+        raise base_module.FFmpegError("가짜 remux 실패")
+
+    monkeypatch.setattr(base_module, "remux", broken_remux)
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    # 폴백 산출물은 초기화+세그먼트 바이트 연결과 동일하다 (현행 수준 보장)
+    assert output.read_bytes() == _expected_output(chunks_per_segment=3)
+    assert len(logger.warnings) == 1  # 무음 실패 금지 — 폴백 경고 1건
+    assert "remux" in logger.warnings[0]
+    assert failures == []  # 폴백은 실패가 아니다
+    assert merge_starts == [True]
+    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더(병합본 포함) 삭제
 
 
 def test_pause_resume_then_complete(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,7 @@ name = "cvdv2"
 version = "2.8.3"
 source = { virtual = "." }
 dependencies = [
+    { name = "imageio-ffmpeg" },
     { name = "pycryptodome" },
     { name = "pyside6" },
     { name = "requests" },
@@ -88,6 +89,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "pycryptodome", specifier = ">=3.20" },
     { name = "pyside6", specifier = ">=6.8.1.1" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -108,6 +110,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 관련 이슈

Closes #88

## 변경 내용

커밋 2개로 분리했다 — (가) 인프라 도입, (나) 동작 변경.

**(가) ffmpeg 도입** — `172a8ba`
- SPEC §6.5 결정대로 **pip 패키지 `imageio-ffmpeg>=0.6.0`** 를 의존성에 추가 (휠 안에 정적 ffmpeg 7.1 동봉, 레포에 바이너리 커밋 없음)
- `core/utils/ffmpeg.py` 신설 — **실행 파일 경로 탐색을 이 모듈 하나에 격리**. 탐색 실패 시 `FFmpegNotFoundError`, remux 실패 시 `RemuxError` (무음 실패 금지, 부분 산출물 미잔류)
- README(한/영)에 ffmpeg 동봉 라이선스 고지 추가

**(나) remux 교체** — `8b2db13`
- `BaseDownloader._remux_with_fallback()`: 병합본을 ffmpeg 스트림 복사(`-c copy`, **재인코딩 없음**)로 재포장. `FFmpegError` 시 **경고 로그 후 병합본을 그대로 산출물로 이동**(현행 바이트 연결 수준 보장)
- `M3U8Downloader.postprocess()` / `HlsAesDownloader.postprocess()`: 병합본을 임시 폴더에 만들고 위 헬퍼 호출. 병합 루프(순서·상태 처리)는 무변경
- UI·앱 계층·파일 다운로더 경로 무변경

## 검증 관문 결과표 (SPEC §6.5 / 이슈 완료 조건)

| 관문 | 결과 |
|---|---|
| macOS arm64 휠 존재 | ✅ `imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl` (21.1MB) — PyPI 확인 |
| Nuitka 번들링 | ✅(로컬 근거) Nuitka 표준 패키지 설정(`standard.nuitka-package.config.yml`)에 `imageio_ffmpeg` 항목이 내장 — 바이너리 포함 + standalone 경로 치환을 Nuitka가 자체 처리하므로 **release.yml 수정 불필요**. 최종 확인은 도입 릴리즈 빌드에서 (이슈 명시대로 로컬 확인 한계) |
| 크기 증가폭 | 휠(압축): win_amd64 **31.2MB** / macOS arm64 **21.1MB** / manylinux x86_64 **29.5MB**. 설치 후 바이너리(win) 87.6MB. onefile 최종 증가폭은 릴리즈에서 실측 필요 |
| 라이선스 → README 고지 | ✅ 패키지 BSD-2-Clause, 동봉 바이너리는 GPL 빌드(win: gyan.dev 7.1, `--enable-gpl --enable-version3` 실행 확인 = GPLv3). 본 프로젝트가 GPL-3.0이라 호환. README.md·README-en.md에 고지 반영 |
| 로컬 검증(설치·탐색·실행) | ✅ `uv sync` 설치 → `get_ffmpeg_exe()` 경로 반환 → `-version` 실행 확인 (`ffmpeg version 7.1-essentials_build-www.gyan.dev`) |

VT 탐지 변화(§6.5 관문 4)는 정의상 도입 릴리즈에서 재측정한다.

## remux 옵션 실측 근거 (이슈 요건: 관용구 금지)

실측 대상: 실제 치지직 라이브 다시보기 VOD 14379191 (5시간 19분, 144p, 세그먼트 9,578개, 병합본 477MB)

**현행 산출물의 결함 확인** — init 세그먼트의 moov는 샘플 테이블이 빈(stsz sample_count=0) fMP4 조각 구조이고 세그먼트는 moof/mdat(+emsg). 즉 **전역 인덱스 없음**, 시작 타임스탬프 1.114초(≠0, 라이브 원본 타임라인 보유).

| 옵션 조합 | 결과 |
|---|---|
| `-c copy` (기본) | start **1.114 → 0.000** — **타임스탬프 0 정규화는 ffmpeg 기본 동작**(`-copyts`를 주지 않는 한 시작 오프셋을 빼고 기록)이라 별도 옵션 불필요. duration 5:19:14.95(= 입력 5:19:16.06 − 시작 오프셋). 전역 인덱스(moov 19.9MB)가 재구축되지만 **파일 꼬리**에 놓임: `[ftyp, free, mdat, moov]` |
| `-c copy -movflags +faststart` (**채택**) | 위와 동일 + **moov가 선두**: `[ftyp, moov, free, mdat]` — 이슈 요건 "전역 인덱스를 선두에 배치" 충족 |
| 그 외 옵션 | 불필요 판정 — `avoid_negative_ts`·`output_ts_offset` 등 없이 산출물 전수 디코드 **오류 0**. TS→MP4의 ADTS→ASC 변환(aac_adtstoasc BSF)은 ffmpeg 7.x가 `-c copy`에서 자동 삽입하므로 명시 지정하지 않음(성공·무결성으로 확인) |

**효과 실측**
- 임의 지점 탐색(`-ss 4:00:00` 첫 프레임): 재포장 전 1.05초 → 재포장 후 **0.11초** (전역 인덱스 사용)
- 전수 디코드 검사(`-v error … -f null -`): **오류 0건** (m3u8·AES 산출물 모두)
- remux 소요: 477MB(5.3시간) 기준 **약 17.5초** — 병합 단계가 그만큼 길어진다. 진행 표시는 병합 100% 도달 후 remux 동안 그대로 유지되는 것을 확인(멈춘 것처럼 보이는 구간은 이 십수 초가 전부이며, 근본 해결은 이슈의 "이슈 2" 범위)

## AES(TS) 경로 포함 판단 (근거)

**포함했다.** 근거:
1. **같은 제약** — #57 산출물도 라이브 원본 타임라인을 보유하고 전역 인덱스가 없다. 여기에 더해 **MPEG-TS 바이트가 `.mp4` 이름으로 저장되는 컨테이너 불일치**까지 있어 편집 프로그램 인식 문제가 더 심하다.
2. **실측 확인** — 실제 암호화 VOD 13714380(3시간 2분, 144p) 완주: 다운로드 277,090,160B(TS) → remux 산출물 **234,961,608B의 진짜 MP4**(`[ftyp, moov(선두), free, mdat]`, start 0.000) — TS 패킷화 오버헤드 ~15% 제거는 덤. 폴백 경고 없음(=remux 성공 경로), 전수 디코드 오류 0.
3. **비용 없음** — 공용 헬퍼(`_remux_with_fallback`) 하나로 두 경로가 같은 코드를 쓰고, 실패 시 폴백도 동일하게 보장된다. 이슈 '작업 범위'에 m3u8만 명시된 것은 #57(hls_aes) 머지 전 작성이기 때문으로 판단했다. 파일 다운로더·UI·앱 계층은 무변경.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (242 passed — 신규 7건 포함)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — `tests/unit/core/test_ffmpeg_utils.py` (경로 탐색·remux 실행·폴백 정책), m3u8 run 테스트에 폴백 통합 테스트 추가
- [x] remux 실패 시 폴백 동작 테스트 확인 (`test_remux_failure_falls_back_to_byte_concat`, `test_fallback_moves_merged_file_when_remux_fails`)
- [x] 박제(rules) 테스트 시나리오·단언 무수정 통과
- [x] 헤드리스 m3u8 1건 완주 (14379191 144p) + 헤드리스 hls_aes 1건 완주 (13714380 144p)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — `core/utils/ffmpeg.py`는 표준 라이브러리 + imageio_ffmpeg만 사용
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 해당 없음(UI 무변경)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: **의존성 추가(imageio-ffmpeg)는 #88에서 사전 승인됨**

## 리뷰어에게

- **run 통합 테스트 2파일의 setup에 remux 스텁(파일 복사) 주입 1줄씩 추가했다** — 기존 단언(바이트 일치·경고 0건)은 무수정이며, 가짜 세션과 같은 수준의 히메틱 유지가 목적. 실제 ffmpeg 실행은 `test_ffmpeg_utils.py`가 전담한다. 박제 rules 테스트는 손대지 않았다.
- **디스크 피크가 병합본+산출물 동시 존재 구간(remux 중)에서 약 2배가 된다** — 종전엔 세그먼트를 지우며 병합해 ~1배였다. 실패·중단 시 정리는 기존 경로(temp_dir 삭제)가 그대로 덮는다.
- remux는 원자적으로 수행된다 — 시작 전 일시정지면 재개를 기다리고, 진행 중의 일시정지는 적용되지 않는다(십수 초 구간).
- 사용자가 저장 파일명을 `.mp4` 외 확장자로 바꾼 경우: ffmpeg가 컨테이너를 못 정하면 실패 → 폴백으로 현행과 동일한 산출물이 나온다.
- **SPEC §6.5(착수 표기)·§8.1 갱신은 금지 구역이라 미수정** — 오너 반영 부탁드립니다.
- 오너 검증 요청(완료 조건): 산출물이 ①편집 프로그램에서 인식되고 ②타임라인이 0부터 시작하며 ③임의 지점 탐색이 정확한지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
