### PR TITLE
feat: 리눅스 동봉 ffmpeg의 gconv 크래시 회피 — GCONV_PATH 가드 (#97)

### DIFF
--- a/core/utils/ffmpeg.py
+++ b/core/utils/ffmpeg.py
@@ -23,19 +23,26 @@ Nuitka가 표준 패키지 설정으로 번들링)이며, 커스텀 빌드 등�
 처리하지 못한다 — 4.2.2(2019)·7.0.2·git master 전 세대 공통, 같은 환경의
 distro·BtbN 빌드는 정상임을 CI 교차 실측으로 확인했다. pip 방식은 기반으로
 유지하고, 리눅스에서만 시스템 설치본이 있으면 그것을 쓴다.
+
+**동봉본을 리눅스에서 쓸 때는 GCONV_PATH 가드를 얹는다 (#97).** 크래시의
+근본 원인이 "정적 glibc가 호스트 gconv 모듈을 dlopen → 세대 비호환"으로
+규명되어(#94 4차 진단), 그 로드를 차단하면 동봉본만으로도 TS remux가
+동작한다. 상세는 _subprocess_env 참조.
 """
 
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from collections.abc import Iterable, Iterator
 
 # GUI 앱의 서브프로세스가 콘솔 창을 띄우지 않게 한다 (Windows 전용 플래그)
 _CREATE_NO_WINDOW = 0x08000000
 
-# 리눅스 여부 — 시스템 ffmpeg 우선 탐색(#94)의 스위치. 테스트가 대체한다
+# 리눅스 여부 — 시스템 ffmpeg 우선 탐색(#94)·GCONV_PATH 가드(#97)의 스위치.
+# 테스트가 대체한다
 _IS_LINUX = sys.platform.startswith("linux")
 
 
@@ -96,6 +103,52 @@ def _not_found_message(reason: str) -> str:
     return f"ffmpeg 실행 파일을 찾지 못했다 ({reason}) — {guide}"
 
 
+def _is_bundled_exe(exe: str) -> bool:
+    """exe가 imageio-ffmpeg 동봉 바이너리인지 판정한다 (#97 가드 적용 조건)."""
+    try:
+        import imageio_ffmpeg
+    except ImportError:
+        return False
+    binaries_dir = os.path.realpath(
+        os.path.join(os.path.dirname(imageio_ffmpeg.__file__), "binaries")
+    )
+    return os.path.realpath(exe).startswith(binaries_dir + os.sep)
+
+
+def _subprocess_env(exe: str) -> dict[str, str] | None:
+    """ffmpeg 서브프로세스에 줄 환경을 반환한다. None이면 부모 환경 상속.
+
+    **GCONV_PATH 가드 (#94·#97)**: 리눅스 동봉본(johnvansickle 정적 빌드)은
+    정적 링크된 구세대 glibc가 mpegts SDT 서비스명의 문자셋 변환(iconv)
+    시점에 **호스트의 gconv 공유 모듈을 dlopen**한다. 신형 glibc(우분투
+    24.04/2.39대) 호스트에서는 모듈 세대가 맞지 않아 SIGSEGV — GCONV_PATH를
+    빈 디렉토리로 돌려 그 로드를 차단하면 크래시가 사라진다(#94 4차 실측).
+    부작용은 SDT 서비스명 문자셋 변환 생략뿐이며(A/V 무관), 산출물 바이트
+    동일성은 테스트로 입증한다.
+
+    시스템 ffmpeg(동적 glibc — 자기 배포판의 gconv와 호환)와 Windows·macOS
+    에는 적용하지 않는다. 프로세스 전역(os.environ)은 건드리지 않는다.
+    imageio-ffmpeg가 동봉 빌드 계열을 교체(musl 등)하면 이 가드는 무해한
+    잉여가 되므로 그때 제거해도 된다.
+    """
+    if not _IS_LINUX or not _is_bundled_exe(exe):
+        return None
+    env = os.environ.copy()
+    env["GCONV_PATH"] = _empty_gconv_dir()
+    return env
+
+
+def _empty_gconv_dir() -> str:
+    """GCONV_PATH용 빈 디렉토리를 보장하고 경로를 반환한다.
+
+    존재하지 않는 경로 대신 빈 디렉토리를 쓴다 — "유효한 경로에 모듈이
+    없음"으로 귀결되어 glibc 버전별 경로 오류 처리 차이를 타지 않는다.
+    """
+    path = os.path.join(tempfile.gettempdir(), "cvdv2-empty-gconv")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
 def remux_stream(chunks: Iterable[bytes], dst_path: str) -> None:
     """바이트 스트림을 stdin으로 받아 재인코딩 없이(스트림 복사) mp4로 재포장한다.
 
@@ -141,6 +194,7 @@ def remux_stream(chunks: Iterable[bytes], dst_path: str) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             creationflags=creationflags,
+            env=_subprocess_env(exe),
         )
     except OSError as e:
         raise RemuxError(f"ffmpeg 실행 실패: {e}") from e

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -15,6 +15,7 @@ import functools
 import os
 import struct
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -94,16 +95,18 @@ def _make_tiny_ts(path) -> None:
 def _resolved_ffmpeg_demuxes_ts() -> bool:
     """선택된 ffmpeg가 mpegts 입력을 읽을 수 있는지 1회 검사한다.
 
-    리눅스 동봉본(jvs 정적 빌드 계열)은 mpegts demux 전반이 SIGSEGV다(#94) —
-    시스템 ffmpeg가 없어 동봉본으로 폴백한 환경(CI 포함)에서는 TS 입력
-    검증을 스킵하고, 건강한 ffmpeg가 잡히면 자동 복귀한다.
+    프로덕션(remux_stream)과 같은 조건으로 검사한다 — 리눅스 동봉본에는
+    GCONV_PATH 가드(#97)가 적용되므로 여기서도 적용한다. 가드로도 못 읽는
+    환경이 있으면 TS 입력 검증을 스킵하고, 건강해지면 자동 복귀한다.
     """
     with tempfile.TemporaryDirectory() as d:
         ts = os.path.join(d, "probe.ts")
         _make_tiny_ts(ts)
+        exe = get_ffmpeg_exe()
         proc = subprocess.run(
-            [get_ffmpeg_exe(), "-v", "error", "-i", ts, "-c", "copy", "-f", "null", "-"],
+            [exe, "-v", "error", "-i", ts, "-c", "copy", "-f", "null", "-"],
             capture_output=True,
+            env=ffmpeg_module._subprocess_env(exe),
         )
         return proc.returncode == 0
 
@@ -406,3 +409,139 @@ def test_stop_while_paused_kills_ffmpeg_and_leaves_no_output(tmp_path):
     assert raised == []  # 중단은 예외·실패가 아니다
     assert not (tmp_path / "out.mp4").exists()  # 불완전 산출물 미잔류
     assert all(os.path.exists(p) for p in paths)  # 세그먼트는 건드리지 않는다
+
+
+# ================================================================ GCONV_PATH 가드 (#97)
+
+
+def _explicit_bundled_exe() -> str:
+    """imageio-ffmpeg 동봉 바이너리 경로를 탐색 순서를 거치지 않고 직접 얻는다.
+
+    CI에 시스템 ffmpeg가 있으면 정상 탐색(get_ffmpeg_exe)은 동봉본을 타지
+    않으므로(#95), 가드 검증은 동봉본을 명시 지정해야 한다 (#97 요건).
+    """
+    import imageio_ffmpeg
+
+    binaries = os.path.join(os.path.dirname(imageio_ffmpeg.__file__), "binaries")
+    for name in os.listdir(binaries):
+        if name.startswith("ffmpeg-"):
+            return os.path.join(binaries, name)
+    raise AssertionError("동봉 바이너리를 찾지 못했다")
+
+
+def _strip_sdt(src_path, dst_path) -> None:
+    """TS에서 SDT(PID 0x11) 패킷만 제거한다 — 가드 유무 양쪽이 성공하는 입력용."""
+    data = open(src_path, "rb").read()
+    kept = bytearray()
+    for i in range(0, len(data) - 187, 188):
+        pkt = data[i : i + 188]
+        if pkt[0] == 0x47 and ((pkt[1] & 0x1F) << 8) | pkt[2] == 0x11:
+            continue
+        kept.extend(pkt)
+    open(dst_path, "wb").write(bytes(kept))
+
+
+def test_gconv_guard_applied_for_bundled_on_linux(monkeypatch):
+    """리눅스+동봉본 조합에서만 GCONV_PATH 가드가 적용된다 — 빈 디렉토리·전역 불변."""
+    monkeypatch.setattr(ffmpeg_module, "_IS_LINUX", True)
+    env = ffmpeg_module._subprocess_env(_explicit_bundled_exe())
+
+    assert env is not None and "GCONV_PATH" in env
+    assert os.path.isdir(env["GCONV_PATH"])
+    assert os.listdir(env["GCONV_PATH"]) == []  # 빈 디렉토리 — 모듈 로드 차단
+    assert "GCONV_PATH" not in os.environ  # 프로세스 전역은 건드리지 않는다
+
+
+def test_gconv_guard_not_applied_for_system_exe(monkeypatch):
+    """시스템 ffmpeg(동적 glibc — 자기 배포판과 호환)에는 가드를 적용하지 않는다."""
+    monkeypatch.setattr(ffmpeg_module, "_IS_LINUX", True)
+    assert ffmpeg_module._subprocess_env("/usr/bin/ffmpeg") is None
+
+
+def test_gconv_guard_not_applied_off_linux(monkeypatch):
+    """리눅스가 아니면 동봉본이어도 가드를 적용하지 않는다 (Windows·macOS 무영향)."""
+    monkeypatch.setattr(ffmpeg_module, "_IS_LINUX", False)
+    assert ffmpeg_module._subprocess_env(_explicit_bundled_exe()) is None
+
+
+def test_remux_stream_passes_guard_env_to_subprocess(tmp_path, monkeypatch):
+    """remux_stream은 _subprocess_env가 준 환경을 그대로 서브프로세스에 전달한다."""
+    import io
+
+    sentinel_env = dict(os.environ, CVDV2_GUARD_MARKER="1")
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured.update(kwargs)
+            self.stdin = io.BytesIO()
+            self.stderr = io.BytesIO(b"")
+
+        def wait(self):
+            return 0
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(ffmpeg_module, "_subprocess_env", lambda exe: sentinel_env)
+    monkeypatch.setattr(ffmpeg_module.subprocess, "Popen", _FakePopen)
+
+    remux_stream(iter([b"x"]), str(tmp_path / "out.mp4"))
+
+    assert captured["env"] is sentinel_env
+
+
+# ================ CI(리눅스) 전용 — 동봉본 명시 지정 실검증 (#97 완료 조건)
+
+
+def test_bundled_ts_remux_succeeds_with_guard(tmp_path, monkeypatch):
+    """최신 배포판(CI)에서 동봉본만으로 TS remux가 성공한다 — #97의 목적 그 자체.
+
+    가드 도입 전에는 이 remux가 SIGSEGV였다(#94). 동봉본을 명시 지정해
+    탐색 순서(시스템 우선)에 좌우되지 않게 한다.
+    """
+    if not sys.platform.startswith("linux"):
+        pytest.skip("리눅스 동봉본 전용 검증")
+    bundled = _explicit_bundled_exe()
+    monkeypatch.setattr(ffmpeg_module, "get_ffmpeg_exe", lambda: bundled)
+    monkeypatch.setitem(globals(), "get_ffmpeg_exe", lambda: bundled)
+
+    src = tmp_path / "src.ts"
+    dst = tmp_path / "dst.mp4"
+    _make_tiny_ts(src)  # SDT 포함 — 가드 없이는 크래시하는 입력
+
+    remux_stream(read_in_chunks(str(src)), str(dst))
+
+    boxes = _top_level_boxes(dst)
+    assert boxes.index("moov") < boxes.index("mdat")
+
+
+def test_guard_output_is_byte_identical(tmp_path, monkeypatch):
+    """가드 적용 전후 산출물이 바이트 단위로 동일하다 — A/V 무영향 입증 (#97).
+
+    양쪽 다 성공하는 입력(fMP4, SDT 제거 TS)으로 비교한다 — SDT 포함 TS는
+    가드 없이는 크래시라 '전' 산출물 자체가 존재하지 않는다.
+    """
+    if not sys.platform.startswith("linux"):
+        pytest.skip("리눅스 동봉본 전용 검증")
+    bundled = _explicit_bundled_exe()
+    monkeypatch.setattr(ffmpeg_module, "get_ffmpeg_exe", lambda: bundled)
+    monkeypatch.setitem(globals(), "get_ffmpeg_exe", lambda: bundled)
+
+    fmp4 = tmp_path / "src.mp4"
+    _make_tiny_fmp4(fmp4)
+    ts_full = tmp_path / "full.ts"
+    _make_tiny_ts(ts_full)
+    ts_nosdt = tmp_path / "nosdt.ts"
+    _strip_sdt(ts_full, ts_nosdt)
+
+    for src in (fmp4, ts_nosdt):
+        guarded = tmp_path / f"{src.stem}_guarded.mp4"
+        remux_stream(read_in_chunks(str(src)), str(guarded))  # 가드 자동 적용
+
+        unguarded = tmp_path / f"{src.stem}_unguarded.mp4"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(ffmpeg_module, "_subprocess_env", lambda exe: None)
+            remux_stream(read_in_chunks(str(src)), str(unguarded))
+
+        assert guarded.read_bytes() == unguarded.read_bytes(), f"{src.name} 산출물 상이"


### PR DESCRIPTION
## 관련 이슈

Closes #97

## 변경 내용

`core/utils/ffmpeg.py` 한 파일 + 테스트. **리눅스에서 동봉 ffmpeg를 실행할 때만** 서브프로세스 환경에 `GCONV_PATH` 가드를 얹는다:

- `_subprocess_env(exe)`: `_IS_LINUX`이고 exe가 imageio-ffmpeg 동봉 바이너리(`_is_bundled_exe` — binaries 디렉토리 realpath 대조)일 때만 `os.environ` 사본에 `GCONV_PATH=<빈 디렉토리>`를 얹어 반환, 그 외 None(부모 환경 상속). **프로세스 전역은 건드리지 않는다** (이슈 요건 2)
- `remux_stream`의 Popen에 `env=_subprocess_env(exe)` 전달 — 앱의 유일한 ffmpeg 호출 지점
- 왜 필요한지(#94의 gconv 메커니즘)와 제거 조건(동봉 빌드 계열 교체 시)을 docstring에 남김 (이슈 요건 4)

## 값 선택 근거 (이슈 요건 3)

**빈 디렉토리** (`<tempdir>/cvdv2-empty-gconv`, 없으면 생성) 채택:
- 존재하지 않는 경로도 크래시를 막는 것은 실측됐지만(#94 4차), "경로 없음"은 glibc 버전별 오류 처리 경로 차이를 탈 여지가 있다. 빈 디렉토리는 항상 "유효한 경로에 변환 모듈 없음"으로 귀결되어 의미가 단일하다.
- 빈 디렉토리 방식 자체도 CI에서 실검증됐다 (아래 — 이 가드로 TS remux 성공).
- 부작용: SDT 서비스명 문자셋 변환 생략(메타데이터) — A/V 무관은 바이트 동일성으로 입증 (아래).

## 검증 (완료 조건 대응)

- **최신 배포판(CI ubuntu-24.04)에서 동봉본만으로 TS remux 성공**: `test_bundled_ts_remux_succeeds_with_guard` — **동봉 바이너리를 탐색 순서 없이 명시 지정**(이슈 요건 6, `_explicit_bundled_exe`가 imageio 패키지 binaries에서 직접 취득). 가드 도입 전에는 SIGSEGV였던 그 입력(SDT 포함 TS) 그대로.
- **가드 전후 바이트 동일성**: `test_guard_output_is_byte_identical` — 가드 유무 양쪽이 성공하는 두 입력(fMP4, SDT 제거 TS)에서 산출물 바이트 완전 일치. SDT 포함 TS는 가드 없이는 크래시라 '전' 산출물이 존재하지 않음을 테스트 docstring에 명시.
- **시스템·타 OS 무영향**: `test_gconv_guard_not_applied_for_system_exe`(시스템 경로엔 None), `test_gconv_guard_not_applied_off_linux`(비리눅스엔 None), `test_gconv_guard_applied_for_bundled_on_linux`(전역 os.environ 불변·빈 디렉토리 확인), `test_remux_stream_passes_guard_env_to_subprocess`(환경 전달 배선)
- pytest 전체 통과 (로컬 257 passed + 리눅스 전용 2건은 CI에서 실행), ruff·core 순수성 가드 통과
- 부수 효과: TS 헬스체크가 프로덕션과 같은 가드 조건으로 검사하게 되어, **그간 CI에서 스킵되던 `test_remux_stream_ts_input_produces_mp4`가 실행으로 복귀**한다 (#92에서 "빌드가 고쳐지면 자동 복귀" 하도록 설계해 둔 지점)

## 아키텍처 체크

- [x] core → app import 없음 — 표준 라이브러리(tempfile)만 추가
- [x] view에서 core 직접 호출 없음 — 해당 없음
- [x] 제안 구역 변경 없음 — 의존성 무변경, 승인 이슈 #97

## 리뷰어에게

- #95(시스템 우선 탐색)와 보완 관계다: 시스템 ffmpeg가 있으면 그쪽(가드 불필요·미적용), 없으면 동봉본+가드로 동작 — 이제 **시스템 ffmpeg 없는 최신 배포판에서도 AES(TS) 경로가 살아난다**.
- imageio-ffmpeg가 동봉 빌드를 musl 계열 등으로 교체하면 가드는 무해한 잉여가 된다 — 제거 조건을 `_subprocess_env` docstring에 남겼다.
- 빈 디렉토리는 OS 임시 폴더 아래 고정 이름으로 생성한다(멱등). 앱 데이터 폴더가 아닌 이유: 이 디렉토리는 내용이 없는 것 자체가 기능이라 보존 가치가 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
