### PR TITLE
chore: 릴리즈 ffmpeg 검증

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Sync dependencies
         run: uv sync
 
+      - name: Verify ffmpeg (3-OS)
+        run: uv run pytest -q -k ffmpeg
+        
       - name: Verify version matches tag
         shell: bash
         run: |


### PR DESCRIPTION
빌드 매트릭스(3-OS)에서 ffmpeg 관련 테스트를 실행해, 특히 macOS에서 한 번도 실행된 적 없는 ffmpeg 경로를 릴리즈 전에 검증한다. 실패 시 아티팩트가 나가지 않는다.