### PR TITLE
chore: v2.9.0-rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cvdv2"
-version = "2.8.3"
+version = "2.9.0-rc1"
 description = "Chzzk VOD Downloader v2"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "cvdv2"
-version = "2.8.3"
+version = "2.9.0rc1"
 source = { virtual = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },


### PR DESCRIPTION
버전 범프. 머지하면 태그 v2.9.0-rc1이 자동 생성되고 릴리즈 빌드가 시작됩니다.