### PR TITLE
chore: ffmpeg 검증 스텝 순서 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
 
       - name: Sync dependencies
         run: uv sync
-
-      - name: Verify ffmpeg (3-OS)
-        run: uv run pytest -q -k ffmpeg
         
       - name: Verify version matches tag
         shell: bash
@@ -55,6 +52,11 @@ jobs:
             patchelf xvfb libegl1 libgl1 libxkbcommon-x11-0 libxcb-icccm4 \
             libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
             libxcb-shape0 libxcb-xinerama0 libxcb-cursor0 libdbus-1-3 imagemagick
+
+      - name: Verify ffmpeg (3-OS)
+        run: uv run pytest -q -k ffmpeg
+        env:
+          QT_QPA_PLATFORM: offscreen
 
       - name: Build (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
pytest-qt가 PySide6를 로드하려면 Qt 런타임 라이브러리가 필요한데, 검증 스텝이 Install Linux build deps보다 앞에 있어 libEGL.so.1을 찾지 못하고 실패했다. 설치 스텝 뒤로 옮기고 QT_QPA_PLATFORM=offscreen을 지정한다.