### PR TITLE
chore: macOS 스모크 실행 대상 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,8 @@ jobs:
       - name: Boot smoke + screenshot (macOS)
         if: runner.os == 'macOS'
         run: |
-          BIN=$(find build/CVDv2.app/Contents/MacOS -type f -perm +111 | head -1)
+          EXEC=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" build/CVDv2.app/Contents/Info.plist)
+          BIN="build/CVDv2.app/Contents/MacOS/$EXEC"
           echo "실행 대상: $BIN"
           "$BIN" &
           PID=$!


### PR DESCRIPTION
ffmpeg 동봉 이후 Contents/MacOS 하위에 실행 가능한 바이너리가 늘어나 find가 앱 본체 대신 imageio_ffmpeg 바이너리를 집었다. Info.plist의 CFBundleExecutable을 읽어 실행 대상을 특정한다 — 진입점 개명(Phase 5) 이후에도 깨지지 않는다.