### PR TITLE
fix: 같은 제목 VOD 다운로드 시 기존 파일 덮어쓰기 방지 (#105)

### DIFF
--- a/content/manager.py
+++ b/content/manager.py
@@ -7,6 +7,7 @@ from content.delegate import ContentListDelegate
 from content.data import ContentItem
 from download.state import DownloadState
 from content.worker import ContentWorker
+from core.utils.paths import build_output_path, ensure_unique_path
 
 class ContentManager(QObject):
     # 메타데이터 매니저 UI
@@ -96,13 +97,11 @@ class ContentManager(QObject):
         해상도 버튼 클릭 시 다운로드 진행.
         """
         if item:
-            title = item.title
-            resolution = item.resolution
-            default_filename = f"{title} {resolution}p.mp4"
+            # 조립·중복 회피는 core가 단일 지점으로 담당한다 — 같은 제목이
+            # 이미 있으면 " (n)"이 붙은 새 경로를 받는다 (#105)
+            item.output_path = build_output_path(item.download_path, item.title, item.resolution)
         else:
-            default_filename = "video.mp4"
-
-        item.output_path = os.path.join(item.download_path, default_filename)
+            item.output_path = ensure_unique_path(os.path.join(item.download_path, "video.mp4"))
 
         if item.output_path:
             # 다운로드 요청 시그널 발행

--- a/content/network.py
+++ b/content/network.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 from core.api.dash import is_supported_sea, parse_dash_manifest, parse_sea_manifest
 from core.api.url_parser import extract_content_no
 from core.models.content import VideoInfo
+from core.utils.paths import sanitize_filename
 
 # Session 관리는 core/api/session.py로 이주했다 (#62, 원본 #31).
 # _session은 아래 NetworkManager가 계속 사용하고, 나머지는 기존 호출부 호환용 re-export다.
@@ -54,7 +55,7 @@ class NetworkManager:
 
         content = response.json().get('content', {})
         metadata = {
-            'title': re.sub(r'[\\/:\*\?"<>|\n]', '', content.get('videoTitle', 'Unknown Title')), # 정규식으로 특수문자 제거
+            'title': sanitize_filename(content.get('videoTitle', 'Unknown Title')), # 금지 문자·제어 문자 제거 (#105)
             'thumbnailImageUrl': content.get('thumbnailImageUrl', ''),
             'category': content.get('videoCategoryValue', 'Unknown Category'),
             'channelName': content.get('channel', {}).get('channelName', 'Unknown Channel'),
@@ -183,7 +184,7 @@ class NetworkManager:
         vodStatus = content.get('vodStatus')
 
         metadata = {
-            'title': re.sub(r'[\\/:\*\?"<>|\n]', '', content.get('clipTitle', 'Unknown Title')), # 정규식으로 특수문자 제거
+            'title': sanitize_filename(content.get('clipTitle', 'Unknown Title')), # 금지 문자·제어 문자 제거 (#105)
             'thumbnailImageUrl': content.get('thumbnailImageUrl', ''),
             'category': content.get('clipCategory', 'Unknown Category'),
             'channelName': content.get('optionalProperty', {}).get('ownerChannel', {}).get('channelName', 'Unknown Channel'),

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -33,6 +33,7 @@ from core.downloaders.decrypt import decrypt_segment, looks_like_ts, sequence_iv
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
 from core.models.plan import DownloadPlan
+from core.utils.paths import temp_dir_for
 
 
 class DecryptionError(Exception):
@@ -58,8 +59,9 @@ class HlsAesDownloader(BaseDownloader):
 
     def __init__(self, data, logger, **callbacks):
         super().__init__(data, logger, **callbacks)
-        # 세그먼트 저장용 임시 폴더 (실패 정리 경로가 참조하므로 실행 전에 확정)
-        self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
+        # 세그먼트 저장용 임시 폴더 (실패 정리 경로가 참조하므로 실행 전에 확정).
+        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105)
+        self.temp_dir = temp_dir_for(self.s.output_path)
         self._key: bytes | None = None
         self._playlist = None
 

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -33,6 +33,7 @@ from core.downloaders.base import BaseDownloader
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
 from core.models.plan import DownloadPlan
+from core.utils.paths import temp_dir_for
 
 
 class M3U8Downloader(BaseDownloader):
@@ -51,8 +52,9 @@ class M3U8Downloader(BaseDownloader):
 
     def __init__(self, data, logger, **callbacks):
         super().__init__(data, logger, **callbacks)
-        # 세그먼트 저장용 임시 폴더 경로 (실패 정리 경로가 참조하므로 실행 전에 확정)
-        self.temp_dir = os.path.join(os.path.dirname(self.s.output_path), "CVDv2_temp")
+        # 세그먼트 저장용 임시 폴더 경로 (실패 정리 경로가 참조하므로 실행 전에 확정).
+        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105)
+        self.temp_dir = temp_dir_for(self.s.output_path)
 
     @classmethod
     def supports(cls, content: Content) -> bool:

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -14,6 +14,7 @@
 문서화한다.
 """
 
+import hashlib
 import os
 import re
 
@@ -21,6 +22,13 @@ import re
 # 제목은 조회 단계에서 이미 정제되지만, core를 직접 쓰는 경로(헤드리스·다른 UI)가
 # 정제를 빠뜨려도 안전하도록 여기서도 방어한다.
 _INVALID_FILENAME_CHARS = re.compile(r'[\\/:\*\?"<>|\n]')
+
+# Windows 예약 장치명 — 이름 시작이 예약어이고 바로 뒤가 끝·점·공백이면 방어한다.
+# 이 앱의 파일명은 항상 " {해상도}p.mp4"가 뒤에 붙어 이름 전체가 예약어와 일치할 수는
+# 없지만, 레거시 장치명 판정(RtlIsDosDeviceName)은 "CON."처럼 예약어+점 시작도 장치로
+# 볼 수 있다. Windows 11 실측으로는 CON.mp4도 생성되지만(예약 완화) 지원 대상인
+# Windows 10이 여전히 예약하므로 보수적으로 막는다.
+_RESERVED_DEVICE_NAMES = re.compile(r"(?i)^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?=$|[. ])")
 
 # 산출물 전체 경로 길이 상한 — Windows 기본 MAX_PATH(260)에서 중복 회피
 # 접미사 " (n)"과 임시 폴더 접두사("CVDv2_temp_") 여유분을 뺀 값
@@ -53,16 +61,26 @@ def build_output_path(directory: str, title: str, resolution: int) -> str:
     """산출물 전체 경로를 조립한다 — 정제·길이 제한·중복 회피 포함.
 
     파일명 형식은 기존과 동일한 `{제목} {해상도}p.mp4`이고, 같은 이름이
-    이미 있을 때만 " (n)"이 붙는다. 전체 경로가 상한을 넘으면 제목
-    부분만 잘라 맞춘다 (해상도 접미사·확장자는 보존).
+    이미 있을 때만 " (n)"이 붙는다. 전체 경로가 상한을 넘으면 제목 부분만
+    잘라 맞추되(해상도 접미사·확장자 보존), 원제목의 해시 6자리를 함께
+    붙인다 — 앞부분이 같은 긴 제목들이 절단 후 동일해져 " (n)"만으로
+    구분되는(식별성 저하) 사태를 막기 위함이다. 끝 점·공백 문제는 이름
+    끝에 항상 접미사가 붙는 구조라 발생하지 않는다(제목의 점은 이름
+    중간에 놓인다).
     """
     safe_title = sanitize_filename(str(title)) or "video"
+    if _RESERVED_DEVICE_NAMES.match(safe_title):
+        safe_title = "_" + safe_title
     suffix = f" {resolution}p.mp4"
     candidate = os.path.join(directory, safe_title + suffix)
     overflow = len(candidate) - _MAX_FULLPATH
     if overflow > 0:
-        keep = max(1, len(safe_title) - overflow)
-        candidate = os.path.join(directory, safe_title[:keep].rstrip() + suffix)
+        # 절단 표식 " ~{해시6}" — 같은 원제목이면 같은 이름(결정적),
+        # 다른 원제목이면 절단 후에도 서로 다른 이름이 된다
+        digest = hashlib.sha1(safe_title.encode("utf-8")).hexdigest()[:6]
+        marker = f" ~{digest}"
+        keep = max(1, len(safe_title) - overflow - len(marker))
+        candidate = os.path.join(directory, safe_title[:keep].rstrip() + marker + suffix)
     return ensure_unique_path(candidate)
 
 

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -18,10 +18,11 @@ import hashlib
 import os
 import re
 
-# Windows에서 파일명에 쓸 수 없는 문자 + 개행 (content/network.py의 제목 정제와 동일 집합).
-# 제목은 조회 단계에서 이미 정제되지만, core를 직접 쓰는 경로(헤드리스·다른 UI)가
-# 정제를 빠뜨려도 안전하도록 여기서도 방어한다.
-_INVALID_FILENAME_CHARS = re.compile(r'[\\/:\*\?"<>|\n]')
+# Windows에서 파일명에 쓸 수 없는 문자 + ASCII 제어 문자 전체(0x00–0x1F, 개행 포함).
+# Windows는 제어 문자가 든 파일명 생성을 거부한다(EINVAL). 조회 단계
+# (content/network.py)의 제목 정제도 이 함수를 쓰지만, core를 직접 쓰는 경로
+# (헤드리스·다른 UI)가 정제를 빠뜨려도 안전하도록 여기서도 방어한다.
+_INVALID_FILENAME_CHARS = re.compile(r'[\\/:\*\?"<>|\x00-\x1f]')
 
 # Windows 예약 장치명 — 이름 시작이 예약어이고 바로 뒤가 끝·점·공백이면 방어한다.
 # 이 앱의 파일명은 항상 " {해상도}p.mp4"가 뒤에 붙어 이름 전체가 예약어와 일치할 수는
@@ -33,6 +34,12 @@ _RESERVED_DEVICE_NAMES = re.compile(r"(?i)^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])
 # 산출물 전체 경로 길이 상한 — Windows 기본 MAX_PATH(260)에서 중복 회피
 # 접미사 " (n)"과 임시 폴더 접두사("CVDv2_temp_") 여유분을 뺀 값
 _MAX_FULLPATH = 240
+
+# 파일명(구성요소 하나)의 UTF-8 바이트 길이 상한 — POSIX 파일시스템(ext4 등)의
+# 구성요소 제한 255바이트에서 " (n)"·임시 폴더 접두사(11바이트) 여유분을 뺀 값.
+# 한글은 UTF-8로 3바이트라 문자 수 상한(_MAX_FULLPATH)만으로는 리눅스에서
+# ENAMETOOLONG이 날 수 있다 (헤드리스 스크립트·CI가 리눅스에서 돈다)
+_MAX_FILENAME_BYTES = 240
 
 
 def sanitize_filename(name: str) -> str:
@@ -61,26 +68,36 @@ def build_output_path(directory: str, title: str, resolution: int) -> str:
     """산출물 전체 경로를 조립한다 — 정제·길이 제한·중복 회피 포함.
 
     파일명 형식은 기존과 동일한 `{제목} {해상도}p.mp4`이고, 같은 이름이
-    이미 있을 때만 " (n)"이 붙는다. 전체 경로가 상한을 넘으면 제목 부분만
-    잘라 맞추되(해상도 접미사·확장자 보존), 원제목의 해시 6자리를 함께
-    붙인다 — 앞부분이 같은 긴 제목들이 절단 후 동일해져 " (n)"만으로
-    구분되는(식별성 저하) 사태를 막기 위함이다. 끝 점·공백 문제는 이름
-    끝에 항상 접미사가 붙는 구조라 발생하지 않는다(제목의 점은 이름
-    중간에 놓인다).
+    이미 있을 때만 " (n)"이 붙는다. 전체 경로 문자 수 또는 파일명 바이트
+    수가 상한을 넘으면 제목 부분만 잘라 맞추되(해상도 접미사·확장자 보존),
+    원제목의 해시 6자리를 함께 붙인다 — 앞부분이 같은 긴 제목들이 절단 후
+    동일해져 " (n)"만으로 구분되는(식별성 저하) 사태를 막기 위함이다.
+    끝 점·공백 문제는 이름 끝에 항상 접미사가 붙는 구조라 발생하지
+    않는다(제목의 점은 이름 중간에 놓인다).
     """
     safe_title = sanitize_filename(str(title)) or "video"
     if _RESERVED_DEVICE_NAMES.match(safe_title):
         safe_title = "_" + safe_title
     suffix = f" {resolution}p.mp4"
     candidate = os.path.join(directory, safe_title + suffix)
-    overflow = len(candidate) - _MAX_FULLPATH
-    if overflow > 0:
+    # 상한 둘을 함께 지킨다: 전체 경로 문자 수(Windows MAX_PATH 대비)와
+    # 파일명 구성요소의 UTF-8 바이트 수(POSIX 255바이트 대비)
+    over_chars = len(candidate) - _MAX_FULLPATH
+    over_bytes = len((safe_title + suffix).encode("utf-8")) - _MAX_FILENAME_BYTES
+    if over_chars > 0 or over_bytes > 0:
         # 절단 표식 " ~{해시6}" — 같은 원제목이면 같은 이름(결정적),
-        # 다른 원제목이면 절단 후에도 서로 다른 이름이 된다
+        # 다른 원제목이면 절단 후에도 서로 다른 이름이 된다.
+        # 문자·바이트 어느 쪽 절단이든 동일하게 붙는다
         digest = hashlib.sha1(safe_title.encode("utf-8")).hexdigest()[:6]
         marker = f" ~{digest}"
-        keep = max(1, len(safe_title) - overflow - len(marker))
-        candidate = os.path.join(directory, safe_title[:keep].rstrip() + marker + suffix)
+        keep = max(1, len(safe_title) - over_chars - len(marker))
+        clipped = safe_title[:keep]
+        # 바이트 예산으로 한 번 더 자른다 — UTF-8 바이트열을 자른 뒤 디코드에서
+        # 깨진 꼬리 시퀀스를 버리는 방식이라 문자 경계(한글 3바이트·이모지
+        # 4바이트)가 깨지지 않는다. 문자 절단만 일어난 경우엔 no-op이다
+        byte_budget = _MAX_FILENAME_BYTES - len((marker + suffix).encode("utf-8"))
+        clipped = clipped.encode("utf-8")[:byte_budget].decode("utf-8", "ignore")
+        candidate = os.path.join(directory, clipped.rstrip() + marker + suffix)
     return ensure_unique_path(candidate)
 
 

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -1,0 +1,79 @@
+"""산출물 경로 유틸 — 파일명 조립·중복 회피·임시 폴더 명명 (#105).
+
+산출물 파일명(`{제목} {해상도}p.mp4`) 조립이 GUI(content/manager.py)와
+헤드리스 스크립트(scripts/headless_download.py)에 같은 식으로 중복돼
+있었고, 어느 쪽도 기존 파일 존재를 확인하지 않아 같은 제목의 VOD를
+받으면 이전 파일이 경고 없이 덮어써졌다. 이 모듈이 조립·중복 회피의
+단일 지점이다 — 호출부는 build_output_path 하나만 부른다.
+
+중복 회피 시점: 경로는 다운로드 시작 직전(output_path 배정 시점)에
+확정된다. 앱은 다운로드를 한 건씩 순차 실행하므로(동시 실행 기본 1)
+배정 시점의 존재 확인으로 충분하다. 같은 폴더에 같은 제목을 동시에
+받는 별도 프로세스(GUI+헤드리스 병행 등)까지는 보장하지 않는다 —
+존재 확인과 파일 생성 사이의 원자성이 없기 때문이며, 알려진 한계로
+문서화한다.
+"""
+
+import os
+import re
+
+# Windows에서 파일명에 쓸 수 없는 문자 + 개행 (content/network.py의 제목 정제와 동일 집합).
+# 제목은 조회 단계에서 이미 정제되지만, core를 직접 쓰는 경로(헤드리스·다른 UI)가
+# 정제를 빠뜨려도 안전하도록 여기서도 방어한다.
+_INVALID_FILENAME_CHARS = re.compile(r'[\\/:\*\?"<>|\n]')
+
+# 산출물 전체 경로 길이 상한 — Windows 기본 MAX_PATH(260)에서 중복 회피
+# 접미사 " (n)"과 임시 폴더 접두사("CVDv2_temp_") 여유분을 뺀 값
+_MAX_FULLPATH = 240
+
+
+def sanitize_filename(name: str) -> str:
+    """파일명에 쓸 수 없는 문자를 제거하고 양끝 공백을 정리한다."""
+    return _INVALID_FILENAME_CHARS.sub("", name).strip()
+
+
+def ensure_unique_path(path: str) -> str:
+    """같은 경로가 이미 있으면 확장자 앞에 " (n)"을 붙인 새 경로를 반환한다.
+
+    기존 파일을 절대 덮어쓰지 않기 위한 장치다 (#105 필수 조건).
+    비어 있는 이름이 나올 때까지 n을 1부터 올린다.
+    """
+    if not os.path.exists(path):
+        return path
+    stem, ext = os.path.splitext(path)
+    n = 1
+    while True:
+        candidate = f"{stem} ({n}){ext}"
+        if not os.path.exists(candidate):
+            return candidate
+        n += 1
+
+
+def build_output_path(directory: str, title: str, resolution: int) -> str:
+    """산출물 전체 경로를 조립한다 — 정제·길이 제한·중복 회피 포함.
+
+    파일명 형식은 기존과 동일한 `{제목} {해상도}p.mp4`이고, 같은 이름이
+    이미 있을 때만 " (n)"이 붙는다. 전체 경로가 상한을 넘으면 제목
+    부분만 잘라 맞춘다 (해상도 접미사·확장자는 보존).
+    """
+    safe_title = sanitize_filename(str(title)) or "video"
+    suffix = f" {resolution}p.mp4"
+    candidate = os.path.join(directory, safe_title + suffix)
+    overflow = len(candidate) - _MAX_FULLPATH
+    if overflow > 0:
+        keep = max(1, len(safe_title) - overflow)
+        candidate = os.path.join(directory, safe_title[:keep].rstrip() + suffix)
+    return ensure_unique_path(candidate)
+
+
+def temp_dir_for(output_path: str) -> str:
+    """세그먼트 임시 폴더 경로를 산출물 파일명에서 파생한다.
+
+    구 코드는 고정 이름("CVDv2_temp") 하나를 모든 다운로드가 공유해,
+    같은 폴더로 향하는 두 다운로드가 겹치면 서로의 세그먼트 폴더를
+    삭제·재생성할 수 있었다 (#105 확인 항목 4). 산출물 파일명(중복
+    회피 후)에서 파생하면 다운로드마다 폴더가 구분된다.
+    """
+    directory = os.path.dirname(output_path)
+    stem = os.path.splitext(os.path.basename(output_path))[0]
+    return os.path.join(directory, f"CVDv2_temp_{stem}")

--- a/scripts/headless_download.py
+++ b/scripts/headless_download.py
@@ -49,6 +49,7 @@ from core.models.events import ProgressEvent  # noqa: E402
 from core.services import metadata_service  # noqa: E402
 from core.services.download_service import DownloadService  # noqa: E402
 from core.services.metadata_service import MetadataError  # noqa: E402
+from core.utils.paths import build_output_path  # noqa: E402
 from download.data import DownloadData  # noqa: E402
 from download.logger import DownloadLogger  # noqa: E402
 from download.resolvers import resolve_aes_key, resolve_m3u8_base_url  # noqa: E402
@@ -128,8 +129,8 @@ def _build_item(result: tuple, content_type: str, resolution: int | None) -> Con
         return None
     item.resolution, item.base_url = selected
 
-    filename = f"{item.title} {item.resolution}p.mp4"
-    item.output_path = os.path.join(item.download_path, filename)
+    # 조립·중복 회피는 core가 단일 지점으로 담당한다 — GUI(manager)와 동일 (#105)
+    item.output_path = build_output_path(item.download_path, item.title, item.resolution)
     return item
 
 

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -323,4 +323,4 @@ def test_run_downloads_decrypts_and_merges_in_order(tmp_path, monkeypatch):
     assert data.completed_threads == SEGMENT_COUNT
     # TS 경로에는 초기화 세그먼트가 없어 병합 수 = 세그먼트 수다
     assert data.merged_segments == SEGMENT_COUNT
-    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+    assert not (tmp_path / "CVDv2_temp_out").exists()  # 임시 폴더 삭제 (#105 산출물 파생 이름)

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -203,7 +203,7 @@ def test_run_merges_segments_in_index_order_byte_exact(tmp_path, monkeypatch):
     assert logger.completed_times and logger.closed == 1
     assert data.completed_threads == SEGMENT_COUNT  # 세그먼트 전부 정상 완료
     assert data.merged_segments == SEGMENT_COUNT + 1  # 초기화 세그먼트 포함 병합
-    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+    assert not (tmp_path / "CVDv2_temp_out").exists()  # 임시 폴더 삭제 (#105 산출물 파생 이름)
 
 
 def test_remux_failure_fails_explicitly_and_preserves_segments(tmp_path, monkeypatch):
@@ -232,7 +232,7 @@ def test_remux_failure_fails_explicitly_and_preserves_segments(tmp_path, monkeyp
     assert any(isinstance(e, base_module.PostprocessError) for e in failures)  # 명시적 실패
     assert logger.errors  # 원인 로그 존재
     # 세그먼트(임시 폴더)는 보존된다 — 후처리 실패로 재다운로드를 강요하지 않는다
-    temp_dir = tmp_path / "CVDv2_temp"
+    temp_dir = tmp_path / "CVDv2_temp_out"
     assert temp_dir.exists()
     assert len(list(temp_dir.iterdir())) == SEGMENT_COUNT + 1  # 초기화 세그먼트 포함
     assert merge_starts == [True]
@@ -265,7 +265,7 @@ def test_stop_during_postprocess_cleans_up_without_failure(tmp_path, monkeypatch
     assert not finished.is_set()
     assert failures == []  # 중단은 실패가 아니다
     assert not output.exists()
-    assert not (tmp_path / "CVDv2_temp").exists()  # 중단은 현행대로 전체 정리
+    assert not (tmp_path / "CVDv2_temp_out").exists()  # 중단은 현행대로 전체 정리
 
 
 def test_pause_resume_then_complete(tmp_path, monkeypatch):
@@ -315,6 +315,6 @@ def test_stop_removes_partial_file_and_temp_dir(tmp_path, monkeypatch):
     assert not thread.is_alive()
 
     assert not output.exists()  # 부분 파일 없음
-    assert not (tmp_path / "CVDv2_temp").exists()  # 임시 폴더 삭제
+    assert not (tmp_path / "CVDv2_temp_out").exists()  # 임시 폴더 삭제
     assert not finished.is_set()
     assert failures == []

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -1,0 +1,111 @@
+"""산출물 경로 유틸(core/utils/paths.py) 단위 테스트 (#105).
+
+핵심 계약:
+- 같은 경로가 이미 있으면 절대 덮어쓰지 않고 " (n)"을 붙인 새 경로를 준다
+- 제목의 Windows 금지 문자는 제거되고, 전체 경로 길이는 상한을 넘지 않는다
+- 세그먼트 임시 폴더 이름은 산출물 파일명에서 파생돼 다운로드 간 구분된다
+"""
+
+import os
+
+from core.utils.paths import (
+    build_output_path,
+    ensure_unique_path,
+    sanitize_filename,
+    temp_dir_for,
+)
+
+
+# ================================================================ ensure_unique_path
+
+
+def test_ensure_unique_path_returns_original_when_free(tmp_path):
+    """비어 있는 경로는 그대로 돌려준다 — 기본 파일명은 변하지 않는다."""
+    path = str(tmp_path / "방송 1080p.mp4")
+    assert ensure_unique_path(path) == path
+
+
+def test_ensure_unique_path_appends_counter_when_taken(tmp_path):
+    """이미 파일이 있으면 확장자 앞에 ' (1)'을 붙인다 — 덮어쓰기 금지 필수 조건."""
+    (tmp_path / "방송 1080p.mp4").write_bytes(b"existing")
+    result = ensure_unique_path(str(tmp_path / "방송 1080p.mp4"))
+    assert result == str(tmp_path / "방송 1080p (1).mp4")
+
+
+def test_ensure_unique_path_increments_until_free(tmp_path):
+    """(1)도 차 있으면 (2), (3)… 비어 있는 번호까지 올린다."""
+    (tmp_path / "방송 1080p.mp4").write_bytes(b"a")
+    (tmp_path / "방송 1080p (1).mp4").write_bytes(b"b")
+    result = ensure_unique_path(str(tmp_path / "방송 1080p.mp4"))
+    assert result == str(tmp_path / "방송 1080p (2).mp4")
+
+
+def test_ensure_unique_path_counts_directories_too(tmp_path):
+    """같은 이름의 디렉토리가 있어도 충돌로 본다 (os.path.exists 기준)."""
+    (tmp_path / "방송 1080p.mp4").mkdir()
+    result = ensure_unique_path(str(tmp_path / "방송 1080p.mp4"))
+    assert result == str(tmp_path / "방송 1080p (1).mp4")
+
+
+# ================================================================ 연속 다운로드 시나리오
+
+
+def test_sequential_same_title_downloads_keep_both_files(tmp_path):
+    """완료 조건: 같은 제목 VOD를 연속으로 받아도 두 파일이 모두 남는다."""
+    first = build_output_path(str(tmp_path), "즐거운 방송", 1080)
+    with open(first, "wb") as f:
+        f.write(b"episode-1")
+
+    second = build_output_path(str(tmp_path), "즐거운 방송", 1080)
+    with open(second, "wb") as f:
+        f.write(b"episode-2")
+
+    assert first != second
+    with open(first, "rb") as f:
+        assert f.read() == b"episode-1"  # 기존 파일이 보존된다
+    with open(second, "rb") as f:
+        assert f.read() == b"episode-2"
+
+
+# ================================================================ 정제·길이 제한
+
+
+def test_sanitize_filename_strips_windows_invalid_chars():
+    """Windows 금지 문자와 개행이 제거된다 — content/network.py 정제와 동일 집합."""
+    assert sanitize_filename('a\\b/c:d*e?f"g<h>i|j\nk') == "abcdefghijk"
+
+
+def test_build_output_path_sanitizes_title(tmp_path):
+    """완료 조건: 특수문자가 있는 제목으로도 정상 경로가 나온다."""
+    result = build_output_path(str(tmp_path), '공지: "오늘 방송" <특집>?', 720)
+    assert result == str(tmp_path / "공지 오늘 방송 특집 720p.mp4")
+
+
+def test_build_output_path_falls_back_when_title_empty(tmp_path):
+    """정제 후 제목이 비면 'video'로 대체한다 — ' 1080p.mp4' 같은 이름을 막는다."""
+    result = build_output_path(str(tmp_path), "???", 1080)
+    assert result == str(tmp_path / "video 1080p.mp4")
+
+
+def test_build_output_path_truncates_long_title(tmp_path):
+    """전체 경로가 상한(240자)을 넘으면 제목만 잘라 맞춘다 — 접미사·확장자 보존."""
+    result = build_output_path(str(tmp_path), "가" * 300, 1080)
+    assert len(result) <= 240
+    assert result.endswith(" 1080p.mp4")
+    assert os.path.dirname(result) == str(tmp_path)
+
+
+# ================================================================ 임시 폴더 명명
+
+
+def test_temp_dir_for_derives_from_output_stem(tmp_path):
+    """임시 폴더는 산출물 파일명(확장자 제외)에서 파생된다."""
+    output = str(tmp_path / "방송 1080p.mp4")
+    assert temp_dir_for(output) == str(tmp_path / "CVDv2_temp_방송 1080p")
+
+
+def test_temp_dir_for_distinct_across_uniquified_outputs(tmp_path):
+    """중복 회피로 갈라진 산출물끼리는 임시 폴더도 겹치지 않는다 (#105 확인 항목 4)."""
+    a = temp_dir_for(str(tmp_path / "방송 1080p.mp4"))
+    b = temp_dir_for(str(tmp_path / "방송 1080p (1).mp4"))
+    assert a != b

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -71,8 +71,23 @@ def test_sequential_same_title_downloads_keep_both_files(tmp_path):
 
 
 def test_sanitize_filename_strips_windows_invalid_chars():
-    """Windows 금지 문자와 개행이 제거된다 — content/network.py 정제와 동일 집합."""
+    """Windows 금지 문자와 개행이 제거된다 — content/network.py 정제가 이 함수를 쓴다."""
     assert sanitize_filename('a\\b/c:d*e?f"g<h>i|j\nk') == "abcdefghijk"
+
+
+def test_sanitize_filename_strips_all_ascii_control_chars():
+    """감사 보강 1: 0x00–0x1F 제어 문자 전체가 제거된다 (Windows는 생성 자체를 거부)."""
+    assert sanitize_filename("a\rb\tc\x00d\x1fe") == "abcde"
+    assert sanitize_filename("".join(chr(c) for c in range(0x20)) + "제목") == "제목"
+
+
+def test_build_output_path_with_control_chars_creates_real_file(tmp_path):
+    """제어 문자가 든 제목도 실제 파일 생성까지 통과한다."""
+    result = build_output_path(str(tmp_path), "탭\t과 캐리지\r리턴", 1080)
+    assert os.path.basename(result) == "탭과 캐리지리턴 1080p.mp4"
+    with open(result, "wb") as f:
+        f.write(b"x")
+    assert os.path.exists(result)
 
 
 def test_build_output_path_sanitizes_title(tmp_path):
@@ -114,6 +129,47 @@ def test_truncated_title_is_deterministic(tmp_path):
     assert build_output_path(str(tmp_path), title, 1080) == build_output_path(
         str(tmp_path), title, 1080
     )
+
+
+def test_filename_respects_posix_byte_limit(tmp_path):
+    """감사 보강 2: 문자 수 상한 안쪽이어도 파일명 UTF-8 바이트가 240을 넘지 않는다.
+
+    한글 150자 제목은 문자 수로는 짧지만 UTF-8로 450바이트라, ext4 등
+    POSIX 파일시스템의 구성요소 255바이트 제한에 걸린다 (ENAMETOOLONG).
+    """
+    result = build_output_path(str(tmp_path), "한" * 150, 1080)
+    basename = os.path.basename(result)
+    assert len(basename.encode("utf-8")) <= 240
+    assert " ~" in basename  # 바이트 절단에도 해시 표식이 동일하게 붙는다
+    assert basename.endswith(" 1080p.mp4")
+    with open(result, "wb") as f:  # 실제 파일 생성까지 통과 (리눅스 CI에서 실검증)
+        f.write(b"x")
+    assert os.path.exists(result)
+
+
+def test_byte_truncation_keeps_character_boundary(tmp_path):
+    """바이트 절단은 문자 경계를 깨지 않는다 — 한글 3바이트·이모지 4바이트."""
+    for title in ("한" * 150, "🎮" * 100, "한🎮" * 70):
+        result = build_output_path(str(tmp_path), title, 1080)
+        basename = os.path.basename(result)
+        assert len(basename.encode("utf-8")) <= 240
+        # 절단된 제목 부분이 원제목의 온전한 접두어다 — 깨진 문자가 있으면 실패한다
+        clipped = basename.rsplit(" ~", 1)[0]
+        assert title.startswith(clipped)
+
+
+def test_byte_truncated_titles_with_same_prefix_stay_distinct(tmp_path):
+    """바이트 절단으로 앞부분이 같아진 제목들도 해시 표식으로 갈라진다."""
+    a = build_output_path(str(tmp_path), "한" * 150 + "일회차", 1080)
+    b = build_output_path(str(tmp_path), "한" * 150 + "이회차", 1080)
+    assert a != b  # 파일을 만들지 않아도 서로 다른 경로
+
+
+def test_byte_limit_covers_temp_dir_name(tmp_path):
+    """임시 폴더 이름(stem + 접두사 11바이트)도 255바이트 안에 들어온다."""
+    result = build_output_path(str(tmp_path), "한" * 150, 1080)
+    temp_name = os.path.basename(temp_dir_for(result))
+    assert len(temp_name.encode("utf-8")) <= 255
 
 
 # ================================================================ Windows 예약어·끝 점

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -95,6 +95,72 @@ def test_build_output_path_truncates_long_title(tmp_path):
     assert os.path.dirname(result) == str(tmp_path)
 
 
+def test_truncated_titles_with_same_prefix_stay_distinct(tmp_path):
+    """추가 확인 3: 앞부분이 같은 긴 제목들은 절단 후에도 해시 표식으로 갈라진다.
+
+    표식 없이는 절단본이 동일해져 " (n)"만으로 구분되고(식별성 저하),
+    파일이 없는 시점엔 아예 같은 경로가 나온다.
+    """
+    prefix = "공통 앞부분 " * 30  # 절단 지점 너머까지 동일한 앞부분
+    a = build_output_path(str(tmp_path), prefix + "1회차", 1080)
+    b = build_output_path(str(tmp_path), prefix + "2회차", 1080)
+    assert a != b  # 파일을 만들지 않아도 서로 다른 경로
+    assert len(a) <= 240 and len(b) <= 240
+
+
+def test_truncated_title_is_deterministic(tmp_path):
+    """절단 표식은 원제목의 해시라 같은 제목이면 항상 같은 이름이다 (충돌 시에만 (n))."""
+    title = "가" * 300
+    assert build_output_path(str(tmp_path), title, 1080) == build_output_path(
+        str(tmp_path), title, 1080
+    )
+
+
+# ================================================================ Windows 예약어·끝 점
+
+
+def test_reserved_device_title_gets_prefixed(tmp_path):
+    """추가 확인 1: 제목이 예약 장치명(그대로/점·공백 후속)이면 '_'를 앞에 붙인다.
+
+    Windows 11 실측으로는 CON.mp4도 생성되지만 지원 대상인 Windows 10이
+    여전히 예약하므로 보수적으로 막는다 (대소문자 무시).
+    """
+    assert os.path.basename(build_output_path(str(tmp_path), "CON", 1080)) == "_CON 1080p.mp4"
+    assert os.path.basename(build_output_path(str(tmp_path), "con.", 720)) == "_con. 720p.mp4"
+    assert os.path.basename(build_output_path(str(tmp_path), "lpt1", 480)) == "_lpt1 480p.mp4"
+
+
+def test_reserved_lookalike_titles_are_untouched(tmp_path):
+    """예약어로 시작하는 일반 단어(CONCERT 등)는 오탐하지 않는다."""
+    assert (
+        os.path.basename(build_output_path(str(tmp_path), "CONCERT 실황", 1080))
+        == "CONCERT 실황 1080p.mp4"
+    )
+    assert (
+        os.path.basename(build_output_path(str(tmp_path), "COM10 리뷰", 1080))
+        == "COM10 리뷰 1080p.mp4"
+    )
+
+
+def test_trailing_dots_in_title_land_mid_filename(tmp_path):
+    """추가 확인 2: 마침표로 끝나는 제목도 접미사가 항상 뒤에 붙어 이름 중간에 놓인다.
+
+    Windows는 이름 '끝'의 점·공백만 조용히 잘라낸다(실측) — 생성된 이름은
+    항상 .mp4로 끝나므로 잘리거나 변형되지 않는다.
+    """
+    result = build_output_path(str(tmp_path), "오늘도 방송합니다...", 1080)
+    assert os.path.basename(result) == "오늘도 방송합니다... 1080p.mp4"
+    with open(result, "wb") as f:
+        f.write(b"x")
+    assert os.path.basename(result) in os.listdir(tmp_path)  # 이름 그대로 저장된다
+
+
+def test_trailing_spaces_in_title_are_stripped(tmp_path):
+    """제목 양끝 공백은 정제 단계에서 제거된다 — ' 제목  ' 같은 입력도 안전."""
+    result = build_output_path(str(tmp_path), "  공백 제목   ", 1080)
+    assert os.path.basename(result) == "공백 제목 1080p.mp4"
+
+
 # ================================================================ 임시 폴더 명명
 
 
@@ -109,3 +175,18 @@ def test_temp_dir_for_distinct_across_uniquified_outputs(tmp_path):
     a = temp_dir_for(str(tmp_path / "방송 1080p.mp4"))
     b = temp_dir_for(str(tmp_path / "방송 1080p (1).mp4"))
     assert a != b
+
+
+def test_same_video_queued_twice_gets_distinct_temp_dirs(tmp_path):
+    """추가 확인 4: 같은 영상을 두 번 큐에 넣어도 임시 폴더가 갈라진다.
+
+    앱은 다운로드를 순차 실행하고 경로는 각 건의 시작 직전에 배정되므로,
+    두 번째 건은 첫 건의 산출물을 보고 " (1)"로 갈라지고 임시 폴더도
+    산출물 이름에서 파생돼 함께 갈라진다. (동일 videoId 여부와 무관 —
+    산출물 경로 기준이라 같은 영상끼리도 충돌하지 않는다)
+    """
+    first = build_output_path(str(tmp_path), "같은 영상", 1080)
+    with open(first, "wb") as f:
+        f.write(b"x")  # 첫 건 완료를 흉내 낸다
+    second = build_output_path(str(tmp_path), "같은 영상", 1080)
+    assert temp_dir_for(first) != temp_dir_for(second)

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -5,6 +5,8 @@
   파싱 자체의 박제 테스트는 tests/unit/core/test_dash.py로 이전했다 (#51).
 """
 
+import json
+
 import pytest
 
 import content.network as network
@@ -162,6 +164,22 @@ class TestGetVideoInfo:
         assert info.membership_benefit_type == "MEMBER_ONLY"
         assert info.encryption_type == "AES"
         assert info.metadata["duration"] == 10925
+
+    def test_title_is_sanitized_for_filenames(self, monkeypatch):
+        """제목의 금지 문자·ASCII 제어 문자는 조회 단계에서 제거된다 (#105).
+
+        정제는 core/utils/paths.py의 sanitize_filename에 위임한다 — 산출물
+        경로 조립(build_output_path)의 방어 정제와 항상 같은 집합을 쓴다.
+        """
+        body = json.dumps({"content": {"videoTitle": "탭\t금지:문자*제어\r문자?"}})
+
+        monkeypatch.setattr(
+            network._session, "get", lambda url, **kwargs: MockResponse(text=body)
+        )
+
+        info = NetworkManager.get_video_info("1", {})
+
+        assert info.metadata["title"] == "탭금지문자제어문자"
 
 
 class TestGetVideoM3u8BaseUrl:


### PR DESCRIPTION
## 관련 이슈

Closes #105

## 변경 내용

**산출물 경로 조립·중복 회피를 `core/utils/paths.py` 단일 지점으로 수렴하고, 같은 경로에 파일이 있으면 덮어쓰지 않고 `" (n)"` 접미사를 붙인 새 파일로 저장한다.**

- `core/utils/paths.py` (신규): `build_output_path`(조립+정제+길이 제한+중복 회피), `ensure_unique_path`, `sanitize_filename`, `temp_dir_for`
- `content/manager.py` / `scripts/headless_download.py`: 각자 중복 조립하던 `f"{title} {resolution}p.mp4"`를 `build_output_path` 호출로 교체
- `core/downloaders/m3u8_downloader.py` / `hls_aes_downloader.py`: 세그먼트 임시 폴더를 고정 공유 이름(`CVDv2_temp`)에서 산출물 파일명 파생(`CVDv2_temp_{파일명 stem}`)으로 변경
- 테스트: `tests/unit/core/test_paths.py` 신규 11건, 임시 폴더 이름을 참조하던 기존 단언 5곳 갱신

## 이슈 확인 항목별 판단

**1. 덮어쓰기 금지 (필수 조건)** — `ensure_unique_path`가 배정 시점에 존재를 확인하고 `" (1)", " (2)"…` 를 붙인다. 디렉토리와의 이름 충돌도 막는다(`os.path.exists` 기준).

**2. 파일명 구분자 판단 — 기본 파일명은 바꾸지 않기로 결정.** 근거:
- 기본 형식 변경(`created_date` 상시 포함 등)은 충돌이 없는 대다수 다운로드까지 파일명이 달라지는 유저 체감 변화다. 충돌은 같은 제목을 다시 받을 때만 발생하므로, 그 경우에만 접미사를 붙이는 것이 영향 범위가 최소다
- `" (n)"` 접미사는 Windows 탐색기의 복사본 명명 관례와 같아 별도 학습 없이 직관적이다
- `created_date` 활용은 향후 "파일명 템플릿" 설정 옵션으로 도입할 수 있게 여지를 남긴다 (원하면 별도 개선 이슈로 제안)

**3. 금지 문자·경로 길이** — 제목 정제는 조회 단계(`content/network.py`)에서 이미 수행되지만, core를 직접 쓰는 경로(헤드리스·다른 UI)가 정제를 빠뜨려도 안전하도록 `build_output_path`가 동일 문자 집합(`\ / : * ? " < > |` + 개행)으로 재방어한다. 전체 경로는 240자 상한(Windows MAX_PATH 260에서 접미사·임시 폴더 접두사 여유분 확보)이며 초과 시 제목 부분만 절단한다(해상도 접미사·확장자 보존).

**4. 임시 폴더 확인 결과** — 제목 기반이 아니라 **고정 이름 `CVDv2_temp` 하나를 모든 다운로드가 공유**하고 있었다. 같은 폴더로 향하는 두 다운로드가 겹치면(`GUI+헤드리스 병행`, 향후 동시 실행 >1) `_prepare_output`의 rmtree가 상대방 세그먼트를 통째로 삭제할 수 있는 구조라, 산출물 파일명(중복 회피 후) 파생으로 바꿔 다운로드마다 폴더를 분리했다. 중복 회피로 갈라진 산출물끼리 임시 폴더도 갈라진다.

**5. 완료 목록/기록 영향** — sqlite 다운로드 기록은 아직 미구현이라 영향 없음. 세션 내 완료 목록·"폴더 열기"(`content/widget.py`)는 `item.output_path`를 참조하는데, 경로가 다운로드 시작 직전(배정 시점)에 확정되고 이후 core가 변경하지 않으므로 UI가 아는 경로와 실제 파일이 항상 일치한다.

**6. 결정 지점 확인 결과** — 세 다운로더가 아니라 **앱 계층 두 곳**(GUI `content/manager.py:onDownload`, 헤드리스 `_build_item`)이 같은 형식을 중복 조립하고 있었다. 구현을 `core/utils/paths.py` 한 곳으로 모으고 두 호출부는 `build_output_path` 호출만 한다.

## 알려진 한계

존재 확인과 파일 생성 사이의 원자성은 없다 — 별도 프로세스 두 개(GUI+헤드리스)가 같은 폴더에 같은 제목을 **정확히 동시에** 받는 경우까지는 보장하지 않는다. 앱 내 다운로드는 순차 실행(동시 1)이라 실사용 영향은 없다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (268 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — `tests/unit/core/test_paths.py` 11건: 연속 같은 제목 다운로드 시 두 파일 보존, 특수문자 제목 정상 저장, 길이 절단, 임시 폴더 분리

참고: `ruff format --check`가 지적하는 `content/manager.py` 등 3파일의 포맷 위반은 main에 이미 있던 것으로(스태시 후 확인) 이 PR 범위에서 손대지 않았다.

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — `core/utils/paths.py`는 `os`·`re`만 사용, `tests/unit/core/test_no_qt_import.py` 통과
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — 호출부는 manager(뷰모델)와 헤드리스 스크립트
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음 (`core/utils/` 하위 모듈 추가는 자유 구역)

## 리뷰어에게

- 임시 폴더 이름이 `CVDv2_temp` → `CVDv2_temp_{파일명 stem}`으로 바뀐다. 후처리(remux) 실패 시 보존되는 세그먼트 폴더를 수동으로 찾는 경우 이름이 달라지는 점만 인지 부탁드립니다 (어느 다운로드의 세그먼트인지 오히려 식별이 쉬워짐).
- 같은 제목을 받을 때 두 번째 파일이 `제목 1080p (1).mp4`가 되는 동작이 의도에 맞는지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
