### PR TITLE
refactor: 전송 종료 시 관측 스레드 정지 — 후처리 진행은 공급 루프가 통지 (#89)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -40,6 +40,9 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
 - 관측(속도 측정·스레드 조정·진행 통지)은 엔진이 소유하는 일반 스레드
   (_monitor_loop)가 수행하고, core/models/events.py의 ProgressEvent 콜백으로
   보고한다. 완료·실패도 같은 계약의 콜백으로 알린다.
+- 관측 스레드는 **전송 단계 동안만** 산다 (#89) — 전송이 끝나면 run()이
+  정지시키고, 후처리(병합·remux) 진행 통지는 _remux_streamed의 공급 루프가
+  같은 ProgressEvent 콜백으로 보고한다.
 - 일시정지·중단은 DownloadTaskModel의 상태와 pause_event를 그대로 사용한다.
 - 콜백은 작업 스레드에서 호출된다 — 어댑터는 Signal emit까지만 해야 한다.
 
@@ -121,6 +124,8 @@ class BaseDownloader(ABC):
         self.lock = threading.Lock()
         self.future_dict: dict = {}
         self.adjust_count = 0
+        # 전송 종료 시 관측 스레드를 깨워 끝내는 신호 — 후처리는 관측 대상이 아니다 (#89)
+        self._monitor_stop = threading.Event()
         self._on_progress: ProgressCallback = on_progress or (lambda event: None)
         self._on_finished: FinishedCallback = on_finished or (lambda: None)
         self._on_failed: FailedCallback = on_failed or (lambda exc: None)
@@ -202,9 +207,16 @@ class BaseDownloader(ABC):
         remux가 실패하면 폴백 없이 PostprocessError로 명확히 실패한다 —
         바이트 연결본은 #88이 고치려던 결함품이라 조용히 대체하지 않는다.
         일시정지·중단은 공급 루프가 세그먼트 병합과 같은 규칙으로 처리한다.
+
+        후처리 구간의 진행 통지도 이 공급 루프가 담당한다 (#89) — 관측
+        스레드는 전송 종료 시점에 정지되므로, 파이프 공급 진행(병합된
+        세그먼트 수)이 곧 진행 신호다.
         """
+        total_segments = len(segment_paths)
+        last_percent = -1
 
         def feed():
+            nonlocal last_percent
             for path in segment_paths:
                 for chunk in read_in_chunks(path):
                     # 다운로드 중지 상태라면 중단 — 공급을 끊고 산출물을 지운다
@@ -215,6 +227,21 @@ class BaseDownloader(ABC):
                         self.s._pause_event.wait()
                     yield chunk
                 self.s.merged_segments += 1
+                # 어댑터가 표시하는 정수 %(분모 = 병합 대상 수 = 이 목록 길이)가
+                # 바뀔 때만 통지한다 — 세그먼트 수천 개짜리 VOD에서도 통지가
+                # 최대 ~101회로 묶인다. 속도 0·활성 0은 구 관측 스레드가 병합
+                # 구간에서 내보내던 값과 동일해 UI 표시 결과가 변하지 않는다
+                percent = int(self.s.merged_segments / total_segments * 100)
+                if percent != last_percent:
+                    last_percent = percent
+                    self._on_progress(
+                        ProgressEvent(
+                            downloaded_size=self.s.total_downloaded_size,
+                            total_size=self._progress_total_size(),
+                            speed=0.0,
+                            active_threads=0,
+                        )
+                    )
 
         try:
             remux_stream(feed(), self.s.output_path)
@@ -297,6 +324,12 @@ class BaseDownloader(ABC):
                     if not self.s.remaining_ranges and not self.future_dict:
                         break
 
+            # 전송이 끝났다 — 후처리는 관측 대상이 아니므로 관측 스레드를 먼저
+            # 정지한다 (#89). 병합 중 스레드 수가 절반씩 줄어드는 로그 꼬리와
+            # 무의미한 speed 0.00 관측이 사라진다. 후처리 진행 통지는
+            # _remux_streamed의 공급 루프가 담당한다
+            self._stop_monitor(monitor)
+
             if self.state == DownloadState.RUNNING:
                 # (4) 다운로드 완료 후 타입별 마무리(병합 등) 후 완료 통지 —
                 # 후처리 필요 여부는 실행 중 추측하지 않고 계획이 답한다 (#83)
@@ -330,6 +363,12 @@ class BaseDownloader(ABC):
             self._on_failed(e)
             self.logger.log_exception("Download failed", e)
             self.logger.save_and_close()
+
+        finally:
+            # 실패·전파 예외 경로에서도 관측 스레드를 남기지 않는다 (#89).
+            # 실패 후 상태가 RUNNING인 채 남는 경로(헤드리스 등)에서는 기존
+            # 관측 루프가 상태 변화만 기다리며 영원히 돌았다
+            self._stop_monitor(monitor)
 
         # 사용자가 강제로 중단한 경우 부분 산출물 삭제
         if self.state == DownloadState.WAITING:
@@ -380,10 +419,29 @@ class BaseDownloader(ABC):
 
     # ============ 관측 루프 (구 Monitor 스레드 — 엔진이 흡수) ============
 
+    def _stop_monitor(self, monitor: threading.Thread) -> None:
+        """관측 스레드를 정지시키고 종료를 기다린다 (#89). 여러 번 불려도 무해하다.
+
+        전송 종료 직후 run()이 호출한다 — 후처리(병합·remux)가 관측 스레드
+        정지 이후에 시작됨을 보장한다. join 타임아웃은 일시정지 대기
+        (_pause_event.wait)에 막혀 있는 극단 경로 대비다(데몬 스레드라
+        프로세스를 붙잡지는 않는다).
+        """
+        self._monitor_stop.set()
+        if monitor.is_alive():
+            monitor.join(timeout=2)
+
     def _monitor_loop(self):
-        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프."""
-        tm.sleep(1)
-        while self.state in [DownloadState.RUNNING, DownloadState.PAUSED]:
+        """주기(1초)마다 스레드 수 조정·속도 측정·진행 통지를 수행하는 관측 루프.
+
+        전송 단계 동안만 산다 — 전송이 끝나면 run()이 _monitor_stop으로
+        정지시킨다. 후처리(병합·remux)는 관측 대상이 아니다 (#89).
+        """
+        self._monitor_stop.wait(1)
+        while not self._monitor_stop.is_set() and self.state in [
+            DownloadState.RUNNING,
+            DownloadState.PAUSED,
+        ]:
             if not self.s._pause_event.is_set():
                 self.s._pause_event.wait()
                 self.measure_speed()
@@ -394,11 +452,12 @@ class BaseDownloader(ABC):
             total_sleep = 1.0  # 총 1초 대기
             interval = 0.1  # 0.1초씩 대기
             elapsed = 0.0
-            while elapsed < total_sleep and self.state in [
-                DownloadState.RUNNING,
-                DownloadState.PAUSED,
-            ]:
-                tm.sleep(interval)
+            while (
+                elapsed < total_sleep
+                and not self._monitor_stop.is_set()
+                and self.state in [DownloadState.RUNNING, DownloadState.PAUSED]
+            ):
+                self._monitor_stop.wait(interval)
                 elapsed += interval
 
     def _adjust_threads(self):

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -268,6 +268,7 @@ class _FakeEngine:
         self.s = SimpleNamespace(
             output_path=str(tmp_path / "out.mp4"),
             merged_segments=0,
+            total_downloaded_size=0,
             _pause_event=threading.Event(),
         )
         self.s._pause_event.set()
@@ -275,6 +276,10 @@ class _FakeEngine:
         self.logger = SimpleNamespace(
             log_error=lambda message, exc=None: self.errors.append(message)
         )
+        # 후처리 진행 통지 경로 (#89) — 이 파일의 검증 대상이 아니므로 무시한다
+        self.progress_events: list = []
+        self._on_progress = self.progress_events.append
+        self._progress_total_size = lambda: None
 
 
 def test_streamed_failure_raises_postprocess_error_and_preserves_segments(tmp_path, monkeypatch):

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -300,6 +300,86 @@ def test_pause_resume_then_complete(tmp_path, monkeypatch):
     assert data.model.state is DownloadState.FINISHED
 
 
+def test_monitor_thread_is_stopped_before_postprocess(tmp_path, monkeypatch):
+    """후처리 중에는 관측 스레드가 살아 있지 않다 — 병합 꼬리 로그의 원천 제거 (#89).
+
+    관측 정지가 remux 시작보다 먼저임을 remux 스텁 안에서 직접 확인한다.
+    """
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    monitor_alive_during_remux = []
+
+    def checking_remux_stream(chunks, dst_path):
+        monitor_alive_during_remux.append(
+            any(t.name == "DownloadMonitor" and t.is_alive() for t in threading.enumerate())
+        )
+        _passthrough_remux_stream(chunks, dst_path)
+
+    monkeypatch.setattr(base_module, "remux_stream", checking_remux_stream)
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert monitor_alive_during_remux == [False]
+    assert output.read_bytes() == _expected_output(chunks_per_segment=3)  # 완주 무영향
+
+
+def test_postprocess_progress_is_emitted_by_feed_loop(tmp_path, monkeypatch):
+    """후처리 진행 통지는 공급 루프가 담당한다 (#89) — 병합 % 변화마다 1회.
+
+    병합 구간 이벤트는 구 관측 스레드의 병합 관측과 동일하게 속도 0·활성
+    스레드 0이어야 한다 (어댑터 변환식 무변경 → UI 표시 결과 무변경).
+    """
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    events = []  # (이벤트, 통지 시점의 병합 세그먼트 수)
+    engine.set_on_progress(lambda event: events.append((event, data.merged_segments)))
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    merge_events = [(e, merged) for e, merged in events if merged > 0]
+    # 초기화 세그먼트 포함 7개 병합 → int(k/7*100)이 매 세그먼트마다 변해 7회 통지
+    assert len(merge_events) == SEGMENT_COUNT + 1
+    assert merge_events[-1][1] == SEGMENT_COUNT + 1  # 마지막 통지가 100% 시점
+    for event, _merged in merge_events:
+        assert event.speed == 0.0
+        assert event.active_threads == 0
+
+
+def test_postprocess_progress_throttled_to_percent_changes(tmp_path, monkeypatch):
+    """세그먼트가 %당 여러 개면 % 변화 시에만 통지한다 — 최대 ~101회로 묶인다 (#89)."""
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    seg_dir = tmp_path / "segs"
+    seg_dir.mkdir()
+    paths = []
+    for i in range(300):
+        p = seg_dir / f"{i:04d}.m4s"
+        p.write_bytes(b"x")
+        paths.append(str(p))
+
+    events = []
+    engine.set_on_progress(lambda event: events.append(event))
+    data.model.start()
+
+    engine._remux_streamed(paths)
+
+    assert data.merged_segments == 300
+    # int(k/300*100), k=1..300은 0~100의 정수를 모두 한 번씩 지난다 → 정확히 101회
+    assert len(events) == 101
+
+
 def test_stop_removes_partial_file_and_temp_dir(tmp_path, monkeypatch):
     """중단(stop)하면 임시 폴더·부분 파일을 삭제하고 완료 콜백을 호출하지 않는다."""
     engine, data, logger, output, finished, failures, merge_starts = _make_engine(


### PR DESCRIPTION
## 관련 이슈

Closes #89

## 변경 내용

**전송 단계가 끝나면 관측 스레드를 정지하고, 후처리(remux) 진행 통지는 `_remux_streamed`의 파이프 공급 루프가 기존 `on_progress` 채널로 담당한다.**

- `core/downloaders/base.py`:
  - `_monitor_stop` 이벤트 추가 — `run()`이 전송 종료 직후(`_stop_monitor`) 관측 스레드를 정지·join한 뒤 후처리에 진입한다. 병합 중 스레드 수가 절반씩 줄어드는 로그 꼬리(40→20→10→…, speed 0.00)의 원천이 사라진다
  - `_monitor_loop`의 대기를 `tm.sleep` → `Event.wait`로 바꿔 정지 신호에 즉시 반응한다 (주기·판단 로직 무변경)
  - `_remux_streamed` 공급 루프가 세그먼트 병합 시점마다 진행을 통지하되, **어댑터 표시 정수 %가 바뀔 때만** 통지한다 (세그먼트 수천 개 VOD에서도 최대 ~101회)
  - `finally`에서 관측 정지를 보장 — 실패 후 상태가 RUNNING인 채 남는 경로(헤드리스 실패 등)에서 관측 루프가 영원히 돌던 **잠재 누수를 함께 정리**했다
- `tests/unit/core/test_m3u8_downloader_run.py`: 신규 3건 — remux 시작 시점에 관측 스레드 비활성, 병합 % 변화마다 공급 루프 통지(속도 0·활성 0), 300세그먼트 스로틀(정확히 101회)
- `tests/unit/core/test_ffmpeg_utils.py`: `_FakeEngine`에 통지 경로 속성 추가 (아래 참고)

## 이슈 본문과 현 구조의 차이 (지시 사항 반영)

이슈는 #92 이전의 "병합 단계"(중간 병합 파일)를 전제로 쓰였다. 현 구조는 세그먼트를 ffmpeg stdin에 직접 흘리는 단일 패스라 **"병합 진행"의 실체가 곧 파이프 공급 진행**이다. 지시대로 공급 루프의 진행(병합된 세그먼트 수)을 후처리 진행 신호로 삼았다 — 별도의 진행 측정 장치가 필요 없고, `data.merged_segments` 증가와 통지가 같은 지점에서 일어나 어긋날 수 없다.

## 후처리 진행 표현 방식의 판단 근거 (제안 2)

이슈가 제시한 두 방식(ProgressEvent 단계 필드 / 별도 콜백) 중 **어느 쪽도 쓰지 않고 기존 채널을 재사용**했다:

- 단계 전환 신호는 **기존 `on_merge_start` 콜백이 이미 제공**한다 — 어댑터(`qt_bridge`)는 이것으로 `item.post_process`를 세우고 변환식을 전환한다. ProgressEvent에 단계 필드를 추가하면 같은 정보가 두 경로로 흘러 정합 문제가 생긴다
- 후처리 통지는 기존 `on_progress`로 내보내되, 이벤트 값(속도 0.0·활성 스레드 0)을 구 관측 스레드가 병합 구간에서 내보내던 값과 동일하게 맞췄다 — **기존 소비자(qt_bridge·헤드리스) 코드 무변경, 이벤트 스키마 무변경, 새 콜백 없음**. "이슈마다 새 콜백을 만들지 않는다" 원칙 그대로다

통지 빈도만 시간 기반(1초)에서 % 변화 기반으로 바뀌는데, 어댑터가 계산하는 % 값 자체는 같은 식(`merged_segments / merge_total`)이므로 **UI 표시 결과는 무변경**이고 진행률은 단조 증가라 튀지 않는다 (제안 3). 통지 분모(`len(segment_paths)`)는 m3u8(초기화 세그먼트 포함)·hls_aes 모두 어댑터의 `merge_total`과 정확히 일치한다.

## 파일 경로 회귀 없음 (제안 4)

파일 다운로더는 후처리가 없어 전송 종료 → 관측 정지 → 완료 통지 순서만 명시화됐다. 기존 `test_file_downloader_run.py` 전체가 무수정 통과한다.

## 박제 테스트에 대하여

박제 테스트(`test_file_downloader_rules.py` / `test_m3u8_downloader_rules.py`)는 **시나리오·단언 무수정** 통과한다. "활성 0 → 감소 틱" 박제(`test_zero_active_threads_counts_as_slow_tick`)도 그대로다 — 규칙 자체는 보존되고, 병합 중에는 그 규칙을 실행할 관측 스레드가 없을 뿐이다. 한 곳 예외: `test_ffmpeg_utils.py`의 `_FakeEngine`(덕타입 하네스)에 새 통지 경로가 참조하는 속성 3개를 추가했다 — 시나리오·단언은 무수정이며, 하네스가 실제 엔진 표면을 따라간 것이다.

## SPEC 부록 기록 (완료 조건 5)

검증 판정 기준의 **"병합 꼬리 구조" 항목이 이 PR로 무효**가 된다 (병합 중 관측 로그 자체가 없어짐). `docs/SPEC.md`는 금지 구역이므로 수정하지 않았다 — **부록 갱신은 소유자 몫**으로 여기에 기록한다. `scripts/summarize_download_log.py`는 병합 꼬리를 참조하지 않아 영향 없다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (285 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — 관측 정지 시점·공급 루프 통지·스로틀 3건
- [x] core 순수성 가드(`test_no_qt_import`) 통과
- [x] 로그의 병합 꼬리 구간: 관측 스레드가 remux 시작 전에 정지함을 테스트로 보장 (`log_thread_debug`·스레드 조정 로그의 발생원 제거)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — UI 파일·`qt_bridge`·`events.py` 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- **오너 스모크 요청** (완료 조건 4): m3u8 1건 — 병합 단계 UI 표시가 기존과 동일하고 진행률이 튀지 않는지, 파일 경로 1건 — 회귀 없는지 확인 부탁드립니다.
- 통지 시점이 "1초마다"에서 "병합 % 변화마다"로 바뀌므로, 세그먼트가 매우 크고 적은 VOD에서는 병합 중 진행 갱신 간격이 1초보다 길어질 수 있습니다(값은 정확, 갱신만 세그먼트 단위). 반대로 세그먼트가 잘면 갱신이 더 촘촘해집니다.
- 헤드리스 스크립트의 병합 구간 로그도 같은 채널이라 초당 1줄 → % 변화당 1줄로 바뀝니다(최대 ~101줄).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
