### PR TITLE
refactor: remux에서 +faststart 제거 — 후처리 2차 패스 제거 (#108)

### DIFF
--- a/core/utils/ffmpeg.py
+++ b/core/utils/ffmpeg.py
@@ -157,7 +157,11 @@ def remux_stream(chunks: Iterable[bytes], dst_path: str) -> None:
       없음). fMP4·TS는 스트리밍 컨테이너라 파이프 입력으로 정상 판별된다
     - ``-c copy``: 재인코딩 금지. 화질 무손실
     - 타임스탬프 0 정규화는 ffmpeg 기본 동작(-copyts 미지정) — 별도 옵션 불필요
-    - ``-movflags +faststart``: 전역 인덱스(moov)를 파일 선두로 이동
+    - ``+faststart``는 쓰지 않는다(#108) — moov를 선두로 옮기는 2차 패스가
+      산출물 전체를 다시 읽고 다시 쓴다(제거로 후처리 I/O 5N→3N). 편집
+      프로그램 인식에 필요한 것은 moov의 **존재**(#88)이지 위치가 아니며,
+      로컬 재생·편집은 랜덤 액세스라 moov가 파일 끝(ffmpeg 기본)이어도
+      duration·시작 0·탐색·디코드가 동일함을 실측으로 확인했다(#108 비교표)
     - ``-f mp4``: 출력 컨테이너를 명시한다(#92) — 산출물 확장자가 .mp4가
       아니어도(유저가 저장 파일명을 바꾼 경우) 확장자 추론에 기대지 않는다
 
@@ -180,8 +184,6 @@ def remux_stream(chunks: Iterable[bytes], dst_path: str) -> None:
         "pipe:0",
         "-c",
         "copy",
-        "-movflags",
-        "+faststart",
         "-f",
         "mp4",
         dst_path,

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -536,7 +536,7 @@ def test_bundled_ts_remux_succeeds_with_guard(tmp_path, monkeypatch):
     remux_stream(read_in_chunks(str(src)), str(dst))
 
     boxes = _top_level_boxes(dst)
-    assert boxes.index("moov") < boxes.index("mdat")
+    assert "moov" in boxes and "mdat" in boxes  # 정상 remux 완주 (moov 위치는 #108)
 
 
 def test_guard_output_is_byte_identical(tmp_path, monkeypatch):

--- a/tests/unit/core/test_ffmpeg_utils.py
+++ b/tests/unit/core/test_ffmpeg_utils.py
@@ -187,8 +187,24 @@ def test_not_found_error_guides_installation(monkeypatch):
 # ================================================================ 스트림 remux
 
 
-def test_remux_stream_produces_mp4_with_leading_moov(tmp_path):
-    """파이프 공급 산출물은 mp4이고 전역 인덱스(moov)가 mdat보다 앞에 있어야 한다."""
+def _assert_fully_decodes(path) -> None:
+    """산출물이 오류 없이 끝까지 디코드되는지 확인한다 (#108 — moov 후행 유효성)."""
+    result = subprocess.run(
+        [get_ffmpeg_exe(), "-hide_banner", "-v", "error", "-i", str(path), "-f", "null", "-"],
+        capture_output=True,
+    )
+    assert result.returncode == 0 and not result.stderr.strip()
+
+
+def test_remux_stream_produces_mp4_with_moov_and_no_second_pass(tmp_path):
+    """산출물은 전역 인덱스(moov)를 가진 mp4이고, moov는 파일 끝이다 (#108).
+
+    편집 프로그램 인식에 필요한 것은 moov의 **존재**(#88)이지 위치가 아니다.
+    moov가 mdat 뒤(ffmpeg 기본)임을 단언해 +faststart의 전체 재기록 2차
+    패스가 되살아나지 않게 박제한다 — 선두 이동이 다시 필요해지면 이
+    단언을 근거와 함께 뒤집어야 한다. 후행 moov 산출물의 유효성은 전체
+    디코드로 확인한다.
+    """
     src = tmp_path / "src.mp4"
     dst = tmp_path / "dst.mp4"
     _make_tiny_fmp4(src)
@@ -196,9 +212,9 @@ def test_remux_stream_produces_mp4_with_leading_moov(tmp_path):
     remux_stream(read_in_chunks(str(src)), str(dst))
 
     boxes = _top_level_boxes(dst)
-    assert "moov" in boxes and "mdat" in boxes
-    # -movflags +faststart의 목적 그 자체 — moov가 mdat보다 앞이다
-    assert boxes.index("moov") < boxes.index("mdat")
+    assert "moov" in boxes and "mdat" in boxes  # 전역 인덱스 존재 (#88의 본질)
+    assert boxes.index("mdat") < boxes.index("moov")  # 2차 패스 없음 (#108)
+    _assert_fully_decodes(dst)
 
 
 def test_remux_stream_ts_input_produces_mp4(tmp_path):
@@ -216,7 +232,9 @@ def test_remux_stream_ts_input_produces_mp4(tmp_path):
     remux_stream(read_in_chunks(str(src)), str(dst))
 
     boxes = _top_level_boxes(dst)
-    assert boxes.index("moov") < boxes.index("mdat")
+    assert "moov" in boxes and "mdat" in boxes
+    assert boxes.index("mdat") < boxes.index("moov")  # 2차 패스 없음 (#108)
+    _assert_fully_decodes(dst)
 
 
 def test_remux_stream_writes_mp4_regardless_of_extension(tmp_path):
@@ -383,7 +401,7 @@ def test_pause_blocks_feed_then_resume_completes(tmp_path):
 
     out = tmp_path / "out.mp4"
     boxes = _top_level_boxes(out)
-    assert boxes.index("moov") < boxes.index("mdat")  # 재개 후 정상 완주
+    assert "moov" in boxes and "mdat" in boxes  # 재개 후 정상 완주 (moov 위치는 #108)
     assert fake.s.merged_segments == len(paths)
 
 


### PR DESCRIPTION
## 관련 이슈

Closes #108

## 변경 내용

**`remux_stream`에서 `-movflags +faststart`를 제거한다.** 두 세그먼트 경로(m3u8·hls_aes)가 이 함수 하나를 공유하므로 한 곳 수정으로 양쪽에 적용된다(제안 3). 파일 다운로더 경로는 후처리가 없어 무관하다.

- `core/utils/ffmpeg.py`: 옵션 제거 + docstring에 제거 근거 기록
- `tests/unit/core/test_ffmpeg_utils.py`: #88의 "선두 moov" 박제를 **의도적으로 반전** — 이제 "moov 존재 + mdat 뒤(2차 패스 없음)"를 박제하고, 후행 moov 산출물의 유효성을 전체 디코드로 검증한다. 선두 이동이 다시 필요해지면 이 단언을 근거와 함께 뒤집도록 docstring에 명시했다

## 실측 비교표 (완료 조건 1)

환경: Windows 11 / NVMe / imageio-ffmpeg 동봉 7.1 (앱과 동일 탐색 경로) / `remux_stream`과 동일한 stdin 파이프 공급 재현 / 3회 측정 중앙값

| 입력 | +faststart ON | OFF | 후처리 소요 변화 | 산출물 크기 |
|---|---|---|---|---|
| fMP4 330MB (m3u8 경로 형식) | 0.50s | 0.34s | **−32%** | 동일 (330,714,653 B) |
| TS 339MB (hls_aes 경로 형식) | 0.73s | 0.62s | **−15%** | 동일 (331,038,003 B) |
| fMP4 427MB | 0.57s | 0.43s | **−25%** | 동일 (426,765,301 B) |

**정직한 주석**: 위 절대치는 NVMe + OS 캐시 최상 조건이라 작다. 2차 패스는 산출물 전체 read+write라 비용이 **파일 크기와 저장장치 속도에 비례**한다 — 수 GB VOD를 HDD/SATA·외장 디스크에 받는 실사용에서 "진행률 100% 후 멈춤" 구간이 그대로 사라지는 것이 본 효과다. 상대 절감(−15~−32%)은 캐시 최상 조건에서의 하한으로 읽는 것이 맞다.

## 산출물 유효성 검증 (완료 조건 2)

faststart 유무 산출물 3쌍 전부에서 확인:

- **크기 바이트 단위 동일** — 달라지는 것은 최상위 박스 순서뿐 (`ftyp,moov,free,mdat` → `ftyp,free,mdat,moov`)
- **duration 00:01:30.00 / start 0.000000 동일** (타임라인 0 시작 유지)
- **전체 디코드 무오류** (`-v error -f null` 종료 0, stderr 없음)
- **중간 탐색 정상** (45초 지점 `-ss` 탐색 후 1초 디코드 무오류)

박제 테스트에도 전체 디코드 검증(`_assert_fully_decodes`)을 추가해 CI에서 계속 확인된다.

## 결론 판단 (제안 4 — 결론을 미리 정하지 않음)

제거가 부적절하다는 근거를 찾지 못했다. 유일한 트레이드오프는 **산출물을 HTTP 프로그레시브 스트리밍으로 서빙하는 경우** 재생 시작 전에 moov(파일 끝)까지 받아야 한다는 것인데, 이 앱은 로컬 저장용 다운로더이고 로컬 재생·편집기는 랜덤 액세스로 색인을 읽으므로 영향이 없다. 그런 용도가 필요한 유저는 ffmpeg 한 줄(`-c copy -movflags +faststart`)로 사후 변환할 수 있다. #88의 편집 프로그램 인식 회귀 여부는 오너 검증 항목으로 남긴다(아래).

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (285 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — 후행 moov 박제 반전 + 전체 디코드 검증 (fMP4·TS 두 경로)
- [x] core 순수성 가드(`test_no_qt_import`) 통과

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — UI·어댑터 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- **오너 검증 요청** (완료 조건 4): 실제 치지직 VOD 1건으로 편집 프로그램 인식(#88 회귀 없음)·타임라인 0 시작·탐색 정확성 확인 부탁드립니다. m3u8·hls_aes 각 1건이면 더 좋습니다.
- #88 당시 "선두 moov" 단언은 faststart의 동작 확인이었고, 편집기 인식의 본질(전역 인덱스 존재)은 이번 반전 후에도 그대로 박제되어 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
