### PR TITLE
feat: 다운로드 로그에 단계 경계·요약 정보 추가 (#110)

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,10 +1,36 @@
+import functools
+import importlib.metadata
 import json
 import logging
 import os
 import platform
+import tomllib
 from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def get_app_version() -> str:
+    """앱 버전 문자열을 반환한다 (#110 — 다운로드 로그 시작 정보용).
+
+    정본은 릴리즈 검증(CI)과 동일하게 pyproject.toml의 [project].version이다.
+    다만 CI의 tomllib 원라이너는 소스 트리 전제라 Nuitka 빌드 실행 파일에는
+    pyproject.toml이 없어 그대로 재사용할 수 없다 — 설치 메타데이터
+    (importlib.metadata, 소스·빌드 양쪽에서 동작)를 우선하고, 소스 실행
+    폴백으로 pyproject.toml을 직접 읽는다. 둘 다 실패하면 "unknown"으로
+    로깅을 막지 않는다.
+    """
+    try:
+        return importlib.metadata.version("cvdv2")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    pyproject = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pyproject.toml")
+    try:
+        with open(pyproject, "rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError):
+        return "unknown"
 
 # 설정 파일 경로 (AppData 디렉토리에 저장)
 APP_NAME = "chzzk-vod-downloader-v2"

--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -51,6 +51,7 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
 data·logger는 DownloadData/DownloadLogger 호환 객체를 주입받는다.
 """
 
+import os
 import threading
 import time as tm
 from abc import ABC, abstractmethod
@@ -95,6 +96,8 @@ class BaseDownloader(ABC):
     # 복호화 키 리졸버 주입이 필요한지 — 서비스가 참조해 set_key_resolver를 호출한다 (#57).
     # 키 취득은 유저 쿠키가 필요해 core가 직접 할 수 없다(core→app 의존 금지)
     requires_key_resolution: bool = False
+    # 후처리 시작 로그(#110)에 남길 작업 이름 — 현행 세그먼트 경로는 모두 remux다
+    postprocess_kind: str = "remux"
     # run()이 실패 콜백으로 환원할 예외 타입 — 그 외 예외는 전파한다
     _failure_exceptions: tuple[type[BaseException], ...] = (Exception,)
 
@@ -126,6 +129,8 @@ class BaseDownloader(ABC):
         self.adjust_count = 0
         # 전송 종료 시 관측 스레드를 깨워 끝내는 신호 — 후처리는 관측 대상이 아니다 (#89)
         self._monitor_stop = threading.Event()
+        # 전송 중 관측된 정점 동시 스레드 수 — 전송 종료 요약 로그용 (#110)
+        self._peak_threads = 0
         self._on_progress: ProgressCallback = on_progress or (lambda event: None)
         self._on_finished: FinishedCallback = on_finished or (lambda: None)
         self._on_failed: FailedCallback = on_failed or (lambda exc: None)
@@ -312,6 +317,10 @@ class BaseDownloader(ABC):
                                 if part_num not in self.future_dict:
                                     item = self.s.remaining_ranges.pop(0)
                                     self.s.future_count += 1
+                                    # 전송 종료 요약(#110)용 정점 동시 스레드 수
+                                    self._peak_threads = max(
+                                        self._peak_threads, self.s.future_count
+                                    )
                                     self._log_item_start(part_num, item)
                                     future = executor.submit(self._download_item, item, part_num)
                                     future.add_done_callback(self._download_completed_callback)
@@ -329,12 +338,30 @@ class BaseDownloader(ABC):
             # 무의미한 speed 0.00 관측이 사라진다. 후처리 진행 통지는
             # _remux_streamed의 공급 루프가 담당한다
             self._stop_monitor(monitor)
+            # 전송 구간 소요는 관측 정지까지 포함해 여기서 확정한다 (#110) —
+            # 이후 구간(후처리)과 합이 전체와 어긋나지 않게 하기 위함이다
+            transfer_elapsed = tm.time() - self.s.start_time
 
             if self.state == DownloadState.RUNNING:
+                # 전송 단계 종료 요약 한 줄 (#110)
+                self.logger.log_transfer_complete(
+                    transfer_elapsed,
+                    self.s.total_downloaded_size,
+                    self.s.failed_threads + self.s.restart_threads,
+                    self._peak_threads,
+                )
                 # (4) 다운로드 완료 후 타입별 마무리(병합 등) 후 완료 통지 —
                 # 후처리 필요 여부는 실행 중 추측하지 않고 계획이 답한다 (#83)
+                postprocess_elapsed = None
                 if plan.requires_postprocess:
+                    self.logger.log_postprocess_start(self.postprocess_kind)
+                    postprocess_started = tm.time()
                     self.postprocess()
+                    if self.state != DownloadState.WAITING:
+                        postprocess_elapsed = tm.time() - postprocess_started
+                        self.logger.log_postprocess_complete(
+                            postprocess_elapsed, os.path.getsize(self.s.output_path)
+                        )
                 # 후처리 중 중단(stop)됐다면 완료 통지를 생략한다 (#92) —
                 # WAITING → FINISHED는 허용되지 않는 전이라, 무조건 완료
                 # 처리하면 전이 예외가 실패 콜백으로 둔갑한다 (구 병합 코드의
@@ -343,6 +370,9 @@ class BaseDownloader(ABC):
                     self.s.end_time = tm.time()
                     total_time = self.s.end_time - self.s.start_time
                     self.logger.log_download_complete(total_time)
+                    # 전체 = 전송 + 후처리 구분 (#110) — 위 완료 줄(형식 불변)이
+                    # 전체 시간임을 새 줄이 드러낸다
+                    self.logger.log_total_breakdown(transfer_elapsed, postprocess_elapsed)
                     self.logger.save_and_close()
                     self._on_finished()
 

--- a/download/logger.py
+++ b/download/logger.py
@@ -101,6 +101,8 @@ class DownloadLogger:
             self.logger.critical(message)
     
     def log_download_info(self, item: ContentItem):
+        # 앱 버전을 시작 정보 블록 첫 줄에 남긴다 (#110 — 제보 분석·버전 간 비교용)
+        self.info(f"app_version: {config.get_app_version()}")
         self.info(f"content_type: {item.content_type}")
         self.info(f"title: {item.title}")
         self.info(f"channel_name: {item.channel_name}")
@@ -136,8 +138,47 @@ class DownloadLogger:
         self.debug(f"Progress: {progress:.2f}% - {total_downloaded}/{total_size} bytes - Speed: {speed:.2f} MB/s")
 
     def log_download_complete(self, total_time: float):
-        """다운로드 완료 정보를 로깅합니다."""
+        """다운로드 완료 정보를 로깅합니다.
+
+        주의: total_time은 전송+후처리를 합친 전체 시간이다. 줄 형식은
+        요약 스크립트(scripts/summarize_download_log.py)의 파싱 계약이라
+        바꾸지 않는다 — 구간 구분은 #110의 새 줄들이 담당한다.
+        """
         self.info(f"Download completed in {total_time:.2f} seconds")
+
+    # ============ 단계 경계 로그 (#110) — 새 줄만 추가, 기존 줄 형식 불변 ============
+
+    def log_transfer_complete(
+        self, elapsed: float, downloaded_bytes: int, retries: int, peak_threads: int
+    ):
+        """전송 단계 종료를 한 줄로 로깅합니다 — 소요·총 바이트·재시도·정점 스레드."""
+        self.info(
+            f"Transfer completed in {elapsed:.2f} seconds - Bytes: {downloaded_bytes}"
+            f" - Retries: {retries} - Peak threads: {peak_threads}"
+        )
+
+    def log_postprocess_start(self, kind: str):
+        """후처리 시작을 로깅합니다 (kind: remux 등)."""
+        self.info(f"Postprocess started - {kind}")
+
+    def log_postprocess_complete(self, elapsed: float, output_size: int):
+        """후처리 종료를 로깅합니다 — 소요 시간과 최종 산출물 크기."""
+        self.info(f"Postprocess completed in {elapsed:.2f} seconds - Output size: {output_size} bytes")
+
+    def log_total_breakdown(self, transfer_elapsed: float, postprocess_elapsed: Optional[float]):
+        """전체 시간의 전송/후처리 구분을 로깅합니다.
+
+        후처리가 없는 경로(file)는 "(no postprocess)"로 표기해 세 다운로더의
+        로그가 같은 위치에서 같은 형태로 끝나게 한다 (#110).
+        """
+        if postprocess_elapsed is None:
+            self.info(f"Total time breakdown - Transfer: {transfer_elapsed:.2f}s (no postprocess)")
+        else:
+            total = transfer_elapsed + postprocess_elapsed
+            self.info(
+                f"Total time breakdown - Transfer: {transfer_elapsed:.2f}s"
+                f" + Postprocess: {postprocess_elapsed:.2f}s = {total:.2f}s"
+            )
 
     def log_error(self, error_message: str, exception: Optional[Exception] = None):
         """에러 정보를 로깅합니다."""

--- a/scripts/summarize_download_log.py
+++ b/scripts/summarize_download_log.py
@@ -40,6 +40,16 @@ _PATTERNS = {
     "slow_retry": re.compile(r"Part (\d+) stopped due to slow speed, will retry"),
     "part_failed": re.compile(r"Part (\d+) download failed"),
     "completed": re.compile(r"Download completed in ([\d.]+) seconds"),
+    # ---- 단계 경계·요약 줄 (#110) — 없던 로그(구버전)에서는 그냥 비어 있다 ----
+    "app_version": re.compile(r"app_version: (.+)$"),
+    "transfer": re.compile(
+        r"Transfer completed in ([\d.]+) seconds - Bytes: (\d+)"
+        r" - Retries: (\d+) - Peak threads: (\d+)"
+    ),
+    "postprocess_start": re.compile(r"Postprocess started - (\w+)"),
+    "postprocess_complete": re.compile(
+        r"Postprocess completed in ([\d.]+) seconds - Output size: (\d+) bytes"
+    ),
 }
 
 
@@ -60,6 +70,15 @@ def summarize(log_path: Path) -> dict:
         "slow_retries": 0,
         "part_failures": 0,
         "completed_in_seconds": None,
+        # 단계 경계 지표 (#110) — 구버전 로그에는 없으므로 None이 기본
+        "app_version": None,
+        "transfer_seconds": None,
+        "transfer_bytes": None,
+        "transfer_retries": None,
+        "transfer_peak_threads": None,
+        "postprocess_kind": None,
+        "postprocess_seconds": None,
+        "postprocess_output_bytes": None,
     }
 
     for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -87,6 +106,18 @@ def summarize(log_path: Path) -> dict:
             summary["initial_threads"] = int(m.group(1))
         elif m := _PATTERNS["completed"].search(line):
             summary["completed_in_seconds"] = float(m.group(1))
+        elif m := _PATTERNS["transfer"].search(line):
+            summary["transfer_seconds"] = float(m.group(1))
+            summary["transfer_bytes"] = int(m.group(2))
+            summary["transfer_retries"] = int(m.group(3))
+            summary["transfer_peak_threads"] = int(m.group(4))
+        elif m := _PATTERNS["postprocess_complete"].search(line):
+            summary["postprocess_seconds"] = float(m.group(1))
+            summary["postprocess_output_bytes"] = int(m.group(2))
+        elif m := _PATTERNS["postprocess_start"].search(line):
+            summary["postprocess_kind"] = m.group(1)
+        elif m := _PATTERNS["app_version"].search(line):
+            summary["app_version"] = m.group(1)
 
     # 파생 지표: 재시도·실패로 인한 재큐잉 합계, 재큐잉이 있었어도 완주했는지 여부.
     # 파트 시작/완료는 DEBUG 로그라 기본 레벨(INFO)에서는 0으로 남는다 — 완주 판정은
@@ -111,6 +142,8 @@ def _format_bytes(size: int | None) -> str:
 def print_summary(summary: dict) -> None:
     """지표 요약을 사람이 읽는 형식으로 출력한다."""
     print(f"=== {summary['file']}")
+    if summary["app_version"]:
+        print(f"  앱 버전          : {summary['app_version']}")
     print(f"  전체 크기        : {_format_bytes(summary['total_size'])}")
     print(f"  파트 크기        : {_format_bytes(summary['part_size'])}")
     print(f"  세그먼트 수      : {summary['segments']}")
@@ -130,6 +163,22 @@ def print_summary(summary: dict) -> None:
     print(
         f"  완료 시간        : {f'{completed:.2f}s' if completed is not None else '(완료 기록 없음)'}"
     )
+    # 단계 경계 지표 (#110) — 구버전 로그에는 줄 자체가 없으므로 표기 생략
+    if summary["transfer_seconds"] is not None:
+        print(
+            f"  전송 구간        : {summary['transfer_seconds']:.2f}s"
+            f" / {_format_bytes(summary['transfer_bytes'])}"
+            f" / 재시도 {summary['transfer_retries']}"
+            f" / 정점 스레드 {summary['transfer_peak_threads']}"
+        )
+    if summary["postprocess_seconds"] is not None:
+        print(
+            f"  후처리 구간      : {summary['postprocess_seconds']:.2f}s"
+            f" ({summary['postprocess_kind']})"
+            f" / 산출물 {_format_bytes(summary['postprocess_output_bytes'])}"
+        )
+    elif summary["transfer_seconds"] is not None:
+        print("  후처리 구간      : (없음)")
     print(f"  완주(복구 포함)  : {'예' if summary['recovered'] else '아니오'}")
 
 

--- a/tests/unit/core/test_file_downloader_run.py
+++ b/tests/unit/core/test_file_downloader_run.py
@@ -28,9 +28,26 @@ class RunLogger:
         self.errors: list[str] = []
         self.completed_times: list[float] = []
         self.closed = 0
+        # 단계 경계 로그 (#110)
+        self.transfer_completes: list[tuple] = []
+        self.postprocess_starts: list[str] = []
+        self.postprocess_completes: list[tuple] = []
+        self.breakdowns: list[tuple] = []
 
     def log_download_start(self, total_size, part_size, segments, initial_threads):
         pass
+
+    def log_transfer_complete(self, elapsed, downloaded_bytes, retries, peak_threads):
+        self.transfer_completes.append((elapsed, downloaded_bytes, retries, peak_threads))
+
+    def log_postprocess_start(self, kind):
+        self.postprocess_starts.append(kind)
+
+    def log_postprocess_complete(self, elapsed, output_size):
+        self.postprocess_completes.append((elapsed, output_size))
+
+    def log_total_breakdown(self, transfer_elapsed, postprocess_elapsed):
+        self.breakdowns.append((transfer_elapsed, postprocess_elapsed))
 
     def log_thread_start(self, thread_id, start, end):
         pass
@@ -162,6 +179,31 @@ def test_run_downloads_file_byte_exact(tmp_path, monkeypatch):
     assert logger.warnings == []  # 느린 파트 오탐·전이 warning 없음
     assert logger.completed_times and logger.closed == 1
     assert data.completed_threads == 4  # 파트 4개 전부 정상 완료
+
+
+def test_phase_boundary_logs_for_file_path(tmp_path, monkeypatch):
+    """파일 경로의 단계 경계 로그 (#110) — 전송 요약 1줄, 후처리 줄 없음.
+
+    후처리가 없는 경로는 구분 줄이 "(no postprocess)"(postprocess_elapsed
+    None)로 남아 세 다운로더의 로그가 같은 형태로 끝난다.
+    """
+    engine, data, logger, output, finished, failures = _make_engine(tmp_path, monkeypatch)
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert len(logger.transfer_completes) == 1
+    _elapsed, downloaded, retries, peak = logger.transfer_completes[0]
+    assert downloaded == len(CONTENT)  # 받은 총 바이트
+    assert retries == 0  # 가짜 세션은 실패·저속이 없다
+    assert 1 <= peak <= 4  # 파트 4개 경로의 정점 동시 스레드
+    assert logger.postprocess_starts == [] and logger.postprocess_completes == []
+    assert len(logger.breakdowns) == 1
+    _transfer, postprocess = logger.breakdowns[0]
+    assert postprocess is None  # 후처리 없음 표기
+    assert logger.completed_times  # 기존 완료 줄(형식 불변)도 그대로
 
 
 def test_pause_resume_then_complete(tmp_path, monkeypatch):

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -107,12 +107,29 @@ class RunLogger:
         self.errors: list[str] = []
         self.completed_times: list[float] = []
         self.closed = 0
+        # 단계 경계 로그 (#110)
+        self.transfer_completes: list[tuple] = []
+        self.postprocess_starts: list[str] = []
+        self.postprocess_completes: list[tuple] = []
+        self.breakdowns: list[tuple] = []
 
     def log_download_start(self, total_size, part_size, segments, initial_threads):
         pass
 
     def log_m3u8_thread_start(self, thread_id, segment_url):
         pass
+
+    def log_transfer_complete(self, elapsed, downloaded_bytes, retries, peak_threads):
+        self.transfer_completes.append((elapsed, downloaded_bytes, retries, peak_threads))
+
+    def log_postprocess_start(self, kind):
+        self.postprocess_starts.append(kind)
+
+    def log_postprocess_complete(self, elapsed, output_size):
+        self.postprocess_completes.append((elapsed, output_size))
+
+    def log_total_breakdown(self, transfer_elapsed, postprocess_elapsed):
+        self.breakdowns.append((transfer_elapsed, postprocess_elapsed))
 
     def log_thread_complete(self, thread_id, downloaded_size):
         pass
@@ -298,6 +315,30 @@ def test_pause_resume_then_complete(tmp_path, monkeypatch):
     assert failures == []
     assert logger.warnings == []  # 상태 전이 warning 0건 (완료 조건)
     assert data.model.state is DownloadState.FINISHED
+
+
+def test_phase_boundary_logs_for_m3u8_path(tmp_path, monkeypatch):
+    """m3u8 경로의 단계 경계 로그 (#110) — 전송 요약 → remux 시작·종료 → 전체 구분."""
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    assert len(logger.transfer_completes) == 1
+    _elapsed, downloaded, retries, peak = logger.transfer_completes[0]
+    assert downloaded > 0 and retries == 0 and peak >= 1
+    assert logger.postprocess_starts == ["remux"]  # 무엇을 하는지
+    assert len(logger.postprocess_completes) == 1
+    _pp_elapsed, output_size = logger.postprocess_completes[0]
+    assert output_size == output.stat().st_size  # 최종 산출물 크기
+    assert len(logger.breakdowns) == 1
+    _transfer, postprocess = logger.breakdowns[0]
+    assert postprocess is not None  # 전체 = 전송 + 후처리 구분
+    assert logger.completed_times  # 기존 완료 줄(형식 불변)도 그대로
 
 
 def test_monitor_thread_is_stopped_before_postprocess(tmp_path, monkeypatch):

--- a/tests/unit/test_download_log_phases.py
+++ b/tests/unit/test_download_log_phases.py
@@ -1,0 +1,115 @@
+"""DownloadLogger 단계 경계 줄(#110)과 요약 스크립트의 하위 호환 검증.
+
+실제 로그 파일을 만들어 scripts/summarize_download_log.py가
+(a) 기존 지표를 계속 뽑고 (b) 새 단계 지표를 추가로 뽑는지 종단 검증한다 —
+새 줄의 메시지 형식과 요약 스크립트 패턴이 어긋나면 여기서 잡힌다.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import config.config as config_module
+from download.logger import DownloadLogger
+from scripts.summarize_download_log import summarize
+
+
+def _make_logger(tmp_path, monkeypatch) -> DownloadLogger:
+    """로그를 tmp_path 아래에 쓰는 DownloadLogger를 만든다."""
+    monkeypatch.setattr(config_module, "CONFIG_DIR", str(tmp_path))
+    return DownloadLogger()
+
+
+def _stub_item() -> SimpleNamespace:
+    """log_download_info가 참조하는 속성만 가진 아이템 스텁."""
+    return SimpleNamespace(
+        content_type="m3u8",
+        title="제목",
+        channel_name="채널",
+        live_open_date="2026-07-28",
+        duration=90,
+        resolution=1080,
+        total_size=0,
+        output_path="out.mp4",
+        download_path="downloads",
+    )
+
+
+def test_get_app_version_is_available():
+    """소스 실행에서 앱 버전이 해석된다 — pyproject 정본과 같은 버전 계열이어야 한다.
+
+    importlib.metadata는 버전을 정규화하므로(예: 2.9.0-rc1 → 2.9.0rc1)
+    문자열 완전 일치가 아니라 "기본 버전(major.minor.patch) 일치"로 비교한다.
+    """
+    root = Path(config_module.__file__).resolve().parent.parent
+    with open(root / "pyproject.toml", "rb") as f:
+        expected = tomllib.load(f)["project"]["version"]
+
+    version = config_module.get_app_version()
+    assert version != "unknown"
+    base = re.match(r"\d+\.\d+\.\d+", version)
+    assert base and expected.startswith(base.group(0))
+
+
+def test_phase_lines_parse_and_old_lines_still_parse(tmp_path, monkeypatch):
+    """완료 조건: 새 줄이 파싱되고, 기존 요약 스크립트 지표도 계속 동작한다."""
+    logger = _make_logger(tmp_path, monkeypatch)
+    logger.log_download_info(_stub_item())
+    logger.log_download_start(1000, 100, 10, 4)
+    logger.log_transfer_complete(12.34, 987654321, 3, 40)
+    logger.log_postprocess_start("remux")
+    logger.log_postprocess_complete(5.67, 987000000)
+    logger.log_download_complete(18.01)
+    logger.log_total_breakdown(12.34, 5.67)
+    log_file = Path(logger.log_file)
+    logger.save_and_close()
+
+    summary = summarize(log_file)
+
+    # 기존 지표 하위 호환 (#110 요건 5 — 기존 줄 형식 불변)
+    assert summary["total_size"] == 1000
+    assert summary["part_size"] == 100
+    assert summary["segments"] == 10
+    assert summary["initial_threads"] == 4
+    assert summary["completed_in_seconds"] == 18.01
+    assert summary["recovered"] is True
+
+    # 새 단계 지표
+    assert summary["app_version"] == config_module.get_app_version()
+    assert summary["transfer_seconds"] == 12.34
+    assert summary["transfer_bytes"] == 987654321
+    assert summary["transfer_retries"] == 3
+    assert summary["transfer_peak_threads"] == 40
+    assert summary["postprocess_kind"] == "remux"
+    assert summary["postprocess_seconds"] == 5.67
+    assert summary["postprocess_output_bytes"] == 987000000
+
+
+def test_breakdown_line_marks_missing_postprocess(tmp_path, monkeypatch):
+    """후처리 없는 경로(file)의 구분 줄은 "(no postprocess)"로 남는다 (#110 요건 6)."""
+    logger = _make_logger(tmp_path, monkeypatch)
+    logger.log_transfer_complete(3.21, 42, 0, 8)
+    logger.log_download_complete(3.25)
+    logger.log_total_breakdown(3.21, None)
+    log_file = Path(logger.log_file)
+    logger.save_and_close()
+
+    text = log_file.read_text(encoding="utf-8")
+    assert "Total time breakdown - Transfer: 3.21s (no postprocess)" in text
+
+    summary = summarize(log_file)
+    assert summary["transfer_seconds"] == 3.21
+    assert summary["postprocess_seconds"] is None
+    assert summary["postprocess_kind"] is None
+
+
+def test_breakdown_line_shows_transfer_plus_postprocess_sum(tmp_path, monkeypatch):
+    """구분 줄은 전송+후처리=전체 형태로 남는다 (#110 요건 4)."""
+    logger = _make_logger(tmp_path, monkeypatch)
+    logger.log_total_breakdown(10.0, 2.5)
+    log_file = Path(logger.log_file)
+    logger.save_and_close()
+
+    text = log_file.read_text(encoding="utf-8")
+    assert "Total time breakdown - Transfer: 10.00s + Postprocess: 2.50s = 12.50s" in text


### PR DESCRIPTION
## 관련 이슈

Closes #110

## 변경 내용

**다운로드 로그에 단계 경계·요약 줄 4종을 추가한다. 기존 줄 형식은 한 글자도 바꾸지 않았다** (요건 5).

새 로그 줄 (모두 INFO, `download/logger.py`의 새 메서드):

```
app_version: 2.9.0rc1                          ← 시작 정보 블록 첫 줄 (요건 1)
Transfer completed in 41.20 seconds - Bytes: 1234567890 - Retries: 2 - Peak threads: 40   ← 요건 2
Postprocess started - remux                     ← 요건 3
Postprocess completed in 6.10 seconds - Output size: 1234500000 bytes
Download completed in 47.35 seconds             ← 기존 줄, 불변 (전체 시간)
Total time breakdown - Transfer: 41.20s + Postprocess: 6.10s = 47.30s   ← 요건 4·7
```

- `core/downloaders/base.py`: 로깅 호출 시점 추가 — **세 다운로더 공통의 한 곳**(요건 6). 전송 종료 시각은 관측 스레드 정지(#89) 직후에 확정해 전송+후처리 합이 어긋나지 않게 했다. 정점 스레드 수는 워커 제출 지점에서 추적한다(`_peak_threads`). 재시도 = 실패 재큐잉 + 저속 재큐잉 합
- 파일 경로(후처리 없음)는 후처리 줄이 빠지고 구분 줄이 `Total time breakdown - Transfer: X.XXs (no postprocess)`로 남는다 — 세 경로가 같은 위치·같은 형태로 끝난다 (요건 6)
- `config/config.py`: `get_app_version()` 헬퍼 추가
- `scripts/summarize_download_log.py`: 새 지표(버전·전송 구간·후처리 구간) 파싱·표시 추가 — 기존 패턴은 무수정 (요건 5)
- `download/logger.py`: `log_download_complete` docstring에 "전체 시간" 명시 + 형식 불변 사유 기록 (요건 7)

## 앱 버전 읽기 경로 판단 (요건 1)

릴리즈 검증(CI)의 tomllib 원라이너는 **소스 트리 전제**라 Nuitka 빌드 실행 파일에는 pyproject.toml이 없어 그대로 재사용할 수 없다. 같은 정본(pyproject `[project].version`)을 쓰되 런타임 헬퍼로 구현했다: `importlib.metadata.version("cvdv2")`(소스·빌드 양쪽 동작, 버전 정규화됨 — `2.9.0-rc1` → `2.9.0rc1`) 우선, 소스 실행 폴백으로 pyproject 직접 읽기, 최후엔 `"unknown"`으로 로깅을 막지 않는다.

## 시간 합계에 대하여 (요건 4·7)

기존 `Download completed in X seconds`(불변)는 전체 벽시계 시간이고, 새 구분 줄의 `= 합계`는 전송·후처리 측정값의 산술 합이다. 두 값은 완료 처리 오버헤드만큼(수 ms) 다를 수 있다 — 구분 줄이 항상 additive하도록 합계를 자체 계산해 표기한다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (291 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시):
  - 엔진 경계 로그: m3u8(전송→remux 시작·종료→구분, 산출물 크기 일치)·file(후처리 줄 없음·`(no postprocess)`) 각 1건 — hls_aes는 base 공통 경로라 m3u8 검증이 커버
  - **종단 검증**: 실제 DownloadLogger로 로그 파일을 만들어 `summarize()`가 기존 지표(하위 호환)와 새 지표를 모두 뽑는지 확인 — 새 줄 형식과 스크립트 패턴이 어긋나면 여기서 잡힌다
- [x] core 순수성 가드(`test_no_qt_import`) 통과 — base는 duck-typed 로거 메서드 호출만 추가

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — 버전 헬퍼는 app 계층(config)에 두고 로거(app)가 호출
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — UI 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- 엔진 duck-typed 로거 계약이 4메서드 넓어져 테스트 하네스 로거(file·m3u8 run)에 기록 메서드를 추가했다 — hls_aes 하네스는 `__getattr__` 캐치올이라 무수정. 기존 테스트의 시나리오·단언은 무수정이다.
- 헤드리스 스크립트는 같은 DownloadLogger를 쓰므로 자동으로 동일한 줄이 남는다.
- 전송 요약·후처리 줄은 성공 경로에만 남는다 — 중단·실패 시엔 기존과 동일하게 예외 로그만 남는다(완료 줄도 원래 안 남던 경로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
