### PR TITLE
fix: 스레드 조정을 총 처리량 등반 규칙으로 교체 — 저해상도 붕괴 해소 (#112)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -27,8 +27,6 @@ file(#73)·m3u8(#74) 엔진이 평행 중복으로 갖고 있던 실행 엔진�
   requires_postprocess가 참일 때만 run()이 호출한다 (#83)
 - ``_initial_queue(items)``: 시작 시 작업 큐 구성 (기본: 목록 그대로)
 - ``_cleanup_after_run()``: 정상 경로 종료 후 정리 (기본 no-op)
-- ``_get_standard_speed()``: 스레드 스케일링 기준 속도 (기본 4 MB/s — 구 파일
-  엔진의 고정 임계 4/2와 동일. m3u8은 해상도별 테이블로 오버라이드)
 - ``_progress_total_size()``: ProgressEvent.total_size (기본: 전체 크기,
   m3u8은 미리 알 수 없어 None)
 - 클래스 속성: ``run_thread_name``(서비스 워커 스레드 이름),
@@ -68,6 +66,27 @@ from core.models.events import (
 )
 from core.models.plan import DownloadPlan
 from core.utils.ffmpeg import FFmpegError, read_in_chunks, remux_stream
+
+
+# ============ 스레드 조정 상수 (#112 — 총 처리량 등반 규칙) ============
+# 판단 신호는 "목표를 올렸을 때 총 처리량이 실제로 늘었는가"다.
+# 근거·실측은 _adjust_threads docstring 참조.
+_CLIMB_STEP = 4  # 한 번에 올리는 목표 스레드 수 (구 규칙의 +4 보폭 유지)
+_TARGET_CAP = 48  # 목표 스레드 상한 — 구 규칙에서 실측된 정점 수준 (서버 부하 상한)
+# 인상 유효 판정: 선형 기대 이득(step/target)의 최소 이 비율이 실측돼야 한다.
+# 낮게 잡는 이유 — 1080p 실측에서 4→8이 +32%, 8→12가 +7%처럼 선형 미만이어도
+# 실질 이득인 준선형 구간이 있다. 과등반은 상한(_TARGET_CAP)이 막고,
+# 미달 등반(최적 이하에서 멈춤)은 곧바로 처리량 손실이라 이쪽을 더 경계한다
+_GROWTH_EFFICIENCY = 0.125
+_SETTLE_TICKS = 2  # 조정 직후 판단을 쉬는 틱 수 — 새 연결 램프업이 측정을 오염시킨다
+_COLLAPSE_RATIO = 0.50  # 붕괴 판정: 정체 기준 총 처리량의 절반 미만
+# 자연 회복 판정 임계 — 실측상 링크 포화 구간의 처리량 노이즈가 ±15% 수준이라
+# (1080p 실측 80~113 MB/s), 10%로 두면 정체↔등반 진동이 생긴다. 기준 자체도
+# 단일 표본이 아니라 지수이동평균으로 평활한다 (_HOLD_EMA_ALPHA)
+_RECOVERY_RATIO = 1.30
+_HOLD_EMA_ALPHA = 0.2  # 정체 기준의 지수이동평균 가중치 (안정 틱에서만 갱신)
+_COLLAPSE_TICKS = 5  # 감소 확정에 필요한 연속 틱 수 (구 규칙과 동일한 관성)
+_REPROBE_TICKS = 15  # 정체 상태에서 재탐침까지의 틱 수
 
 
 class PostprocessError(Exception):
@@ -131,6 +150,14 @@ class BaseDownloader(ABC):
         self._monitor_stop = threading.Event()
         # 전송 중 관측된 정점 동시 스레드 수 — 전송 종료 요약 로그용 (#110)
         self._peak_threads = 0
+        # 총 처리량 등반 상태 (#112) — 판단 규칙은 _adjust_threads 참조
+        self._reference_speed: float | None = None  # 직전 인상 직전의 총 처리량
+        self._reference_target = 0  # 직전 인상 직전의 목표 스레드 수
+        self._reference_step = _CLIMB_STEP  # 직전 인상의 실제 폭 (상한 직전엔 +4 미만)
+        self._hold_reference: float | None = None  # 정체 구간의 기준 총 처리량
+        self._at_ceiling = False  # 상한 도달(정체) 여부
+        self._settle_ticks = 0  # 조정 직후 판단을 쉬는 틱 수
+        self._stall_ticks = 0  # 정체 지속 틱 수 (재탐침 타이머)
         self._on_progress: ProgressCallback = on_progress or (lambda event: None)
         self._on_finished: FinishedCallback = on_finished or (lambda: None)
         self._on_failed: FailedCallback = on_failed or (lambda exc: None)
@@ -263,10 +290,6 @@ class BaseDownloader(ABC):
 
     def _cleanup_after_run(self) -> None:
         """정상 경로(비예외) 종료 후 정리 (기본 no-op). m3u8은 임시 폴더를 지운다."""
-
-    def _get_standard_speed(self) -> float:
-        """스레드 스케일링 기준 속도(MB/s). 기본 4 — 구 파일 엔진의 고정 임계와 동일."""
-        return 4.0
 
     def _progress_total_size(self) -> int | None:
         """ProgressEvent에 실을 전체 크기. 미리 알 수 없는 다운로더는 None."""
@@ -491,41 +514,118 @@ class BaseDownloader(ABC):
                 elapsed += interval
 
     def _adjust_threads(self):
+        """총 처리량 등반으로 목표 스레드 수를 조정한다 (#112).
+
+        판단 신호는 "목표를 올렸을 때 총 처리량(speed_mb)이 실제로
+        늘었는가"다. 늘면 계속 올리고(+4), 늘지 않으면 직전 인상을 되물리고
+        그 지점을 상한으로 정체한다. 정체 중 처리량이 절반 미만으로 지속
+        하락하면 절반으로 줄이고, 주기적으로 재탐침한다.
+
+        구 규칙(스레드당 평균 속도 vs 해상도별 기준)을 버린 이유 (#112 실측):
+        - 치지직은 연결당 처리량을 제한한다(144p 연결당 ~0.95 MB/s). 총량은
+          스레드 수에 선형(4→3.85, 8→7.64, 16→15.06, 32→29.57 MB/s)이라
+          "스레드당 속도가 낮으면 줄인다"는 총 처리량만 떨어뜨린다 — 방향이
+          반대다
+        - 평균의 분모가 관측 순간의 활성 수(future_count)였다. 세그먼트가
+          잘게 쪼개진 저해상도에서는 빈 슬롯 순간(활성 0)이 '저속'으로
+          오판돼 실제 4.7 MB/s로 받는 중에도 4→2→1로 붕괴했다(로그 실측).
+          총 처리량은 활성 수와 무관해 이 오판이 구조적으로 사라진다
         """
-        다운로드 진행 중, 속도 등에 따라 스레드 수를 동적으로 조정한다.
+        total_speed = self.s.speed_mb
 
-        기준 속도(_get_standard_speed) 초과 틱이 쌓이면 +4, 기준/2 미만 틱이
-        쌓이면 절반으로. 중간 대역은 카운터를 0으로 감쇠한다 (히스테리시스).
-        """
-        with self.lock:
-            future_count = self.s.future_count
+        if self._settle_ticks > 0:
+            # 조정 직후의 측정은 이전 목표 구간과 섞여 있다 — 한 틱 쉰다
+            self._settle_ticks -= 1
+            return
+        if self._reference_speed is None and self._hold_reference is None and total_speed <= 0:
+            return  # 시작 직후 첫 유효 측정 전 — 판단 근거가 없다
 
-        avg_active_speed = self.s.speed_mb / future_count if future_count > 0 else 0
-
-        standard_speed = self._get_standard_speed()
-
-        if avg_active_speed > standard_speed:
-            self.adjust_count += 1
-        elif avg_active_speed < standard_speed / 2:
-            self.adjust_count -= 1
+        if self._at_ceiling:
+            self._hold(total_speed)
         else:
-            if self.adjust_count > 0:
-                self.adjust_count -= 1
-            elif self.adjust_count < 0:
-                self.adjust_count += 1
+            self._climb(total_speed)
 
-        if self.adjust_count > 1:
-            self.s.adjust_threads = min(self.s.max_threads, self.s.adjust_threads + 4)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
-        elif self.adjust_count < -4:
-            self.s.adjust_threads = max(1, self.s.adjust_threads // 2)
-            self.logger.log_thread_adjust(
-                self.s.adjust_threads, self.s.speed_mb
-            )  # 스레드 조정 로그
-            self.adjust_count = 0
+    def _climb(self, total_speed: float) -> None:
+        """등반 단계: 직전 인상이 유효했으면 +4 계속, 아니면 되물리고 정체 전환.
+
+        유효 판정은 "인상분이 선형 기대 이득의 최소 일부(_GROWTH_EFFICIENCY)로
+        총 처리량에 반영됐는가"다 — 고정 비율(예: +10%)은 목표가 커질수록
+        선형 이득(+4/n)보다 커져 정상 등반을 막기 때문에, 요구 증가폭을
+        인상 전 목표에 비례시킨다.
+        """
+        if self._reference_speed is not None:
+            # 상한 직전의 부분 인상(+4 미만)도 실제 인상 폭 기준으로 판정한다
+            required = self._reference_speed * (
+                1 + _GROWTH_EFFICIENCY * self._reference_step / self._reference_target
+            )
+            if total_speed <= required:
+                # 직전 인상이 총 처리량을 늘리지 못했다 — 여기가 상한이다.
+                # 효과 없던 인상분은 정확히 되물려 연결 수를 아낀다.
+                # 정체 기준은 두 표본 중 큰 쪽 — 인상 직전의 낮은 표본을
+                # 기준으로 삼으면 노이즈 상단이 '회복'으로 오판돼 진동한다
+                self.s.adjust_threads = self._reference_target
+                self._enter_hold(max(self._reference_speed, total_speed))
+                self.logger.log_thread_adjust(self.s.adjust_threads, total_speed)
+                return
+
+        cap = min(self.s.max_threads, _TARGET_CAP)
+        if self.s.adjust_threads >= cap:
+            self._enter_hold(total_speed)
+            return
+
+        self._reference_speed = total_speed
+        self._reference_target = self.s.adjust_threads
+        new_target = min(cap, self.s.adjust_threads + _CLIMB_STEP)
+        self._reference_step = new_target - self.s.adjust_threads
+        self.s.adjust_threads = new_target
+        self._settle_ticks = _SETTLE_TICKS
+        self.logger.log_thread_adjust(self.s.adjust_threads, total_speed)
+
+    def _hold(self, total_speed: float) -> None:
+        """정체 단계: 붕괴 감시(지속 하락 시 절반)·자연 회복 감지·주기 재탐침."""
+        self._stall_ticks += 1
+
+        if total_speed < self._hold_reference * _COLLAPSE_RATIO:
+            self.adjust_count -= 1
+            if self.adjust_count <= -_COLLAPSE_TICKS:
+                # 처리량이 기준의 절반 미만으로 지속 하락(네트워크·서버 악화).
+                # 하락한 처리량이 새 기준이 된다 — 추가 감소는 또다시 절반
+                # 미만으로 떨어졌을 때만 일어난다 (연쇄 자동 붕괴 방지)
+                halved = max(1, self.s.adjust_threads // 2)
+                if halved != self.s.adjust_threads:
+                    self.s.adjust_threads = halved
+                    self._settle_ticks = _SETTLE_TICKS
+                    self.logger.log_thread_adjust(halved, total_speed)
+                self._hold_reference = total_speed
+                self.adjust_count = 0
+                self._stall_ticks = 0
+            return
+
+        if total_speed > self._hold_reference * _RECOVERY_RATIO:
+            # 정체 기준보다 뚜렷이 빨라졌다(경합 해소 등) — 등반 재개
+            self._resume_climb()
+            return
+
+        # 안정 대역 — 기준을 평활 갱신하고(노이즈 내성), 감소 카운터 감쇠,
+        # 주기 재탐침
+        self._hold_reference += _HOLD_EMA_ALPHA * (total_speed - self._hold_reference)
+        if self.adjust_count < 0:
+            self.adjust_count += 1
+        if self._stall_ticks >= _REPROBE_TICKS:
+            self._resume_climb()
+
+    def _enter_hold(self, reference_speed: float) -> None:
+        """정체 상태로 전환한다 — reference_speed가 붕괴·회복 판단 기준이 된다."""
+        self._at_ceiling = True
+        self._hold_reference = reference_speed
+        self._stall_ticks = 0
+        self.adjust_count = 0
+
+    def _resume_climb(self) -> None:
+        """등반을 재개한다 — 다음 틱에 한 칸 탐침부터 다시 시작한다."""
+        self._at_ceiling = False
+        self._reference_speed = None
+        self.adjust_count = 0
 
     def measure_speed(self):
         """직전 틱 대비 다운로드 바이트 증가량으로 속도(MB/s)를 계산한다."""

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -140,17 +140,6 @@ class HlsAesDownloader(BaseDownloader):
         # 전체 바이트 크기를 미리 알 수 없다 — 세그먼트 수 기반 계산은 어댑터가 한다
         return None
 
-    def _get_standard_speed(self) -> float:
-        """해상도별 기준 속도 — m3u8 경로와 동일 테이블(같은 세그먼트 전송 특성)."""
-        if self.s.resolution == 144:
-            return 0.2
-        elif self.s.resolution in [360, 480]:
-            return 0.5
-        elif self.s.resolution == 720:
-            return 1.2
-        else:
-            return 3
-
     # ============ 키 취득 ============
 
     def _resolve_key(self, content: Content, key_uri: str) -> bytes:

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -16,7 +16,6 @@ m3u8 고유 부분만 남는다:
 - postprocess: 세그먼트를 인덱스 순서로 ffmpeg stdin에 흘리는 단일 패스
   재포장 (#88·#92) — 시작은 on_merge_start 콜백으로 알리고, 실패 시 폴백
   없이 명확히 실패한다 (세그먼트 보존)
-- 스레드 스케일링 기준 속도는 해상도별 테이블(_get_standard_speed)
 - 전체 크기를 미리 알 수 없어 ProgressEvent.total_size는 None이다.
   진행률 계산(세그먼트 수 기반)은 어댑터의 몫이다.
 """
@@ -199,18 +198,4 @@ class M3U8Downloader(BaseDownloader):
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
 
-    # ============ 스레드 스케일링 기준 (해상도별) ============
-
-    def _get_standard_speed(self) -> float:
-        """
-        해상도에 따른 표준 속도 값을 반환합니다.
-        """
-        if self.s.resolution == 144:
-            return 0.2
-        elif self.s.resolution in [360, 480]:
-            return 0.5
-        elif self.s.resolution == 720:
-            return 1.2
-        else:
-            return 3
 

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -93,123 +93,127 @@ def _engine_module():
     return mod
 
 
-# ================================================================ 스레드 증가/감소
+# ================================================================ 스레드 조정 (#112 — 총 처리량 등반)
+#
+# 구 규칙(스레드당 평균 속도 vs 고정 임계 4/2 MB/s)의 박제는 #112로 폐기했다.
+# 판단 신호를 총 처리량의 실제 증감으로 바꾼 근거는 base._adjust_threads
+# docstring과 m3u8 규칙 테스트의 섹션 주석 참조 (파일 경로도 같은 base 규칙을 쓴다).
 
 
-def test_fast_two_ticks_increase_threads_by_4():
-    """평균 > 4 MB/s 틱 2회 → adjust_count 2(>1) → 스레드 +4, 카운터 리셋."""
+def _tick(scaler, data, speed: float) -> None:
+    """1초 관측 틱을 흉내 낸다 — 측정된 총 처리량 반영 후 조정 1회."""
+    data.speed_mb = speed
+    scaler._adjust_threads()
+
+
+def test_warmup_without_measurement_does_nothing():
+    """첫 유효 측정 전(속도 0)에는 조정하지 않는다 — 시작 직후 오판 방지."""
+    data, logger = _make_data(), RecordingLogger()
+    scaler = _make_scaler(data, logger)
+
+    _tick(scaler, data, 0.0)
+
+    assert data.adjust_threads == 4
+    assert logger.adjust_calls == []
+
+
+def test_first_valid_tick_probes_up_by_4():
+    """첫 유효 측정에서 +4 탐침을 시작한다 (구 규칙의 +4 보폭 유지)."""
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 32
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 4
-    data.speed_mb = 20.0  # 평균 5 MB/s
-    scaler._adjust_threads()
-    assert (scaler.adjust_count, data.adjust_threads) == (1, 4)  # 1틱으로는 불변
+    _tick(scaler, data, 3.9)
 
-    scaler._adjust_threads()
     assert data.adjust_threads == 8
-    assert scaler.adjust_count == 0
-    assert logger.adjust_calls == [(8, 20.0)]
+    assert logger.adjust_calls == [(8, 3.9)]
 
 
-def test_increase_is_capped_at_max_threads():
-    """증가 시 상한은 max_threads다."""
+def test_climbs_while_throughput_grows_and_caps_at_max_threads():
+    """총 처리량이 느는 동안 +4 계단으로 오르되 상한은 min(max_threads, 48)이다."""
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 10
-    data.adjust_threads = 8
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 8
-    data.speed_mb = 40.0  # 평균 5 MB/s
-    scaler._adjust_threads()
-    scaler._adjust_threads()
+    for _ in range(10):
+        _tick(scaler, data, data.adjust_threads * 0.95)
 
     assert data.adjust_threads == 10  # 8+4=12가 아니라 상한 10
 
 
-def test_slow_five_ticks_halve_threads():
-    """평균 < 2 MB/s 틱 5회 → adjust_count -5(<-4) → 스레드 절반, 카운터 리셋."""
+def test_reverts_and_holds_when_raise_does_not_increase_throughput():
+    """인상해도 총 처리량이 늘지 않으면 되물리고 그 지점을 상한으로 정체한다."""
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 32
-    data.adjust_threads = 8
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 8
-    data.speed_mb = 8.0  # 평균 1 MB/s
-    for _ in range(4):
-        scaler._adjust_threads()
-    assert data.adjust_threads == 8  # 4틱까지는 불변 (-4는 경계 미달)
+    _tick(scaler, data, 5.0)  # 4→8 (기준 5.0)
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.2)  # 요구치(5.0×1.125=5.625) 미달 → 8→4 되물림 + 정체
 
-    scaler._adjust_threads()
     assert data.adjust_threads == 4
-    assert scaler.adjust_count == 0
-    assert logger.adjust_calls == [(4, 8.0)]
+    assert logger.adjust_calls == [(8, 5.0), (4, 5.2)]
+
+
+def test_sustained_collapse_halves_after_five_ticks():
+    """정체 기준의 절반 미만이 5틱 지속되면 절반으로 줄인다 (관성은 구 규칙과 동일)."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 32
+    scaler = _make_scaler(data, logger)
+
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 9.0)  # settle 1
+    _tick(scaler, data, 9.0)  # settle 2
+    _tick(scaler, data, 9.0)  # 요구치(5.0×1.125) 초과 → 8→12 (기준 9.0)
+    _tick(scaler, data, 9.2)  # settle 1
+    _tick(scaler, data, 9.2)  # settle 2
+    _tick(scaler, data, 9.2)  # 요구치(9.0×1.0417=9.375) 미달 → 12→8 되물림 + 정체 (기준 9.2)
+    assert data.adjust_threads == 8
+
+    for _ in range(4):  # 기준의 절반(4.6) 미만 4틱 — 아직 불변
+        _tick(scaler, data, 4.0)
+    assert data.adjust_threads == 8
+
+    _tick(scaler, data, 4.0)  # 5틱째 — 절반으로
+    assert data.adjust_threads == 4
 
 
 def test_halving_floor_is_one_thread():
-    """감소 시 하한은 1스레드다."""
-    data, logger = _make_data(), RecordingLogger()
-    data.adjust_threads = 1
-    scaler = _make_scaler(data, logger)
-
-    data.future_count = 1
-    data.speed_mb = 0.5
-    for _ in range(5):
-        scaler._adjust_threads()
-
-    assert data.adjust_threads == 1
-
-
-def test_middle_band_decays_adjust_count_toward_zero():
-    """중간 대역(2~4 MB/s)은 누적 카운터를 0으로 1씩 되돌린다 (히스테리시스)."""
+    """처리량 하락이 이어지면 절반씩 1까지 내려가고, 그 밑으로는 내려가지 않는다."""
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 32
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 4
-    data.speed_mb = 20.0  # 평균 5 → +1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 1
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.0)  # 요구치 미달 → 되물림 → 4 정체 (기준 5.0)
+    assert data.adjust_threads == 4
 
-    data.speed_mb = 12.0  # 평균 3 → 감쇠 -1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
-    assert data.adjust_threads == 4  # 임계 미달로 불변
+    for _ in range(7):  # 기준(5.0)의 절반 미만 지속 → 4→2 (새 기준 2.0)
+        _tick(scaler, data, 2.0)
+    assert data.adjust_threads == 2
 
-    data.speed_mb = 4.0  # 평균 1 → -1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == -1
-    data.speed_mb = 12.0  # 평균 3 → 감쇠 +1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
+    for _ in range(7):  # 또 절반 미만으로 하락 → 2→1
+        _tick(scaler, data, 0.9)
+    assert data.adjust_threads == 1
+
+    for _ in range(10):  # 더 하락해도 1 밑으로는 내려가지 않는다
+        _tick(scaler, data, 0.1)
+    assert data.adjust_threads == 1
 
 
-def test_band_boundaries_are_exclusive():
-    """경계값 4 MB/s·2 MB/s는 중간 대역이다 (초과/미만 판정)."""
+def test_zero_active_sample_is_not_a_slow_signal():
+    """관측 순간 활성 0이어도 총 처리량이 신호다 — 구 규칙 붕괴 원인의 반전 박제 (#112)."""
     data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 32
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 2
-    data.speed_mb = 8.0  # 평균 정확히 4 → 증가 아님
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
+    data.future_count = 0  # 빈 슬롯 순간에 관측됐다
+    _tick(scaler, data, 3.9)
 
-    data.speed_mb = 4.0  # 평균 정확히 2 → 감소 아님
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
-
-
-def test_zero_active_threads_counts_as_slow_tick():
-    """활성 스레드 0이면 평균 0으로 간주되어 감소 방향 틱이다."""
-    data, logger = _make_data(), RecordingLogger()
-    scaler = _make_scaler(data, logger)
-
-    data.future_count = 0
-    data.speed_mb = 10.0
-    scaler._adjust_threads()
-
-    assert scaler.adjust_count == -1
+    assert data.adjust_threads == 8  # 감소가 아니라 정상 탐침
 
 
 # ================================================================ 속도 계산

--- a/tests/unit/core/test_m3u8_downloader_rules.py
+++ b/tests/unit/core/test_m3u8_downloader_rules.py
@@ -67,7 +67,7 @@ def _make_data(resolution: int = 1080, output_path: str = "unused.mp4") -> Downl
 
 
 def _make_scaler(data: DownloadData, logger: RecordingLogger):
-    """스케일링 규칙(_adjust_threads/measure_speed/_get_standard_speed) 보유 객체를 만든다.
+    """스케일링 규칙(_adjust_threads/measure_speed) 보유 객체를 만든다.
 
     이주 전: download.monitor_m3u8.MonitorM3U8Thread / 이주 후: core M3U8Downloader.
     반환 객체는 adjust_count 속성과 세 메서드를 노출해야 한다.
@@ -94,157 +94,262 @@ def _engine_module():
     return mod
 
 
-# ================================================================ 해상도별 기준 속도
+# ================================================================ 스레드 조정 (#112 — 총 처리량 등반)
+#
+# 구 규칙(스레드당 평균 속도 vs 해상도별 기준 테이블)의 박제는 #112로 폐기했다.
+# 근거: (1) 치지직은 연결당 처리량을 제한해(144p 연결당 ~0.95 MB/s, 총량은
+# 스레드 수에 선형) 스레드당 속도는 줄일 신호가 아니고, (2) 평균의 분모였던
+# 순간 활성 수는 세그먼트가 잘게 쪼개진 저해상도에서 빈 슬롯을 '저속'으로
+# 오판해 4→2→1 붕괴를 일으켰다. 새 신호는 총 처리량의 실제 증감이다.
 
 
-@pytest.mark.parametrize(
-    ("resolution", "standard"),
-    [(144, 0.2), (360, 0.5), (480, 0.5), (720, 1.2), (1080, 3), (1440, 3)],
-)
-def test_standard_speed_table(resolution, standard):
-    """기준 속도는 해상도별 고정 테이블을 따른다 (그 외 해상도는 3 MB/s)."""
-    data, logger = _make_data(resolution=resolution), RecordingLogger()
-    scaler = _make_scaler(data, logger)
-
-    assert scaler._get_standard_speed() == pytest.approx(standard)
-
-
-def test_same_speed_judged_by_resolution_band():
-    """같은 평균 속도라도 해상도 기준에 따라 증가/감소 방향이 갈린다."""
-    # 평균 1.3 MB/s: 720p(기준 1.2)에서는 증가 방향
-    data, logger = _make_data(resolution=720), RecordingLogger()
-    scaler = _make_scaler(data, logger)
-    data.future_count = 2
-    data.speed_mb = 2.6
+def _tick(scaler, data, speed: float) -> None:
+    """1초 관측 틱을 흉내 낸다 — 측정된 총 처리량 반영 후 조정 1회."""
+    data.speed_mb = speed
     scaler._adjust_threads()
-    assert scaler.adjust_count == 1
 
-    # 1080p(기준 3, 하한 1.5)에서는 같은 1.3 MB/s가 감소 방향
-    data, logger = _make_data(resolution=1080), RecordingLogger()
+
+def test_warmup_without_measurement_does_nothing():
+    """첫 유효 측정 전(속도 0)에는 조정하지 않는다 — 시작 직후 오판 방지."""
+    data, logger = _make_data(), RecordingLogger()
     scaler = _make_scaler(data, logger)
-    data.future_count = 2
-    data.speed_mb = 2.6
-    scaler._adjust_threads()
-    assert scaler.adjust_count == -1
+
+    _tick(scaler, data, 0.0)
+
+    assert data.adjust_threads == 4
+    assert logger.adjust_calls == []
 
 
-# ================================================================ 스레드 증가/감소
-
-
-def test_fast_two_ticks_increase_threads_by_4():
-    """평균 > 기준(1080p: 3 MB/s) 틱 2회 → adjust_count 2(>1) → 스레드 +4, 카운터 리셋."""
+def test_first_valid_tick_probes_up_by_4():
+    """첫 유효 측정에서 +4 탐침을 시작한다 (구 규칙의 +4 보폭 유지)."""
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 6996
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 4
-    data.speed_mb = 20.0  # 평균 5 MB/s
-    scaler._adjust_threads()
-    assert (scaler.adjust_count, data.adjust_threads) == (1, 4)  # 1틱으로는 불변
+    _tick(scaler, data, 3.9)
 
-    scaler._adjust_threads()
     assert data.adjust_threads == 8
-    assert scaler.adjust_count == 0
-    assert logger.adjust_calls == [(8, 20.0)]
+    assert logger.adjust_calls == [(8, 3.9)]
 
 
-def test_increase_is_capped_at_max_threads():
-    """증가 시 상한은 max_threads(세그먼트 수)다."""
+def test_settle_ticks_after_change_skip_decision():
+    """조정 직후 2틱은 판단을 쉰다 — 새 연결 램프업이 섞인 측정으로 판단하지 않는다."""
     data, logger = _make_data(), RecordingLogger()
-    data.max_threads = 10
-    data.adjust_threads = 8
+    data.max_threads = 6996
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 8
-    data.speed_mb = 40.0  # 평균 5 MB/s
-    scaler._adjust_threads()
-    scaler._adjust_threads()
+    _tick(scaler, data, 3.9)  # 4→8
+    _tick(scaler, data, 100.0)  # settle 1 — 무시된다
+    _tick(scaler, data, 100.0)  # settle 2 — 무시된다
+
+    assert data.adjust_threads == 8
+    assert logger.adjust_calls == [(8, 3.9)]
+
+
+def test_climbs_to_cap_while_throughput_scales_linearly():
+    """총 처리량이 선형으로 느는 동안 +4 계단으로 상한(48)까지 등반한다.
+
+    #112 실측 재현: 144p 연결당 ~0.95 MB/s 선형 구간. 계단 모양(+4)은
+    구 규칙의 1080p 정상 궤적(4→8→…→48)과 동일해야 한다 (회귀 금지 조건).
+    """
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    for _ in range(40):  # settle 틱 포함 여유 있는 반복
+        _tick(scaler, data, data.adjust_threads * 0.95)
+
+    assert data.adjust_threads == 48
+    targets = [call[0] for call in logger.adjust_calls]
+    assert targets == [8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48]  # +4 계단
+
+
+def test_cap_respects_max_threads():
+    """상한은 min(max_threads, 48)이다 — 세그먼트가 적으면 그 수가 상한."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 10
+    scaler = _make_scaler(data, logger)
+
+    for _ in range(10):
+        _tick(scaler, data, data.adjust_threads * 0.95)
 
     assert data.adjust_threads == 10  # 8+4=12가 아니라 상한 10
 
 
-def test_slow_five_ticks_halve_threads():
-    """평균 < 기준/2(1080p: 1.5 MB/s) 틱 5회 → adjust_count -5(<-4) → 스레드 절반, 카운터 리셋."""
+def test_reverts_and_holds_when_raise_does_not_increase_throughput():
+    """인상해도 총 처리량이 늘지 않으면 되물리고 그 지점을 상한으로 정체한다.
+
+    서버가 총량 기준으로 제한하는 구간에서는 스레드를 늘려도 이득이 없다 —
+    이때 연결 수를 아끼는 것이 (d) 규명 결과에 맞는 동작이다.
+    """
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 6996
-    data.adjust_threads = 8
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 8
-    data.speed_mb = 8.0  # 평균 1 MB/s
-    for _ in range(4):
-        scaler._adjust_threads()
-    assert data.adjust_threads == 8  # 4틱까지는 불변 (-4는 경계 미달)
+    _tick(scaler, data, 5.0)  # 4→8 (기준 5.0)
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.2)  # 요구치(5.0×1.125=5.625) 미달 → 8→4 되물림 + 정체
 
-    scaler._adjust_threads()
     assert data.adjust_threads == 4
-    assert scaler.adjust_count == 0
-    assert logger.adjust_calls == [(4, 8.0)]
+    assert logger.adjust_calls == [(8, 5.0), (4, 5.2)]
+
+    for _ in range(5):  # 정체 중 같은 속도로는 더 조정하지 않는다
+        _tick(scaler, data, 5.0)
+    assert data.adjust_threads == 4
+
+
+def test_growth_requirement_scales_with_target():
+    """유효 판정 요구 증가폭은 인상 전 목표에 비례한다.
+
+    고정 비율(+10% 등)은 목표가 커질수록 선형 이득(+4/n)보다 커져 정상
+    등반을 막는다 — 목표 40→44 인상의 선형 이득(+9.5%, 38.0→41.8)은
+    고정 +10%로는 기각되지만 비례 요구치(38×1.0125=38.475)로는 유효다.
+    등반 중간 상태는 시나리오로 만들기 길어 직접 세팅한다.
+    """
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    data.adjust_threads = 44
+    scaler = _make_scaler(data, logger)
+    scaler._reference_speed = 38.0  # 목표 40이 내던 총 처리량 (40×0.95)
+    scaler._reference_target = 40
+
+    _tick(scaler, data, 41.8)  # 44×0.95 — 선형 이득. 요구치 38.475 초과
+
+    assert data.adjust_threads == 48  # 인상 유효 → 계속 등반
+
+
+def test_sustained_collapse_halves_after_five_ticks():
+    """정체 기준의 절반 미만이 5틱 지속되면 절반으로 줄인다 (관성은 구 규칙과 동일)."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 9.0)  # settle 1
+    _tick(scaler, data, 9.0)  # settle 2
+    _tick(scaler, data, 9.0)  # 요구치(5.0×1.125) 초과 → 8→12 (기준 9.0)
+    _tick(scaler, data, 9.2)  # settle 1
+    _tick(scaler, data, 9.2)  # settle 2
+    _tick(scaler, data, 9.2)  # 요구치(9.0×1.0417=9.375) 미달 → 12→8 되물림 + 정체 (기준 9.2)
+    assert data.adjust_threads == 8
+
+    for _ in range(4):  # 기준의 절반(4.6) 미만 4틱 — 아직 불변
+        _tick(scaler, data, 4.0)
+    assert data.adjust_threads == 8
+
+    _tick(scaler, data, 4.0)  # 5틱째 — 절반으로
+    assert data.adjust_threads == 4
+    assert logger.adjust_calls[-1] == (4, 4.0)
 
 
 def test_halving_floor_is_one_thread():
-    """감소 시 하한은 1스레드다."""
-    data, logger = _make_data(), RecordingLogger()
-    data.adjust_threads = 1
-    scaler = _make_scaler(data, logger)
+    """처리량 하락이 이어지면 절반씩 1까지 내려가고, 그 밑으로는 내려가지 않는다.
 
-    data.future_count = 1
-    data.speed_mb = 0.5
-    for _ in range(5):
-        scaler._adjust_threads()
-
-    assert data.adjust_threads == 1
-
-
-def test_middle_band_decays_adjust_count_toward_zero():
-    """중간 대역(1080p: 1.5~3 MB/s)은 누적 카운터를 0으로 1씩 되돌린다 (히스테리시스)."""
+    절반 감소 후에는 그 시점 처리량이 새 기준이 된다 — 추가 감소는 기준
+    대비 또다시 절반 미만으로 떨어졌을 때만 일어난다(연쇄 자동 붕괴 방지).
+    """
     data, logger = _make_data(), RecordingLogger()
     data.max_threads = 6996
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 4
-    data.speed_mb = 20.0  # 평균 5 → +1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 1
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.0)  # 요구치 미달 → 되물림 → 4 정체 (기준 5.0)
+    assert data.adjust_threads == 4
 
-    data.speed_mb = 8.0  # 평균 2 → 감쇠 -1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
+    for _ in range(7):  # 기준(5.0)의 절반 미만 지속 → 4→2 (새 기준 2.0)
+        _tick(scaler, data, 2.0)
+    assert data.adjust_threads == 2
+
+    for _ in range(7):  # 또 절반 미만으로 하락 → 2→1
+        _tick(scaler, data, 0.9)
+    assert data.adjust_threads == 1
+
+    for _ in range(10):  # 더 하락해도 1 밑으로는 내려가지 않는다
+        _tick(scaler, data, 0.1)
+    assert data.adjust_threads == 1
+
+
+def test_collapse_counter_decays_on_stable_tick():
+    """붕괴 카운터는 안정 틱에서 0으로 1씩 되돌아간다 (히스테리시스 유지)."""
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.0)  # 되물림 → 4 정체 (기준 5.0)
+
+    for _ in range(3):  # 붕괴 방향 3틱
+        _tick(scaler, data, 2.0)
+    assert scaler.adjust_count == -3
+
+    _tick(scaler, data, 5.0)  # 안정 틱 — 감쇠
+    assert scaler.adjust_count == -2
     assert data.adjust_threads == 4  # 임계 미달로 불변
 
-    data.speed_mb = 4.0  # 평균 1 → -1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == -1
-    data.speed_mb = 8.0  # 평균 2 → 감쇠 +1
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
 
+def test_hold_resumes_climbing_on_recovery():
+    """정체 기준보다 +30% 넘게 빨라지면 등반을 재개한다 (경합 해소 등 상황 변화).
 
-def test_band_boundaries_are_exclusive():
-    """경계값(기준·기준/2)은 중간 대역이다 (초과/미만 판정)."""
+    임계 30%는 링크 포화 구간의 처리량 노이즈(±15% 실측)로 인한 정체↔등반
+    진동을 막기 위한 값이다 — 노이즈 범위 안의 출렁임으로는 재개하지 않는다.
+    """
     data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 2
-    data.speed_mb = 6.0  # 평균 정확히 3 → 증가 아님
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.0)  # 되물림 → 4 정체 (기준 5.0)
+    assert data.adjust_threads == 4
 
-    data.speed_mb = 3.0  # 평균 정확히 1.5 → 감소 아님
-    scaler._adjust_threads()
-    assert scaler.adjust_count == 0
+    _tick(scaler, data, 5.6)  # +12% — 노이즈 범위, 재개하지 않는다
+    assert data.adjust_threads == 4
+
+    _tick(scaler, data, 7.0)  # 기준×1.3(6.5+) 초과 — 재개 신호
+    _tick(scaler, data, 7.0)  # 등반 재개: +4 탐침
+
+    assert data.adjust_threads == 8
 
 
-def test_zero_active_threads_counts_as_slow_tick():
-    """활성 스레드 0이면 평균 0으로 간주되어 감소 방향 틱이다 (병합 꼬리 구간의 동력)."""
+def test_reprobe_after_fifteen_stall_ticks():
+    """정체가 15틱 이어지면 +4 재탐침한다 — 서버 상황 변화를 놓치지 않기 위함."""
     data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
     scaler = _make_scaler(data, logger)
 
-    data.future_count = 0
-    data.speed_mb = 10.0
-    scaler._adjust_threads()
+    _tick(scaler, data, 5.0)  # 4→8
+    _tick(scaler, data, 5.0)  # settle 1
+    _tick(scaler, data, 5.0)  # settle 2
+    _tick(scaler, data, 5.0)  # 되물림 → 4 정체
+    assert data.adjust_threads == 4
 
-    assert scaler.adjust_count == -1
+    for _ in range(15):  # 안정 정체 15틱
+        _tick(scaler, data, 5.0)
+    _tick(scaler, data, 5.0)  # 재탐침 틱
+
+    assert data.adjust_threads == 8
+
+
+def test_zero_active_sample_is_not_a_slow_signal():
+    """관측 순간 활성 0이어도 총 처리량이 신호다 — 구 규칙 붕괴 원인의 반전 박제 (#112).
+
+    구 규칙은 활성 0 표본을 평균 0(저속)으로 간주해, 세그먼트가 잘게 쪼개진
+    저해상도에서 실제 4.7 MB/s로 받는 중에도 4→2→1로 붕괴시켰다.
+    """
+    data, logger = _make_data(), RecordingLogger()
+    data.max_threads = 6996
+    scaler = _make_scaler(data, logger)
+
+    data.future_count = 0  # 빈 슬롯 순간에 관측됐다
+    _tick(scaler, data, 3.9)
+
+    assert data.adjust_threads == 8  # 감소가 아니라 정상 탐침
 
 
 # ================================================================ 속도 계산


### PR DESCRIPTION
## 관련 이슈

Closes #112

## 원인 판정과 근거 (진행 순서 1)

지시대로 구현 전에 코드 분석과 실측으로 (a)~(d)를 가렸다. **판정: (d) + 판단 신호의 구조적 결함(승격된 (c)). (a)·(b)는 반증.**

**(a)·(b) 반증** — hls_aes는 파일 기본값이 아니라 m3u8과 동일한 해상도 테이블을 이미 갖고 있었고, 144p 항목(0.2 MB/s)도 있었다. 코드 확인으로 기각.

**(d) 확정 — 서버 연결당 제한 + 총량 선형.** 지시대로 스레드 수를 고정해 총 처리량을 실측했다 (VOD 13714380, 144p, 각 전송 구간):

| 스레드 (고정) | 전송 소요 | 총 처리량 | 연결당 |
|---|---|---|---|
| main auto (붕괴→1) | 178.5s | 1.48 MB/s | — |
| 4 | 68.7s | 3.85 MB/s | 0.96 |
| 8 | 34.6s | 7.64 MB/s | 0.96 |
| 16 | 17.5s | 15.06 MB/s | 0.94 |
| 32 | 8.9s | 29.57 MB/s | 0.92 |

연결당 ~0.95 MB/s로 제한되고 **총량은 스레드 수에 선형**이다. "스레드당 속도가 낮으면 줄인다"는 이 구간에서 방향이 반대다 — 줄일수록 총량만 떨어진다. 참고: 고정 4스레드의 68.7초는 오너의 과거 기록 65초와 일치한다(과거엔 우연히 붕괴가 안 일어났던 것).

**붕괴 방아쇠 — 순간 활성 수 분모.** 구 규칙의 평균 = `speed_mb / future_count(관측 순간)`이고 **활성 0 순간은 평균 0(저속 틱)으로 판정**됐다. 144p 세그먼트는 ~127KB라 0.1~0.3초에 끝나 관측 시점에 빈 슬롯이 잦다 — 베이스라인 로그 실측: **실제 4.73 MB/s로 받는 중에 4→2로 절반**, 이어 1로 붕괴 후 약 2분 고착(1.1~1.2 MB/s), 1→5→2→1 진동. 1080p는 세그먼트가 커서(수 초/개) 이 오판이 안 일어난다 — 해상도별 차이의 정체다.

## 수정 (진행 순서 2) — 이슈가 제시한 후보 그대로

판단 신호를 **"스레드를 늘렸을 때 총 처리량이 실제로 늘었는가"**로 교체했다 (`base._adjust_threads`, 세 다운로더 공통 한 곳):

- **등반**: 총 처리량이 늘면 +4씩 계속 (보폭·1초 틱은 구 규칙 유지). 인상 유효 판정은 "선형 기대 이득(step/target)의 1/8 이상 실측" — 고정 비율은 목표가 커질수록 선형 이득보다 커져 등반을 막고, 1080p엔 +32%(4→8)·+7%(8→12) 같은 준선형 구간이 실재한다. 미달 등반은 곧 처리량 손실이라 임계를 낮게 두고, 과등반은 상한이 막는다
- **정체**: 인상이 무효면 정확히 되물리고 그 지점이 상한. 조정 직후 2틱은 판단 유예(새 연결 램프업이 측정 오염), 정체 기준은 EMA 평활 + 회복 임계 +30% (실측 노이즈 ±15%로 인한 진동 방지 — 실제로 10% 임계에서는 4↔8 진동이 재현됐다)
- **감소**: 정체 기준의 절반 미만이 5틱 지속(관성은 구 규칙과 동일)일 때만 절반. 하락값이 새 기준이 되어 연쇄 자동 붕괴가 없다. 하한 1 유지
- **재탐침**: 정체 15틱마다 +4 탐침 — 서버 상황 변화 추적
- **상한 48**: 구 규칙에서 실측된 정점 수준. 총량 신호는 스레드당 브레이크가 없어 명시적 상한으로 서버 부하를 묶는다
- 해상도 기준 테이블(`_get_standard_speed`)은 판단에서 빠져 **제거** (base 기본값 + m3u8·hls_aes 오버라이드, 관측 순간 활성 수는 판단에서 제외 — 디버그 로그에만 남음)

## 측정 (진행 순서 5 — #110 Transfer 줄 기준, 같은 VOD 연달아 실행)

**144p (개선 수치):**

| | 궤적 | 전송 소요 |
|---|---|---|
| main | 4→2→1 붕괴, 1→5→2→1 진동 | **178.5s** (1.48 MB/s) |
| 수정 | 4→8→12→…→36 계단 상승 (완주로 종료) | **31.0s** (8.53 MB/s) — **5.8배** |

수정판 다른 회차는 17.2초(서버 상태에 따라 변동)까지 관측됐다. 고정 스레드 실측상 상한(32고정 8.9초)에 근접한다.

**1080p (회귀 금지 — 진행 순서 4):**

| | 궤적 | 60초 누적 평균 |
|---|---|---|
| main | 4→8→…→48 계단, 48 유지 | 5534MB/58.8s = **94.1 MB/s** (연결 48) |
| 수정 | 4→8→12, 이후 8~12 정체(15틱 주기 재탐침) | 5696MB/59.7s = **95.4 MB/s** (연결 8~12) |

**전송 속도 무회귀**(오히려 +1.4%)를 확인했다. 다만 **궤적 모양은 의도적으로 다르다**: 새 규칙은 "이득이 있을 때만" 오르므로, 12스레드 이상이 총량을 늘리지 못하는 이 링크에서는 8~12에서 멈춘다 — 같은 속도를 1/5의 연결로 낸다. 구 궤적(48까지 상승)은 이득 없는 44개 연결을 유지하는 것이었음이 실측으로 드러났다. "궤적 유지"를 문자 그대로가 아니라 "속도 무회귀 + 계단 상승 모양 유지"로 해석했다 — 다르게 판단하시면 알려달라.

## 박제 테스트 (진행 순서 3)

규칙이 바뀌므로 **스케일링 섹션의 박제를 교체**했다 (파일·m3u8 규칙 테스트 각각). 바꾼 것과 이유:

- 제거: 해상도 기준 테이블·평균 속도 대역·활성 0 = 저속 틱 박제 — 위 규명으로 폐기된 규칙
- 신규 박제: 워밍업 무판단 / +4 탐침·계단 / 선형 구간 48 등반(구 1080p 궤적 모양 보존) / min(max_threads, 48) 상한 / 무효 인상 되물림·정체 / 비례 요구치(고정 +10%가 기각하는 40→44 선형 이득을 수용) / 지속 붕괴 절반·하한 1 / 히스테리시스 감쇠 / 회복 재개(+30%) / 15틱 재탐침 / **활성 0 표본은 저속 신호가 아니다(붕괴 원인의 반전 박제)**
- 스케일링 외 섹션(속도 계산·세그먼트/파트 다운로드·재큐잉)의 시나리오·단언은 무수정

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (290 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — 위 박제 교체 목록
- [x] core 순수성 가드(`test_no_qt_import`) 통과
- [x] 실기 검증: 144p 완주 2회·1080p 60초 관찰 2회(수정판)·main 대조 2회 — 모두 실제 치지직 VOD

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — core/downloaders/base.py 중심 변경, UI 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- 상한 48·유효 임계 1/8·회복 +30%·재탐침 15틱은 실측 기반 초기값이다 — 상수로 모아 두었으니(`base.py` 상단) 운영 중 조정이 쉽다.
- 1080p 정체점이 8~12로 낮아진 것은 "같은 속도, 1/5 연결"이라 개선으로 판단했지만, 48 연결 유지가 의도적이었다면(예: 세션 선점) 알려달라 — `_TARGET_CAP`을 낮은 정체점에서도 계속 오르는 규칙으로 바꾸는 건 간단하다.
- 저속 파트 개별 재시도(`slow_count`, 100KB/s 미만 5회 → 재큐잉)는 별개 메커니즘으로 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
