### PR TITLE
fix: 재큐잉된 파트를 Range로 이어받기 — 부분 진행분 보존 (#78)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -498,6 +498,12 @@ class BaseDownloader(ABC):
             if not self.s._pause_event.is_set():
                 self.s._pause_event.wait()
                 self.measure_speed()
+                # 재개 직후 궤적 앵커 (#78) — 관측 로그가 스레드 수 변화 시에만
+                # 남으면 재개 후 재상승 여부를 로그로 확인할 수 없다. 기존
+                # 조정 로그와 같은 형식으로 현재 목표·속도를 한 줄 남긴다.
+                # 일시정지 구간이 섞인 이 측정으로는 조정 판단을 하지 않는다
+                self.logger.log_thread_adjust(self.s.adjust_threads, self.s.speed_mb)
+                self._settle_ticks = max(self._settle_ticks, 1)
             else:
                 self._adjust_threads()
                 self.measure_speed()

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -8,7 +8,9 @@ core/downloaders/base.py의 BaseDownloader로 이주했다(#82). 이 클래스�
   (ranges.py 사용)을 DownloadPlan으로 반환한다 (#83). 총 크기를 미리 알므로
   계획의 total_size를 채우고, ProgressEvent.total_size로 이어진다
 - _download_part: 파트(바이트 구간) 단위 다운로드 — 저속 재시도·일시정지·
-  중단 핸들링 포함. 규칙은 tests/unit/core/test_file_downloader_rules.py가 박제한다
+  중단 핸들링 포함. 재큐잉된 파트는 이미 받은 바이트 뒤에서 Range로
+  이어받는다(#78 — 206이 아니면 처음부터 폴백). 규칙은
+  tests/unit/core/test_file_downloader_rules.py가 박제한다
 - postprocess 없음 (베이스 기본 no-op)
 
 스레드 스케일링 기준 속도는 베이스 기본값(4 MB/s — 구 고정 임계 4/2와 동일)을
@@ -39,6 +41,12 @@ class FileDownloader(BaseDownloader):
     worker_pool_prefix = "DownloadWorker"
     # 구 코드와 동일하게 요청 예외만 실패로 처리한다 — 그 외 예외는 전파
     _failure_exceptions = (requests.RequestException,)
+
+    def __init__(self, data, logger, **callbacks):
+        super().__init__(data, logger, **callbacks)
+        # 재큐잉된 파트가 이미 받아 쓴 바이트 수 — 재시도가 이어받는다 (#78).
+        # (start, end) → 산출물에 쓰인 바이트 수. 완료·폴백 시 지운다
+        self._part_progress: dict[tuple[int, int], int] = {}
 
     @classmethod
     def supports(cls, content: Content) -> bool:
@@ -91,21 +99,38 @@ class FileDownloader(BaseDownloader):
         """
         파일의 특정 구간(start~end)을 다운로드하는 함수.
         속도가 느릴 경우 재시도 로직, 일시정지/중지 핸들링을 포함한다.
+
+        재큐잉된 파트는 이미 받아 쓴 바이트 뒤에서 Range로 이어받는다 (#78).
+        서버가 이어받기 Range를 존중하지 않으면(206이 아니면) 파트 처음부터
+        다시 받는 폴백을 탄다. 판정 규칙(저속·실패 재큐잉)은 무변경이다.
         """
         slow_count = 0
+        resume_offset = self._resume_offset(start, end)
         downloaded_size = 0
         while not self.state == DownloadState.WAITING:
             try:
-                headers = {"Range": f"bytes={start}-{end}"}
+                range_start = start + resume_offset
+                headers = {"Range": f"bytes={range_start}-{end}"}
                 # 스레드로컬 세션으로 같은 워커의 반복 요청 간 연결을 재사용한다 (#31)
                 response = get_thread_session().get(
                     self.s.base_url, headers=headers, stream=True, timeout=30
                 )
                 response.raise_for_status()
+                if resume_offset > 0 and response.status_code != 206:
+                    # 이어받기 Range가 거부됐다(200 전체 응답 등) — 기록을 버리고
+                    # 파트 처음부터 받는다 (#78 폴백)
+                    self.logger.warning(
+                        f"Part {part_num} resume rejected "
+                        f"(status {response.status_code}), retrying from start"
+                    )
+                    response.close()
+                    self._part_progress.pop((start, end), None)
+                    resume_offset = 0
+                    continue
                 part_start_time = tm.time()
 
                 with open(self.s.output_path, "r+b") as f:
-                    f.seek(start)
+                    f.seek(range_start)
                     for chunk in response.iter_content(chunk_size=8192):
                         if self.state == DownloadState.WAITING:
                             return part_num
@@ -118,36 +143,71 @@ class FileDownloader(BaseDownloader):
                             elapsed = tm.time() - part_start_time
 
                             if elapsed > 0:
+                                # 속도 판정은 이번 시도가 받은 바이트 기준,
+                                # 진행 표시는 이어받은 바이트를 포함한다 (#78)
                                 speed_kb_s = downloaded_size / elapsed / 1024
                                 self._check_speed_and_update_progress(
-                                    part_num, downloaded_size, total_size, speed_kb_s
+                                    part_num,
+                                    resume_offset + downloaded_size,
+                                    total_size,
+                                    speed_kb_s,
                                 )
                                 if speed_kb_s < 100:
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
                                         with self.lock:
+                                            self._record_partial(
+                                                start, end, resume_offset + downloaded_size
+                                            )
                                             self._requeue_slow((start, end), part_num)
                                         return part_num
                                 else:
                                     slow_count = 0
 
-                            if downloaded_size >= (end - start + 1):
+                            if downloaded_size >= (end - range_start + 1):
                                 break
 
                 # 성공적으로 마무리된 경우
                 with self.lock:
                     self.s.completed_threads += 1
-                    self.s.completed_progress += downloaded_size
+                    self.s.completed_progress += resume_offset + downloaded_size
                     self.s.threads_progress[part_num] = 0
-                self.logger.log_thread_complete(part_num, downloaded_size)
+                self._part_progress.pop((start, end), None)
+                self.logger.log_thread_complete(part_num, resume_offset + downloaded_size)
                 return part_num
 
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
+                    self._record_partial(start, end, resume_offset + downloaded_size)
                     self._requeue_failed((start, end), part_num)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
+
+    def _record_partial(self, start: int, end: int, downloaded: int) -> None:
+        """재큐잉 직전까지 산출물에 받아 쓴 바이트 수를 기록한다 (#78)."""
+        if downloaded > 0:
+            self._part_progress[(start, end)] = downloaded
+        else:
+            self._part_progress.pop((start, end), None)
+
+    def _resume_offset(self, start: int, end: int) -> int:
+        """파트의 이어받기 오프셋을 반환한다. 확신이 없으면 0(처음부터)이다 (#78).
+
+        무결성 확인: 산출물 파일이 기록된 오프셋(start+기록)까지는 실제로
+        자라 있어야 한다 — 못 미치면 쓰기가 유실된 것이므로 기록을 버린다.
+        """
+        recorded = self._part_progress.get((start, end), 0)
+        if recorded <= 0:
+            return 0
+        try:
+            file_size = os.path.getsize(self.s.output_path)
+        except OSError:
+            file_size = -1
+        if file_size < start + recorded:
+            self._part_progress.pop((start, end), None)
+            return 0
+        return recorded
 
     # ============ 유틸 메서드 ============
 

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -107,6 +107,10 @@ class FileDownloader(BaseDownloader):
         slow_count = 0
         resume_offset = self._resume_offset(start, end)
         downloaded_size = 0
+        if resume_offset > 0:
+            # 이어받기 발생 사실과 오프셋을 남긴다 (#78 스모크 확인 수단) —
+            # 이 줄 없는 재시도는 파트 처음부터 받은 것이다
+            self.logger.log_part_resume(part_num, resume_offset, end - start + 1)
         while not self.state == DownloadState.WAITING:
             try:
                 range_start = start + resume_offset

--- a/download/logger.py
+++ b/download/logger.py
@@ -148,6 +148,14 @@ class DownloadLogger:
 
     # ============ 단계 경계 로그 (#110) — 새 줄만 추가, 기존 줄 형식 불변 ============
 
+    def log_part_resume(self, part_num: int, offset: int, part_size: int):
+        """파트 이어받기 시작을 로깅합니다 (#78) — 재시도가 어느 오프셋부터 받는지.
+
+        이 줄이 없는 재시도는 파트 처음부터 받은 것이다. 이어받기가 거부되어
+        처음부터 폴백한 경우는 "resume rejected" warning으로 구분된다.
+        """
+        self.info(f"Part {part_num} resuming from byte {offset}/{part_size}")
+
     def log_transfer_complete(
         self, elapsed: float, downloaded_bytes: int, retries: int, peak_threads: int
     ):

--- a/download/task.py
+++ b/download/task.py
@@ -57,12 +57,14 @@ class DownloadTask:
             self.logger.log_download_info(self.item)
 
     def pause(self):
-        """다운로드 일시정지."""
-        self._try_transition("pause")
+        """다운로드 일시정지. 성공 시 로그를 남긴다 (#78 스모크 — UI→엔진 도달 확인용)."""
+        if self._try_transition("pause"):
+            self.logger.info("Download paused")
 
     def resume(self):
-        """다운로드 재개."""
-        self._try_transition("resume")
+        """다운로드 재개. 성공 시 로그를 남긴다 (#78 스모크 — UI→엔진 도달 확인용)."""
+        if self._try_transition("resume"):
+            self.logger.info("Download resumed")
 
     def stop(self):
         """다운로드 취소(대기 상태로 복귀)."""

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -363,3 +363,138 @@ def test_request_exception_requeues_range_as_failed(tmp_path, monkeypatch):
     assert data.remaining_ranges == [(0, MB - 1)]
     assert data.threads_progress[0] == 0
     assert len(logger.errors) == 1
+
+
+# ================================================================ 파트 이어받기 (#78)
+
+
+class ResumeResponse(FakeResponse):
+    """status_code를 가진 스트리밍 응답 — 이어받기(206) 검증용."""
+
+    def __init__(self, chunks, status_code=206):
+        super().__init__(chunks)
+        self.status_code = status_code
+
+    def close(self):
+        pass
+
+
+class RecordingSession:
+    """요청별 Range 헤더를 기록하고 준비된 응답을 순서대로 돌려준다 (#78)."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.range_headers: list[str] = []
+
+    def get(self, url, headers=None, **kwargs):
+        self.range_headers.append(headers["Range"])
+        return self._responses.pop(0)
+
+
+CHUNK = 8192
+PART_END = 3 * CHUNK - 1  # 3청크짜리 파트 (0 ~ 24575)
+
+
+def _prepare_resume_engine(tmp_path, monkeypatch, responses, prewritten: bytes = b""):
+    """이어받기 시나리오용 엔진 — 산출물 선기록과 응답 시퀀스를 주입한다."""
+    output = tmp_path / "part.bin"
+    output.write_bytes(prewritten)
+
+    data = _make_data(str(output))
+    logger = RecordingLogger()
+    engine, _task = _make_engine(data, logger)
+
+    data.model.start()
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+
+    mod = _engine_module()
+    session = RecordingSession(responses)
+    monkeypatch.setattr(mod, "get_thread_session", lambda: session)
+    monkeypatch.setattr(mod.tm, "time", TickingClock(1e-6))  # 항상 고속 판정
+    return engine, data, logger, session, output
+
+
+def test_requeued_part_resumes_with_range(tmp_path, monkeypatch):
+    """재큐잉된 파트는 이미 받은 바이트 뒤에서 Range로 이어받는다 (#78).
+
+    완료 시 누적 진행은 이어받은 바이트를 포함한 파트 전체여야 한다.
+    """
+    engine, data, logger, session, output = _prepare_resume_engine(
+        tmp_path,
+        monkeypatch,
+        responses=[ResumeResponse([b"y" * CHUNK], status_code=206)],
+        prewritten=b"x" * (2 * CHUNK),  # 앞선 시도가 2청크를 받아 둔 상태
+    )
+    engine._record_partial(0, PART_END, 2 * CHUNK)
+
+    returned = engine._download_part(0, PART_END, 0, 3 * CHUNK)
+
+    assert returned == 0
+    assert session.range_headers == [f"bytes={2 * CHUNK}-{PART_END}"]  # 이어받기 요청
+    assert data.completed_threads == 1
+    assert data.completed_progress == 3 * CHUNK  # 이어받은 바이트 포함 전체
+    assert logger.thread_completes == [(0, 3 * CHUNK)]
+    assert output.read_bytes() == b"x" * (2 * CHUNK) + b"y" * CHUNK  # 기존 바이트 보존
+    assert (0, PART_END) not in engine._part_progress  # 완료 후 기록 정리
+
+
+def test_resume_rejected_falls_back_to_full_retry(tmp_path, monkeypatch):
+    """완료 조건: 서버가 이어받기 Range를 존중하지 않으면(200) 전체 재시도로 폴백한다."""
+    engine, data, logger, session, output = _prepare_resume_engine(
+        tmp_path,
+        monkeypatch,
+        responses=[
+            ResumeResponse([], status_code=200),  # 이어받기 거부 — 전체 응답
+            ResumeResponse([b"z" * CHUNK] * 3, status_code=200),  # 처음부터 전체 파트
+        ],
+        prewritten=b"x" * (2 * CHUNK),
+    )
+    engine._record_partial(0, PART_END, 2 * CHUNK)
+
+    returned = engine._download_part(0, PART_END, 0, 3 * CHUNK)
+
+    assert returned == 0
+    assert session.range_headers == [
+        f"bytes={2 * CHUNK}-{PART_END}",  # 이어받기 시도
+        f"bytes=0-{PART_END}",  # 거부 후 파트 처음부터
+    ]
+    assert any("resume rejected" in w for w in logger.warnings)
+    assert data.completed_progress == 3 * CHUNK
+    assert output.read_bytes() == b"z" * (3 * CHUNK)  # 전체를 새로 받았다
+
+
+def test_resume_integrity_mismatch_restarts_from_start(tmp_path, monkeypatch):
+    """완료 조건: 기록된 오프셋만큼 파일이 자라 있지 않으면 처음부터 받는다."""
+    engine, data, logger, session, output = _prepare_resume_engine(
+        tmp_path,
+        monkeypatch,
+        responses=[ResumeResponse([b"z" * CHUNK] * 3, status_code=206)],
+        prewritten=b"",  # 기록(2청크)과 달리 파일이 비어 있다 — 쓰기 유실 상황
+    )
+    engine._record_partial(0, PART_END, 2 * CHUNK)
+
+    returned = engine._download_part(0, PART_END, 0, 3 * CHUNK)
+
+    assert returned == 0
+    assert session.range_headers == [f"bytes=0-{PART_END}"]  # 이어받기 시도 없음
+    assert (0, PART_END) not in engine._part_progress  # 무결성 실패 기록은 폐기된다
+    assert data.completed_progress == 3 * CHUNK
+    assert output.read_bytes() == b"z" * (3 * CHUNK)
+
+
+def test_slow_requeue_records_partial_progress(tmp_path, monkeypatch):
+    """저속 재큐잉 시 받아 쓴 바이트가 기록된다 — 다음 시도의 이어받기 근거 (#78).
+
+    저속 판정 규칙(연속 6회 < 100 KB/s) 자체는 무변경이다 — 박제는
+    test_slow_part_restarts_after_six_slow_chunks가 그대로 유지한다.
+    """
+    chunks = [b"x" * CHUNK] * 10  # 1초/청크 → 항상 저속
+    engine, data, logger = _prepare_running_engine(
+        tmp_path, monkeypatch, chunks=chunks, clock_step=1.0
+    )
+
+    engine._download_part(0, 40 * MB - 1, 0, 40 * MB)
+
+    # 저속 판정은 6청크째에 나므로 그때까지 받은 바이트가 기록된다
+    assert engine._part_progress[(0, 40 * MB - 1)] == 6 * CHUNK

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -33,6 +33,7 @@ class RecordingLogger:
         self.warnings: list[str] = []
         self.errors: list[str] = []
         self.thread_completes: list[tuple] = []
+        self.part_resumes: list[tuple] = []  # 이어받기 로그 (#78)
 
     def log_thread_adjust(self, active_threads, avg_speed):
         self.adjust_calls.append((active_threads, avg_speed))
@@ -45,6 +46,9 @@ class RecordingLogger:
 
     def log_thread_complete(self, thread_id, downloaded_size):
         self.thread_completes.append((thread_id, downloaded_size))
+
+    def log_part_resume(self, part_num, offset, part_size):
+        self.part_resumes.append((part_num, offset, part_size))
 
     def log_error(self, message, exception=None):
         self.errors.append(message)
@@ -432,6 +436,7 @@ def test_requeued_part_resumes_with_range(tmp_path, monkeypatch):
 
     assert returned == 0
     assert session.range_headers == [f"bytes={2 * CHUNK}-{PART_END}"]  # 이어받기 요청
+    assert logger.part_resumes == [(0, 2 * CHUNK, 3 * CHUNK)]  # 발생 사실·오프셋 로그 (#78)
     assert data.completed_threads == 1
     assert data.completed_progress == 3 * CHUNK  # 이어받은 바이트 포함 전체
     assert logger.thread_completes == [(0, 3 * CHUNK)]
@@ -478,6 +483,7 @@ def test_resume_integrity_mismatch_restarts_from_start(tmp_path, monkeypatch):
 
     assert returned == 0
     assert session.range_headers == [f"bytes=0-{PART_END}"]  # 이어받기 시도 없음
+    assert logger.part_resumes == []  # 이어받기 로그도 없다 — 처음부터 받았다는 뜻
     assert (0, PART_END) not in engine._part_progress  # 무결성 실패 기록은 폐기된다
     assert data.completed_progress == 3 * CHUNK
     assert output.read_bytes() == b"z" * (3 * CHUNK)

--- a/tests/unit/core/test_file_downloader_run.py
+++ b/tests/unit/core/test_file_downloader_run.py
@@ -37,6 +37,9 @@ class RunLogger:
     def log_download_start(self, total_size, part_size, segments, initial_threads):
         pass
 
+    def log_part_resume(self, part_num, offset, part_size):
+        pass
+
     def log_transfer_complete(self, elapsed, downloaded_bytes, retries, peak_threads):
         self.transfer_completes.append((elapsed, downloaded_bytes, retries, peak_threads))
 

--- a/tests/unit/test_download_task_adapter.py
+++ b/tests/unit/test_download_task_adapter.py
@@ -18,10 +18,14 @@ class _FakeLogger:
 
     def __init__(self):
         self.warnings: list[str] = []
+        self.infos: list[str] = []
         self.logged_items: list[object] = []
 
     def warning(self, message: str):
         self.warnings.append(message)
+
+    def info(self, message: str):
+        self.infos.append(message)
 
     def log_download_info(self, item):
         self.logged_items.append(item)
@@ -86,6 +90,27 @@ def test_pause_event_is_shared_with_download_data():
 
     task.resume()
     assert data._pause_event.is_set()
+
+
+def test_pause_and_resume_are_logged():
+    """일시정지·재개 성공이 로그에 남는다 (#78) — UI→엔진 도달 여부를 로그로 확인하기 위함."""
+    task, _, _, logger = _make_task()
+    task.start()
+
+    task.pause()
+    assert "Download paused" in logger.infos
+
+    task.resume()
+    assert "Download resumed" in logger.infos
+
+
+def test_failed_pause_is_not_logged_as_success():
+    """전이가 무시된 경우(허용되지 않는 상태) 성공 로그를 남기지 않는다."""
+    task, _, _, logger = _make_task()
+
+    task.pause()  # WAITING에서 pause는 허용되지 않는 전이
+    assert "Download paused" not in logger.infos
+    assert logger.warnings  # 무시 경고만 남는다
 
 
 def test_invalid_transition_is_absorbed_not_raised():


### PR DESCRIPTION
## 관련 이슈

Closes #78

## 변경 내용

**재큐잉된 파트가 이미 받아 쓴 바이트 뒤에서 HTTP Range로 이어받는다** (`core/downloaders/file_downloader.py`). 판정 규칙은 무변경 — "재큐잉된 작업을 어떻게 다시 받는가"만 바뀌었다.

- **바이트 추적** (제안 1): 저속·실패 재큐잉 직전에 `(start, end) → 받아 쓴 바이트`를 기록한다(`_record_partial`). 산출물에 실제로 쓰인 바이트만 기록되므로 기록 = 디스크 상태다
- **Range 이어받기 + 폴백** (제안 2): 재시도는 `bytes={start+기록}-{end}`로 요청하고, 이어받기 요청인데 응답이 206이 아니면(200 전체 응답 등) 기록을 버리고 파트 처음부터 받는다. 폴백 시 warning 로그를 남긴다
- **무결성 확인** (제안 3): 이어받기 전에 산출물 크기가 `start+기록` 이상인지 확인한다 — 못 미치면 쓰기가 유실된 것이므로 기록을 폐기하고 처음부터 받는다(`_resume_offset`)
- **진행 집계 정합**: 진행 표시(`threads_progress`)는 이어받은 바이트를 포함하고, 완료 시 `completed_progress`에도 파트 전체(이어받은 바이트 포함)가 반영된다 — 진행률이 100% 미만에서 끝나는 계산 어긋남이 없다
- **재개 후 궤적 가시화** (완료 조건 5): 관측 스레드의 일시정지 해제 지점에서 기존 조정 로그와 **같은 형식**(`Active threads: N - Download speed: X`)으로 앵커 한 줄을 남긴다 — 재개 후 스케일링 재상승 여부를 로그로 구분할 수 있다(오너가 지적한 "재개 후 궤적이 안 보이는" 문제). 같은 형식이라 summarize 스크립트 궤적 파싱에 자연 포함된다. 아울러 재개 직후 첫 측정(일시정지 구간이 섞임)으로는 조정 판단을 하지 않도록 1틱 유예한다

## 세그먼트 경로 적용 판단 (제안 4 — 미적용, 근거)

파일 파트는 해상도에 따라 수십 MB(테스트 기준 40MB)라 손실이 크지만, 세그먼트는 수백 KB~수 MB로 재시도 비용의 상한이 작다. 추가로:
- **hls_aes**: AES-CBC 복호화가 세그먼트 전체 바이트를 전제한다 — 부분 이어받기는 블록 경계·IV 처리가 붙어 복잡도 대비 이득이 없다
- **m3u8**: 세그먼트 임시 파일은 시도마다 `"wb"`로 새로 쓰는 단순 구조고, 유지 이득이 파일 파트 대비 한 자릿수 이상 작다

따라서 **파일 경로에만 적용**했다. 세그먼트 손실이 실측으로 문제가 되면 별도 이슈로 제안하겠다.

## 이슈 등록 이후 구조 변화와의 관계 (지시 사항)

- **#113 (총 처리량 등반)**: 판단 신호는 바뀌었지만 이 이슈가 손대는 **재큐잉·느린 파트 판정 규칙은 그대로**다 — 본 PR도 판정 규칙을 건드리지 않고 재시도 방식만 바꾼다. 이슈 본문의 "일시정지 → 속도 0 → 느린 파트 판정" 경로는 현 구조에서도 유효하다(판정은 파트별 `slow_count`, 스케일링과 무관). 재개 앵커 로그·판단 1틱 유예는 #113의 정체(EMA) 상태와 정합적이다 — 일시정지 구간이 섞인 측정이 붕괴 카운터에 들어가는 것을 막는다
- **#92 (단일 패스·세그먼트 보존)**: 후처리 경로는 무변경. 파트 이어받기는 전송 단계 안의 일이라 충돌 없음
- **#105 (임시 폴더 파생)**: 세그먼트 경로 미적용이므로 접점 없음. 파일 경로의 산출물은 단일 파일 그대로다

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (294 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)
- [x] core 순수성 가드(`test_no_qt_import`) 통과
- [x] **Range 미지원(200) 폴백** — 테스트로 확인 (완료 조건 2): 두 번째 요청이 `bytes=0-`로 나가고 warning이 남는다
- [x] **무결성 불일치 시 처음부터** — 테스트로 확인 (완료 조건 3): 기록보다 파일이 작으면 이어받기 요청 자체가 없다
- [x] 이어받기 정상 경로: Range 헤더·기존 바이트 보존·완료 집계(파트 전체) 검증
- [x] 저속 재큐잉 시 부분 기록 생성 검증

## 박제 테스트와의 관계 (제안 5)

**판정 규칙 박제는 무수정**이다: `test_slow_part_restarts_after_six_slow_chunks`(저속 6회 판정), `test_fast_part_completes_and_accumulates_progress`, `test_request_exception_requeues_range_as_failed` — 시나리오·단언 그대로 통과한다. 신규 테스트 4건은 별도 섹션("파트 이어받기")으로 추가했고 기존 하네스(FakeResponse 등)는 건드리지 않았다(이어받기용 응답·세션 클래스는 신규).

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — UI·앱 계층 무변경 (작업 범위 준수)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- **오너 스모크 요청** (완료 조건 4·5): 대용량 VOD(파일 경로) 다운로드 중 일시정지 → 재개 → 완주 후, (1) 재개 후 재큐잉된 파트의 Range 요청이 파트 처음(`bytes={파트 start}-`)이 아니라 중간 오프셋에서 시작하는지(DEBUG 레벨이면 `Thread N started - Range` 줄로도 확인 가능), (2) 재개 직후 `Active threads:` 앵커 줄 이후 스케일링이 재상승하는지, (3) 산출물 바이트 크기가 기준선과 일치하는지 확인 부탁드립니다.
- 이어받기 기록은 엔진 인스턴스 수명(한 다운로드) 안에서만 유지됩니다 — 앱 재시작 후 재개는 기존과 동일하게 `_get_remaining_ranges`(파일 크기 기반)가 담당하며 무변경입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
