### PR TITLE
fix: 빌드된 exe에서 app_version이 unknown으로 기록됨 (#116)

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,5 +1,4 @@
 import functools
-import importlib.metadata
 import json
 import logging
 import os
@@ -9,28 +8,34 @@ from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
+# pyproject.toml [project].version의 미러 상수 (#116). **정본은 pyproject.toml이다.**
+# Nuitka 번들에는 pyproject.toml도 배포 메타데이터(dist-info)도 포함되지 않아
+# 빌드 실행 파일은 이 상수를 쓴다. 정본과의 불일치는 단위 테스트
+# (tests/unit/test_download_log_phases.py)가 잡는다 — 버전을 올릴 때는
+# pyproject.toml과 이 상수를 함께 갱신할 것.
+APP_VERSION = "2.9.0-rc2"
+
 
 @functools.lru_cache(maxsize=1)
 def get_app_version() -> str:
     """앱 버전 문자열을 반환한다 (#110 — 다운로드 로그 시작 정보용).
 
     정본은 릴리즈 검증(CI)과 동일하게 pyproject.toml의 [project].version이다.
-    다만 CI의 tomllib 원라이너는 소스 트리 전제라 Nuitka 빌드 실행 파일에는
-    pyproject.toml이 없어 그대로 재사용할 수 없다 — 설치 메타데이터
-    (importlib.metadata, 소스·빌드 양쪽에서 동작)를 우선하고, 소스 실행
-    폴백으로 pyproject.toml을 직접 읽는다. 둘 다 실패하면 "unknown"으로
-    로깅을 막지 않는다.
+    소스 실행은 pyproject를 직접 읽어 정본 문자열 그대로 돌려주고, 파일이
+    없는 빌드 실행(Nuitka onefile)은 미러 상수(APP_VERSION)를 쓴다 (#116).
+
+    구 구현이 우선하던 importlib.metadata는 쓰지 않는다 — Nuitka 번들에
+    dist-info가 없어 빌드에서 실패했고(#116의 원인 절반), 소스에서도 버전을
+    정규화(2.9.0-rc1 → 2.9.0rc1)해 정본 문자열과 어긋났다.
     """
-    try:
-        return importlib.metadata.version("cvdv2")
-    except importlib.metadata.PackageNotFoundError:
-        pass
-    pyproject = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pyproject.toml")
+    pyproject = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pyproject.toml"
+    )
     try:
         with open(pyproject, "rb") as f:
             return tomllib.load(f)["project"]["version"]
     except (OSError, KeyError, tomllib.TOMLDecodeError):
-        return "unknown"
+        return APP_VERSION
 
 # 설정 파일 경로 (AppData 디렉토리에 저장)
 APP_NAME = "chzzk-vod-downloader-v2"

--- a/tests/unit/test_download_log_phases.py
+++ b/tests/unit/test_download_log_phases.py
@@ -5,7 +5,6 @@
 새 줄의 메시지 형식과 요약 스크립트 패턴이 어긋나면 여기서 잡힌다.
 """
 
-import re
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -36,20 +35,31 @@ def _stub_item() -> SimpleNamespace:
     )
 
 
-def test_get_app_version_is_available():
-    """소스 실행에서 앱 버전이 해석된다 — pyproject 정본과 같은 버전 계열이어야 한다.
-
-    importlib.metadata는 버전을 정규화하므로(예: 2.9.0-rc1 → 2.9.0rc1)
-    문자열 완전 일치가 아니라 "기본 버전(major.minor.patch) 일치"로 비교한다.
-    """
+def _pyproject_version() -> str:
+    """정본(pyproject.toml)의 버전 문자열."""
     root = Path(config_module.__file__).resolve().parent.parent
     with open(root / "pyproject.toml", "rb") as f:
-        expected = tomllib.load(f)["project"]["version"]
+        return tomllib.load(f)["project"]["version"]
 
-    version = config_module.get_app_version()
-    assert version != "unknown"
-    base = re.match(r"\d+\.\d+\.\d+", version)
-    assert base and expected.startswith(base.group(0))
+
+def test_get_app_version_matches_pyproject_exactly():
+    """소스 실행의 앱 버전은 정본(pyproject) 문자열과 정확히 일치한다 (#116).
+
+    구 구현의 importlib.metadata는 버전을 정규화해(2.9.0-rc1 → 2.9.0rc1)
+    정본과 어긋났다 — 이제 pyproject 직접 읽기라 완전 일치를 요구한다.
+    """
+    config_module.get_app_version.cache_clear()
+    assert config_module.get_app_version() == _pyproject_version()
+
+
+def test_version_mirror_constant_matches_pyproject():
+    """미러 상수(APP_VERSION)는 정본(pyproject)과 정확히 일치해야 한다 (#116).
+
+    Nuitka 빌드 실행 파일에는 pyproject.toml이 없어 이 상수가 쓰인다.
+    이 테스트가 실패하면 버전 인상 시 config/config.py의 APP_VERSION을
+    함께 갱신하지 않은 것이다 — 배포 빌드가 다시 틀린 버전을 기록하게 된다.
+    """
+    assert config_module.APP_VERSION == _pyproject_version()
 
 
 def test_phase_lines_parse_and_old_lines_still_parse(tmp_path, monkeypatch):


### PR DESCRIPTION
## 관련 이슈

Closes #116

## 원인 확인

이슈의 추정 그대로임을 실측으로 확정했다. 미니 Nuitka standalone 번들(`config` 패키지 포함)을 만들어 내부를 검사한 결과:

- 번들에 `cvdv2` **dist-info 없음** → `importlib.metadata.version("cvdv2")`가 `PackageNotFoundError`
- 번들에 **pyproject.toml 없음** → 폴백도 실패
- → 최종 `"unknown"`

추가 문제 하나: importlib.metadata 경로는 소스 실행에서도 버전을 **정규화**해(`2.9.0-rc1` → `2.9.0rc1`) 정본 문자열과 어긋난 값을 기록하고 있었다(rc1 시절 소스 실행 로그의 `app_version: 2.9.0rc1`이 그 흔적).

## 변경 내용

**pyproject 직접 읽기 + 미러 상수 폴백** (`config/config.py`):

- 소스 실행: pyproject.toml을 직접 읽어 **정본 문자열 그대로** 반환 (정규화 없음)
- 빌드 실행(파일 없음): 미러 상수 `APP_VERSION` 반환
- importlib.metadata 경로는 제거 — 빌드에서 실패하고 소스에서 정본과 어긋나 양쪽 다 결함이었다

**정본은 여전히 pyproject.toml이다.** 미러 상수의 불일치는 신규 단위 테스트(`test_version_mirror_constant_matches_pyproject`)가 정확 일치로 강제한다 — 어긋난 채로는 CI가 통과하지 못한다.

## 방식 판단 근거 (이슈 요구)

- **배포 메타데이터 포함 옵션**(`--include-distribution-metadata`)이나 **pyproject 데이터 파일 동봉**(`--include-data-files`)은 release.yml 수정이 필요하다 — `.github/`은 금지 구역이라 이 PR에서 손댈 수 없고, 워크플로우가 바뀌기 전까지 exe가 계속 unknown으로 남는다. 미러 상수는 **코드만으로 즉시 해결**되고 플랫폼·빌드 방식과 무관하게 동작한다
- 비용은 버전 인상 시 두 곳(pyproject + 상수) 갱신이다. 가드 테스트가 누락을 막지만, 마찰을 없애려면 **Version Bump 워크플로우의 bump 스크립트에 상수 갱신을 추가**하는 것이 좋다(금지 구역 — 소유자 몫). bump 단계의 파이썬 스크립트에 아래를 덧붙이면 된다:

```python
# config/config.py의 APP_VERSION 미러도 함께 갱신 (#116)
c = pathlib.Path("config/config.py")
ctext = c.read_text(encoding="utf-8")
cnew, cn = re.subn(r'(?m)^(APP_VERSION\s*=\s*")[^"]*(")', lambda m: m.group(1) + version + m.group(2), ctext, count=1)
if cn != 1:
    raise SystemExit("config/config.py에서 APP_VERSION 줄을 찾지 못했습니다.")
c.write_text(cnew, encoding="utf-8")
```
(커밋 대상에 `config/config.py` 추가도 필요: `git add pyproject.toml uv.lock config/config.py`)

## 검증 (완료 조건)

- [x] **빌드 산출물에서 버전 정확** — 미니 Nuitka standalone 프로브(`config` 포함, pyproject·dist-info 미포함 확인)를 빌드해 실행: `app_version=2.9.0-rc2` 출력 확인. 본 앱 exe와 동일한 조건(번들에 두 소스 모두 부재)이다
- [x] **소스 실행에서 버전 정확** — `test_get_app_version_matches_pyproject_exactly`가 정본 문자열 완전 일치를 단언 (구 구현은 정규화로 이 테스트를 통과하지 못한다)
- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (297 passed, 2 skipped — 스킵은 기존과 동일. Windows 로컬 실행이라 xvfb 미사용)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — config(앱 계층)만 변경
- [x] view에서 core 직접 호출 없음 (viewmodel 경유) — UI 무변경
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: 해당 없음

## 리뷰어에게

- rc2 → rc3 인상 시 이 브랜치 머지 후라면 `APP_VERSION`도 함께 올려야 합니다(테스트가 잊음을 잡아줍니다). 위의 Version Bump 워크플로우 보강을 적용하시면 이후 자동입니다.
- 다음 태그 릴리즈 후 exe 로그 첫 줄이 `app_version: <태그 버전>`으로 나오는지 한 번만 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
