### PR TITLE
chore: 릴리즈 노트 정비

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+    labels:
+      - chore
+      - documentation
+  categories:
+    - title: 버그 수정
+      labels:
+        - bug
+    - title: 개선
+      labels:
+        - improvement
+    - title: 그 밖
+      labels:
+        - "*"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,6 +23,8 @@ jobs:
           token: ${{ secrets.RELEASE_PAT }}
 
       - name: Create tag if version is new
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           VERSION=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "pyproject version: $VERSION"
@@ -31,6 +33,22 @@ jobs:
             echo "태그 v$VERSION 이미 존재 — 건너뜁니다."
             exit 0
           fi
+
+          # ── 추가: 정식 버전이면 같은 버전의 프리릴리즈를 먼저 정리 ──
+          case "$VERSION" in
+            *-*)
+              echo "프리릴리즈($VERSION) — 정리 건너뜀"
+              ;;
+            *)
+              for tag in $(git tag -l "v${VERSION}-*"); do
+                echo "프리릴리즈 정리: $tag"
+                gh release delete "$tag" --yes --cleanup-tag 2>/dev/null \
+                  || git push origin ":refs/tags/$tag"
+                git tag -d "$tag" >/dev/null 2>&1 || true
+              done
+              ;;
+          esac
+          # ────────────────────────────────────────────────
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,10 +238,31 @@ jobs:
             echo 'VTEOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="${{ github.ref_name }}" --jq '.body')
+          {
+            echo 'body<<NOTESEOF'
+            echo '<details>'
+            echo '<summary>전체 변경 목록</summary>'
+            echo ''
+            echo "$NOTES"
+            echo ''
+            echo '</details>'
+            echo 'NOTESEOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          body: ${{ steps.vtmd.outputs.body }}
-          generate_release_notes: true
+          body: |
+            ${{ steps.vtmd.outputs.body }}
+
+            ${{ steps.notes.outputs.body }}
+          generate_release_notes: false
           prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
자동 생성 목록을 라벨 기준으로 분류하고 <details>로 접는다. 정식 태그 시 같은 버전의 프리릴리즈 태그·릴리즈를 자동 정리한다.