### PR TITLE
fix: 조회 HTTP 요청에 connect/read 타임아웃 설정 — 네트워크 단절 시 5초 내 포기

### DIFF
--- a/content/network.py
+++ b/content/network.py
@@ -16,6 +16,13 @@ NAVER_API = "https://apis.naver.com"
 CHZZK_API = "https://api.chzzk.naver.com"
 VIDEOHUB_API = "https://api-videohub.naver.com"
 
+# 조회(메타데이터·매니페스트) 요청 공통 타임아웃 (#129).
+# 타임아웃이 없으면 네트워크 단절 시 OS TCP 타임아웃(관측 ~47초, 환경 따라 더 김)까지
+# 조회가 갇힌다. connect 5초: 정상 연결은 1초 미만이라 여유가 충분하고 OS SYN
+# 재시도보다 먼저 끊는다. read 15초: 응답이 작은 JSON/XML이라 평시 1초 미만 —
+# 느린 회선·서버 지연에 여유를 두되 OS 타임아웃보다 훨씬 먼저 포기한다.
+REQUEST_TIMEOUT = (5, 15)
+
 
 class NetworkManager:
 
@@ -50,7 +57,7 @@ class NetworkManager:
         """
         api_url = f"{CHZZK_API}/service/v2/videos/{video_no}"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = _session.get(api_url, cookies=cookies, headers=headers)
+        response = _session.get(api_url, cookies=cookies, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         content = response.json().get('content', {})
@@ -84,7 +91,7 @@ class NetworkManager:
         """
         manifest_url = f"{NAVER_API}/neonplayer/vodplay/v2/playback/{video_id}?key={in_key}"
         headers = {"Accept": "application/dash+xml"}
-        response = _session.get(manifest_url, cookies=cookies, headers=headers)
+        response = _session.get(manifest_url, cookies=cookies, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         return parse_dash_manifest(response.text)
@@ -100,7 +107,7 @@ class NetworkManager:
         """
         manifest_url = f"{NAVER_API}/neonplayer/vodplay/v2/playback/{video_id}?key={in_key}"
         headers = {"Accept": "application/dash+xml"}
-        response = _session.get(manifest_url, cookies=cookies, headers=headers)
+        response = _session.get(manifest_url, cookies=cookies, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         if not is_supported_sea(response.text):
@@ -153,7 +160,7 @@ class NetworkManager:
         data = json.loads(json_str)
         media = data.get("media", [])
         path = media[0].get("path")
-        response = _session.get(path, cookies=cookies)
+        response = _session.get(path, cookies=cookies, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
         content = response.text.splitlines()
 
@@ -176,7 +183,7 @@ class NetworkManager:
         """
         api_url = f"{CHZZK_API}/service/v1/clips/{clip_no}/detail?optionalProperties=OWNER_CHANNEL"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = _session.get(api_url, cookies=cookies, headers=headers)
+        response = _session.get(api_url, cookies=cookies, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         content = response.json().get('content', {})
@@ -201,7 +208,7 @@ class NetworkManager:
         """
         manifest_url = f"{VIDEOHUB_API}/shortformhub/feeds/v3/card?serviceType=CHZZK&seedMediaId={clip_id}&mediaType=VOD"
         headers = {"User-Agent": "Mozilla/5.0"}
-        response = _session.get(manifest_url, cookies=cookies, headers=headers)
+        response = _session.get(manifest_url, cookies=cookies, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         data = response.json()

--- a/content/widget.py
+++ b/content/widget.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import QWidget, QPushButton, QMessageBox
 from PySide6.QtGui import QPixmap, QDesktopServices
 from PySide6.QtCore import Qt, QSize, Signal, QUrl, QDir, QProcess
 from content.data import ContentItem
-from content.network import get_thread_session
+from content.network import REQUEST_TIMEOUT, get_thread_session
 from download.state import DownloadState
 from ui.contentItemWidget import Ui_ContentItemWidget
 from time import strftime, gmtime
@@ -84,11 +84,11 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         def update_button_text():
             try:
                 if not self.item.is_segment_based:
-                    resp = get_thread_session().head(base_url)
+                    resp = get_thread_session().head(base_url, timeout=REQUEST_TIMEOUT)
                     resp.raise_for_status()
                     size = int(resp.headers.get('content-length', 0))
                     if size == 0:
-                        resp = get_thread_session().get(base_url, stream=True)
+                        resp = get_thread_session().get(base_url, stream=True, timeout=REQUEST_TIMEOUT)
                         resp.raise_for_status()
                         size = int(resp.headers.get('content-length', 0))
                         resp.close()
@@ -133,7 +133,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
 
     def fetchImage(self, label, url, maxHeight, type):
         try:
-            response = get_thread_session().get(url)
+            response = get_thread_session().get(url, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
             image = QPixmap()
             image.loadFromData(response.content)

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -10,7 +10,7 @@ import json
 import pytest
 
 import content.network as network
-from content.network import NetworkManager
+from content.network import REQUEST_TIMEOUT, NetworkManager
 from core.api.dash import parse_dash_manifest
 from core.api.url_parser import extract_content_no
 from tests.mocks.mock_http import MockResponse
@@ -102,7 +102,11 @@ class TestGetVideoDashManifest:
             (
                 "https://apis.naver.com/neonplayer/vodplay/v2/playback/test-video-id"
                 "?key=test-in-key",
-                {"cookies": cookies, "headers": {"Accept": "application/dash+xml"}},
+                {
+                    "cookies": cookies,
+                    "headers": {"Accept": "application/dash+xml"},
+                    "timeout": REQUEST_TIMEOUT,  # 조회 갇힘 방지 (#129)
+                },
             )
         ]
         # 반환값은 core 파서에 응답 본문을 그대로 넘긴 결과와 일치해야 한다
@@ -151,7 +155,11 @@ class TestGetVideoInfo:
         assert calls == [
             (
                 "https://api.chzzk.naver.com/service/v2/videos/13714380",
-                {"cookies": cookies, "headers": {"User-Agent": "Mozilla/5.0"}},
+                {
+                    "cookies": cookies,
+                    "headers": {"User-Agent": "Mozilla/5.0"},
+                    "timeout": REQUEST_TIMEOUT,  # 조회 갇힘 방지 (#129)
+                },
             )
         ]
         # 반환은 tuple이 아닌 VideoInfo 필드 접근 (#61). 기대값 자체는 무변경.
@@ -205,6 +213,9 @@ class TestGetVideoM3u8BaseUrl:
         base_url = NetworkManager.get_video_m3u8_base_url(json_str, 1080, cookies)
 
         assert calls == [
-            ("https://example.invalid/master.m3u8", {"cookies": cookies})
+            (
+                "https://example.invalid/master.m3u8",
+                {"cookies": cookies, "timeout": REQUEST_TIMEOUT},  # 조회 갇힘 방지 (#129)
+            )
         ]
         assert base_url == "https://example.invalid/1080/playlist.m3u8"

--- a/tests/unit/test_network_timeouts.py
+++ b/tests/unit/test_network_timeouts.py
@@ -1,0 +1,125 @@
+"""NetworkManager 조회 요청의 타임아웃 검증 (#129).
+
+타임아웃이 없으면 네트워크 단절 시 OS TCP 타임아웃(~47초+)까지 조회가 갇힌다.
+모든 조회 호출이 REQUEST_TIMEOUT(connect·read)을 싣는지 가짜 세션으로 확인한다.
+다운로드 경로(세그먼트·파트)는 기존 timeout=30이 이미 있어 이 테스트 범위 밖.
+"""
+
+import json
+
+import pytest
+
+import content.network as network
+from content.network import NetworkManager, REQUEST_TIMEOUT
+from tests.mocks.mock_http import MockResponse
+
+COOKIES = {"NID_AUT": "REDACTED", "NID_SES": "REDACTED"}
+
+
+class RecordingSession:
+    """호출 kwargs를 기록하고 준비된 응답을 돌려주는 가짜 세션."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self._response
+
+
+class BytesResponse(MockResponse):
+    """content 바이트가 필요한 호출(get_aes_key)용 응답."""
+
+    def __init__(self, content: bytes = b"key", status_code: int = 200):
+        super().__init__(status_code=status_code)
+        self.content = content
+
+
+def _install(monkeypatch, response):
+    session = RecordingSession(response)
+    monkeypatch.setattr(network, "_session", session)
+    return session
+
+
+M3U8_PLAYLIST = "\n".join(
+    [
+        "#EXTM3U",
+        '#EXT-X-STREAM-INF:BANDWIDTH=1,RESOLUTION=1920x1080',
+        "1080/playlist.m3u8",
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "call", "response"),
+    [
+        (
+            "get_video_info",
+            lambda: NetworkManager.get_video_info("123", COOKIES),
+            MockResponse(text=json.dumps({"content": {}})),
+        ),
+        (
+            "get_clip_info",
+            lambda: NetworkManager.get_clip_info("clipUID", COOKIES),
+            MockResponse(text=json.dumps({"content": {}})),
+        ),
+        (
+            "get_clip_manifest",
+            lambda: NetworkManager.get_clip_manifest("clip-id", COOKIES),
+            MockResponse(
+                text=json.dumps({"card": {"content": {"error": {"errorCode": "X"}}}})
+            ),
+        ),
+        (
+            "get_video_m3u8_base_url",
+            lambda: NetworkManager.get_video_m3u8_base_url(
+                json.dumps({"media": [{"path": "http://example.invalid/master.m3u8"}]}),
+                1080,
+                COOKIES,
+            ),
+            MockResponse(text=M3U8_PLAYLIST),
+        ),
+    ],
+)
+def test_metadata_calls_carry_request_timeout(monkeypatch, name, call, response):
+    """조회 호출은 모두 REQUEST_TIMEOUT을 실어야 한다."""
+    session = _install(monkeypatch, response)
+
+    call()
+
+    assert session.calls, name
+    for _url, kwargs in session.calls:
+        assert kwargs.get("timeout") == REQUEST_TIMEOUT, name
+
+
+@pytest.mark.parametrize("method", ["get_video_dash_manifest", "get_video_sea_manifest"])
+def test_manifest_calls_carry_request_timeout(monkeypatch, load_mock_response, method):
+    """매니페스트 조회도 REQUEST_TIMEOUT을 실어야 한다 (실픽스처 XML 파싱 통과)."""
+    xml = load_mock_response("dash_manifest.xml")
+    session = _install(monkeypatch, MockResponse(text=xml))
+
+    getattr(NetworkManager, method)("video-id", "in-key", COOKIES)
+
+    assert session.calls
+    for _url, kwargs in session.calls:
+        assert kwargs.get("timeout") == REQUEST_TIMEOUT
+
+
+def test_aes_key_keeps_dedicated_timeout(monkeypatch):
+    """복호화 키 요청의 기존 timeout=30은 유지된다 (#57 경로, 이 이슈 범위 밖)."""
+    session = _install(monkeypatch, BytesResponse())
+
+    NetworkManager.get_aes_key("http://example.invalid/key", COOKIES)
+
+    assert session.calls
+    _url, kwargs = session.calls[0]
+    assert kwargs.get("timeout") == 30
+
+
+def test_request_timeout_is_connect_read_pair():
+    """connect·read를 모두 지정한다 — 단일 값이면 connect만 걸리는 실수 방지."""
+    assert isinstance(REQUEST_TIMEOUT, tuple)
+    assert len(REQUEST_TIMEOUT) == 2
+    connect, read = REQUEST_TIMEOUT
+    assert 0 < connect <= read


### PR DESCRIPTION
## 관련 이슈

Closes #129

## 변경 내용

조회(카드 채우기) 경계의 모든 HTTP 요청에 `REQUEST_TIMEOUT = (5, 15)`(connect 5초 · read 15초)를 설정했다.

- `content/network.py`: 타임아웃 없던 6개 호출 전부 — `get_video_info` / `get_video_dash_manifest` / `get_video_sea_manifest` / `get_video_m3u8_base_url` / `get_clip_info` / `get_clip_manifest`. `get_aes_key`의 기존 `timeout=30`(#57)은 유지.
- `content/widget.py`: 해상도 크기 프로브(HEAD/GET)·썸네일 요청 3곳 — 카드 등장 후 네트워크가 끊기면 이 데몬 스레드들이 무기한 매달려 "확인 중..."이 영영 안 풀리던 것도 같은 경계라 함께 적용.

### 값의 근거 (작업 내용 1)

- **connect 5초**: 정상 연결은 1초 미만이라 5배 여유. OS SYN 재시도 주기(윈도우 초기값 기준 ~21초+)보다 먼저 앱이 판단권을 가진다.
- **read 15초**: 조회 응답은 작은 JSON/XML이라 평시 1초 미만 — 느린 회선·서버 지연에 15배 여유를 두되, 관측된 OS TCP 타임아웃(~47초)의 1/3 이내에 포기한다.
- **실측**: 비라우팅 주소로 검증 — 기존 무한 대기(OS ~47초) → `ConnectTimeout` **5.0초**. 타임아웃 발화 후에는 #127의 유형 매핑이 "네트워크 연결을 확인해 주세요"로 안내한다(#127 미머지 상태에서도 예외는 정상 전파되어 카드 정리·다이얼로그는 동작).

### 적용 범위 판단 (작업 내용 2)

훑은 결과 타임아웃 부재는 조회 경계뿐이었다:

| 경로 | 이전 | 이 PR |
|---|---|---|
| `content/network.py` 메타데이터·매니페스트 6곳 | 없음 | `REQUEST_TIMEOUT` |
| `content/widget.py` 크기 프로브·썸네일 3곳 | 없음 | `REQUEST_TIMEOUT` |
| `get_aes_key` (다운로드 시작 시 키 취득) | 30초 | 유지 |
| 다운로드 세그먼트·파트 (`file_downloader.py:120`, `m3u8:155`, `hls_aes:169·213`) | **이미 30초** | 무변경 |

`get_video_m3u8_base_url`은 다운로드 시작 시 리졸버(`download/resolvers.py:53`)도 쓰지만, 1회성 플레이리스트 요청이라 #128의 세그먼트 재큐 상한과 겹치지 않아 포함했다.

### 다건 동시 실패 시 다이얼로그 (작업 내용 3 — 확인·보고만)

**N건 실패 = N개의 모달 다이얼로그**다. 각 워커의 `contentError`가 개별적으로 `QMessageBox.critical`을 호출하며, critical의 중첩 이벤트 루프가 큐에 쌓인 시그널을 계속 처리하므로 첫 다이얼로그가 떠 있는 동안 다음 것이 그 위에 겹쳐 뜰 수 있다(Qt 의미론상 재진입 — GUI 실측은 안 함). 유저는 N번 닫아야 한다. 지시대로 집계는 넣지 않았다 — 실패의 카드 표시 전환(#128 후속 1번)이 들어오면 소멸하는 문제.

### 다운로드 경로 (작업 내용 4 — 확인·보고만)

세그먼트·파트 요청은 위 표대로 **이미 전부 timeout=30**이라 이 이슈의 결함이 없다. 다만 #128 조사에서 확인된 대로 타임아웃 발화 후 `_requeue_failed`가 상한 없이 무한 재큐하므로, 영구 단절 시 "타임아웃은 걸리지만 영원히 재시도"가 된다 — 재큐 상한(#128 후속 2번) 범위라 여기서는 수정하지 않았다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] 전체 pytest 통과 — 315 passed, 2 skipped (Windows라 xvfb 없이 실행)
- [x] 새 로직에 대한 테스트 추가됨 — `tests/unit/test_network_timeouts.py` 8건: 조회 6개 메서드 전부 타임아웃 전달, get_aes_key 30초 유지, (connect, read) 쌍 형식 검증. 기존 `test_network.py`의 kwargs 정확 일치 박제 3건은 타임아웃 포함으로 갱신.

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- 실환경 스모크: 네트워크 끊고 URL 추가 → 약 5초 내 오류 다이얼로그 + 로딩 카드 정리 확인 부탁드립니다.
- #127과 파일 겹침 없음(#127: metadata_service·worker·translations / 본 PR: network·widget·tests) — 머지 순서 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
