### PR TITLE
fix: 오류 재큐에 항목별 상한 도입 — 영구 오류(404·403) 무한 재큐 차단 (#131)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -56,6 +56,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
+import requests
+
 from core.models.content import Content
 from core.models.download_state import DownloadState
 from core.models.events import (
@@ -87,6 +89,30 @@ _RECOVERY_RATIO = 1.30
 _HOLD_EMA_ALPHA = 0.2  # 정체 기준의 지수이동평균 가중치 (안정 틱에서만 갱신)
 _COLLAPSE_TICKS = 5  # 감소 확정에 필요한 연속 틱 수 (구 규칙과 동일한 관성)
 _REPROBE_TICKS = 15  # 정체 상태에서 재탐침까지의 틱 수
+
+
+# ============ 오류 재큐 상한 (#131) ============
+# 상한이 없으면 영구 오류(404·403)가 무한 재큐돼 다운로드가 끝나지도,
+# 실패하지도 않는다. 상한은 예외로 인한 재큐(_requeue_failed)에만 건다 —
+# 저속 재큐(_requeue_slow)는 잘 동작하는 회선에서도 정상적으로 여러 번
+# 발동하는 규칙이라, 함께 세면 느린 회선의 정상 다운로드가 실패한다.
+_PERMANENT_ERROR_REQUEUE_LIMIT = 2  # 항목별 최대 재큐 횟수 — 총 3회 시도
+_TRANSIENT_ERROR_REQUEUE_LIMIT = 10  # 항목별 최대 재큐 횟수 — 총 11회 시도
+# 4xx 중 일시적일 수 있는 상태 — 요청 타임아웃(408)·과요청(429)은 재시도가 유효하다
+_TRANSIENT_HTTP_STATUSES = frozenset({408, 429})
+
+
+def _is_permanent_error(exc: BaseException) -> bool:
+    """재시도해도 결과가 같은 오류인지 판정한다 (#131).
+
+    4xx 응답(408·429 제외)은 같은 요청에 같은 답이 돌아온다 — 세그먼트
+    소실(404)·권한/만료(403)가 대표다. 그 외(5xx·타임아웃·연결 끊김)는
+    일시적일 수 있어 재시도 여지를 더 준다.
+    """
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        status = exc.response.status_code
+        return 400 <= status < 500 and status not in _TRANSIENT_HTTP_STATUSES
+    return False
 
 
 class PostprocessError(Exception):
@@ -146,6 +172,8 @@ class BaseDownloader(ABC):
         self.lock = threading.Lock()
         self.future_dict: dict = {}
         self.adjust_count = 0
+        # 항목별 오류 재큐 횟수 (#131) — 상한 판정용. 저속 재큐는 세지 않는다
+        self._error_requeues: dict = {}
         # 전송 종료 시 관측 스레드를 깨워 끝내는 신호 — 후처리는 관측 대상이 아니다 (#89)
         self._monitor_stop = threading.Event()
         # 전송 중 관측된 정점 동시 스레드 수 — 전송 종료 요약 로그용 (#110)
@@ -329,6 +357,7 @@ class BaseDownloader(ABC):
                 with self.lock:
                     self.s.future_count = 0
                     self.future_dict = {}
+                    self._error_requeues = {}
 
                 while not self.state == DownloadState.WAITING:
                     # (1) 현재 활성 스레드 수보다 적으면 -> 추가 스레드 할당
@@ -447,11 +476,40 @@ class BaseDownloader(ABC):
             self._on_failed(e)
             self.logger.log_error("Thread failed", e)
 
-    def _requeue_failed(self, item, part_num: int) -> None:
-        """예외 발생 시 작업을 다시 다운로드할 수 있도록 remaining_ranges에 등록."""
+    def _requeue_failed(self, item, part_num: int, exc: BaseException) -> None:
+        """예외 발생 시 작업을 다시 다운로드할 수 있도록 remaining_ranges에 등록.
+
+        항목별 재큐 횟수에 상한을 둔다 (#131) — 영구 오류(4xx)는 짧게,
+        일시 오류(5xx·타임아웃·연결 끊김)는 길게 허용한다. 상한 도달 시
+        재큐 대신 원인을 로그에 남기고 다운로드 전체를 실패로 끝낸다.
+        저속 재큐(_requeue_slow)는 이 상한에 세지 않는다.
+        """
+        count = self._error_requeues.get(item, 0)
+        permanent = _is_permanent_error(exc)
+        limit = _PERMANENT_ERROR_REQUEUE_LIMIT if permanent else _TRANSIENT_ERROR_REQUEUE_LIMIT
+        if count >= limit:
+            kind = "permanent" if permanent else "transient"
+            self._fail_fatally(
+                exc,
+                f"Part {part_num} requeue limit reached "
+                f"({count} requeues, {kind} error) — giving up",
+            )
+            return
+        self._error_requeues[item] = count + 1
         self.s.failed_threads += 1
         self.s.threads_progress[part_num] = 0
         self.s.remaining_ranges.append(item)
+
+    def _fail_fatally(self, exc: BaseException, log_message: str) -> None:
+        """워커에서 회복 불가능한 오류가 났을 때 다운로드 전체를 중단시킨다.
+
+        상태를 중단으로 돌려 실행 루프·관측 루프가 빠져나오게 하고, 실패를
+        통지한다. 부분 산출물 정리는 run()의 중단 경로가 수행한다.
+        (hls_aes 복호화 실패 경로에서 승격 — #131부터 재큐 상한 도달도 쓴다)
+        """
+        self.logger.log_error(log_message, exc)
+        self._on_failed(exc)
+        self.model.stop()
 
     def _requeue_slow(self, item, part_num: int) -> None:
         """저속으로 중도 중단한 작업을 재시작하도록 등록."""

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -184,7 +184,7 @@ class FileDownloader(BaseDownloader):
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
                     self._record_partial(start, end, resume_offset + downloaded_size)
-                    self._requeue_failed((start, end), part_num)
+                    self._requeue_failed((start, end), part_num, e)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
 

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -247,7 +247,7 @@ class HlsAesDownloader(BaseDownloader):
                     # 복호화 실패는 재시도해도 낫지 않는다(키·정렬 문제). 재큐잉하면
                     # 무한 루프가 되고, 그대로 전파하면 future_dict가 정리되지 않아
                     # 실행 루프가 끝나지 않는다 — 다운로드 전체를 중단시킨다
-                    self._fail_fatally(e)
+                    self._fail_fatally(e, "Segment decryption failed")
                     return part_num
 
                 temp_file = os.path.join(self.temp_dir, f"{index:0{self.width}d}.ts")
@@ -264,17 +264,7 @@ class HlsAesDownloader(BaseDownloader):
 
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
-                    self._requeue_failed((index, segment), part_num)
+                    self._requeue_failed((index, segment), part_num, e)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
-
-    def _fail_fatally(self, exc: BaseException) -> None:
-        """워커에서 회복 불가능한 오류가 났을 때 다운로드 전체를 중단시킨다.
-
-        상태를 중단으로 돌려 실행 루프·관측 루프가 빠져나오게 하고, 실패를
-        통지한다. 부분 산출물 정리는 run()의 중단 경로가 수행한다.
-        """
-        self.logger.log_error("Segment decryption failed", exc)
-        self._on_failed(exc)
-        self.model.stop()
 

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -194,7 +194,7 @@ class M3U8Downloader(BaseDownloader):
 
             except (requests.RequestException, requests.Timeout) as e:
                 with self.lock:
-                    self._requeue_failed((index, segment), part_num)
+                    self._requeue_failed((index, segment), part_num, e)
                 self.logger.log_error(f"Part {part_num} download failed", e)
                 return part_num
 

--- a/tests/unit/core/test_requeue_limit.py
+++ b/tests/unit/core/test_requeue_limit.py
@@ -1,0 +1,349 @@
+"""오류 재큐 상한 검증 (#131).
+
+상한 없는 재큐는 영구 오류(404·403)를 영원히 재시도해 다운로드가 끝나지도,
+실패하지도 않았다. 이 테스트는 새 상한 규칙을 검증한다:
+
+- 오류 재큐는 항목별로 상한이 있다 — 영구 오류(4xx)는 짧게(2회),
+  일시 오류(5xx·타임아웃·연결 끊김)는 길게(10회)
+- 상한 도달 시 재큐 대신 실패 콜백이 호출되고 원인이 로그에 남는다
+- 저속 재큐(<100 KB/s 연속 6회)는 상한에 세지 않는다 — 정상 회선에서도
+  발동하는 규칙이라 함께 세면 느린 회선의 정상 다운로드가 실패한다
+
+1회 실패 시 재큐 동작 자체는 기존 박제 테스트가 고정한다
+(test_file_downloader_rules / test_m3u8_downloader_rules — 시나리오·단언 무수정).
+"""
+
+import requests
+
+from core.downloaders.base import _is_permanent_error
+from core.models.download_state import DownloadState
+from download.data import DownloadData
+
+MB = 1024 * 1024
+CHUNK = 8192
+
+
+class RecordingLogger:
+    """DownloadLogger 호환 가짜 로거 — 실제 파일을 만들지 않고 호출만 기록한다."""
+
+    def __init__(self):
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+        self.thread_completes: list[tuple] = []
+
+    def log_thread_adjust(self, active_threads, avg_speed):
+        pass
+
+    def log_thread_debug(self, active_threads, download_speed, avg_speed):
+        pass
+
+    def log_thread_start(self, thread_id, start, end):
+        pass
+
+    def log_m3u8_thread_start(self, thread_id, segment):
+        pass
+
+    def log_thread_complete(self, thread_id, downloaded_size):
+        self.thread_completes.append((thread_id, downloaded_size))
+
+    def log_part_resume(self, part_num, offset, part_size):
+        pass
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+class FakeResponse:
+    """스트리밍 응답 흉내 — 지정한 청크 목록을 그대로 흘린다."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        yield from self._chunks
+
+
+class FakeSession:
+    """get_thread_session() 대체 — 준비된 응답을 반환하거나 예외를 던진다."""
+
+    def __init__(self, response=None, exception=None):
+        self._response = response
+        self._exception = exception
+
+    def get(self, url, **kwargs):
+        if self._exception is not None:
+            raise self._exception
+        return self._response
+
+
+class TickingClock:
+    """time.time 대체 — 호출마다 지정 간격으로 흐르는 가짜 시계."""
+
+    def __init__(self, step: float):
+        self.now = 1_000_000.0
+        self.step = step
+
+    def __call__(self) -> float:
+        self.now += self.step
+        return self.now
+
+
+class FakeHttpResponse:
+    """HTTPError에 실을 상태 코드만 가진 응답 흉내."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    """지정 상태 코드의 HTTPError를 만든다 (raise_for_status 산출물과 동형)."""
+    return requests.HTTPError(f"HTTP {status}", response=FakeHttpResponse(status))
+
+
+def _make_data(output_path: str) -> DownloadData:
+    """테스트용 DownloadData를 만든다 (네트워크 정보는 더미)."""
+    return DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=1080,
+        content_type="video",
+    )
+
+
+# ================================================================ 오류 분류
+
+
+def test_client_errors_are_permanent():
+    """404·403 등 4xx(408·429 제외)는 재시도해도 결과가 같은 영구 오류다."""
+    assert _is_permanent_error(_http_error(404))
+    assert _is_permanent_error(_http_error(403))
+    assert _is_permanent_error(_http_error(410))
+
+
+def test_retryable_statuses_and_transport_errors_are_transient():
+    """408·429·5xx·연결/타임아웃 오류는 일시 오류로 분류한다."""
+    assert not _is_permanent_error(_http_error(408))
+    assert not _is_permanent_error(_http_error(429))
+    assert not _is_permanent_error(_http_error(500))
+    assert not _is_permanent_error(_http_error(503))
+    assert not _is_permanent_error(requests.ConnectionError("boom"))
+    assert not _is_permanent_error(requests.Timeout("slow"))
+    assert not _is_permanent_error(requests.HTTPError("no response attached"))
+
+
+# ================================================================ 파일 경로 (base 공통 규칙)
+
+
+def _prepare_file_engine(tmp_path, monkeypatch, exception=None, chunks=None, clock_step=1e-6):
+    """RUNNING 상태의 FileDownloader와 부속(데이터·로거·실패 기록)을 준비한다."""
+    import core.downloaders.file_downloader as mod
+    from core.downloaders.file_downloader import FileDownloader
+
+    output = tmp_path / "part.bin"
+    output.write_bytes(b"")
+
+    data = _make_data(str(output))
+    logger = RecordingLogger()
+    failures: list[BaseException] = []
+    engine = FileDownloader(data, logger, on_failed=failures.append)
+
+    data.model.start()
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+
+    monkeypatch.setattr(
+        mod, "get_thread_session", lambda: FakeSession(FakeResponse(chunks or []), exception)
+    )
+    monkeypatch.setattr(mod.tm, "time", TickingClock(clock_step))
+    return engine, data, logger, failures
+
+
+def test_permanent_error_fails_download_at_limit(tmp_path, monkeypatch):
+    """완료 조건: 영구 오류(404)를 주입하면 상한(재큐 2회)에서 멈추고 실패로 끝난다."""
+    error = _http_error(404)
+    engine, data, logger, failures = _prepare_file_engine(tmp_path, monkeypatch, exception=error)
+
+    for attempt in range(2):  # 1·2회째 실패 — 아직 재큐된다
+        data.remaining_ranges = []  # 실행 루프가 pop해 갔다고 가정
+        engine._download_part(0, MB - 1, 0, MB)
+        assert data.remaining_ranges == [(0, MB - 1)], f"{attempt + 1}회째는 재큐돼야 한다"
+        assert failures == []
+
+    data.remaining_ranges = []
+    returned = engine._download_part(0, MB - 1, 0, MB)  # 3회째 — 상한 도달
+
+    assert returned == 0  # 워커는 정상 반환한다 (future_dict 정리 경로 유지)
+    assert data.remaining_ranges == []  # 더 이상 재큐하지 않는다
+    assert failures == [error]  # 실패 콜백으로 끝난다
+    assert data.model.state is DownloadState.WAITING  # 실행 루프 종료 신호
+    assert data.failed_threads == 2  # 재큐된 횟수만 센다
+    # 완료 조건: 원인이 로그에 남는다 — 상한 도달 사실과 오류 분류
+    assert any("requeue limit" in m and "permanent" in m for m in logger.errors)
+
+
+def test_transient_error_gets_longer_allowance(tmp_path, monkeypatch):
+    """일시 오류(연결 끊김)는 재큐 10회까지 허용되고, 11회째에 실패로 끝난다."""
+    error = requests.ConnectionError("boom")
+    engine, data, logger, failures = _prepare_file_engine(tmp_path, monkeypatch, exception=error)
+
+    for _ in range(10):  # 10회까지는 재큐된다
+        data.remaining_ranges = []
+        engine._download_part(0, MB - 1, 0, MB)
+        assert data.remaining_ranges == [(0, MB - 1)]
+        assert failures == []
+
+    data.remaining_ranges = []
+    engine._download_part(0, MB - 1, 0, MB)  # 11회째 — 상한 도달
+
+    assert data.remaining_ranges == []
+    assert failures == [error]
+    assert data.model.state is DownloadState.WAITING
+    assert any("requeue limit" in m and "transient" in m for m in logger.errors)
+
+
+def test_requeue_counts_are_per_item(tmp_path, monkeypatch):
+    """상한은 항목별이다 — 한 파트의 실패가 다른 파트의 허용 횟수를 깎지 않는다."""
+    error = _http_error(404)
+    engine, data, logger, failures = _prepare_file_engine(tmp_path, monkeypatch, exception=error)
+
+    for _ in range(2):  # 파트 (0, MB-1)이 상한 직전까지 실패
+        data.remaining_ranges = []
+        engine._download_part(0, MB - 1, 0, MB)
+
+    data.remaining_ranges = []
+    engine._download_part(MB, 2 * MB - 1, 1, 2 * MB)  # 다른 파트의 첫 실패
+
+    assert data.remaining_ranges == [(MB, 2 * MB - 1)]  # 정상 재큐
+    assert failures == []
+
+
+# ================================================================ 저속 재큐 분리 (m3u8 경로)
+
+
+def _prepare_m3u8_engine(tmp_path):
+    """RUNNING 상태의 M3U8Downloader와 부속을 준비한다 (세그먼트 로직만 단위 검증)."""
+    import core.downloaders.m3u8_downloader as mod
+    from core.downloaders.m3u8_downloader import M3U8Downloader
+
+    data = _make_data(str(tmp_path / "out.mp4"))
+    logger = RecordingLogger()
+    failures: list[BaseException] = []
+    engine = M3U8Downloader(data, logger, on_failed=failures.append)
+
+    data.model.start()
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+    engine.temp_dir = str(tmp_path)
+    engine.width = 4
+    return engine, data, logger, failures, mod
+
+
+def test_slow_requeues_are_unlimited_and_download_still_completes(tmp_path, monkeypatch):
+    """완료 조건: 저속 재큐가 양 상한(2·10회)을 넘게 반복돼도 실패하지 않고 완주한다."""
+    engine, data, logger, failures, mod = _prepare_m3u8_engine(tmp_path)
+
+    slow_chunks = [b"x" * CHUNK] * 10  # 1초/청크 → 8 KB/s로 항상 저속
+    monkeypatch.setattr(mod, "get_thread_session", lambda: FakeSession(FakeResponse(slow_chunks)))
+    monkeypatch.setattr(mod.tm, "time", TickingClock(1.0))
+
+    for _ in range(12):  # 영구(2)·일시(10) 상한 모두 초과
+        data.remaining_ranges = []
+        engine._download_segment(index=7, segment="segment_007.m4v", part_num=0, total_ranges=4)
+        assert data.remaining_ranges == [(7, "segment_007.m4v")]  # 계속 재큐된다
+
+    assert failures == []  # 저속 재큐는 실패가 아니다
+    assert data.restart_threads == 12
+    assert data.model.state is DownloadState.RUNNING
+
+    # 속도가 회복되면 같은 세그먼트가 정상 완주한다
+    fast_chunks = [b"x" * CHUNK] * 3
+    monkeypatch.setattr(mod, "get_thread_session", lambda: FakeSession(FakeResponse(fast_chunks)))
+    monkeypatch.setattr(mod.tm, "time", TickingClock(1e-6))
+    engine._download_segment(index=7, segment="segment_007.m4v", part_num=0, total_ranges=4)
+
+    assert data.completed_threads == 1
+    assert failures == []
+
+
+def test_slow_requeues_do_not_consume_error_allowance(tmp_path, monkeypatch):
+    """저속 재큐와 오류 재큐는 별도 계열이다 — 저속 반복 후에도 오류 허용 횟수는 그대로다."""
+    engine, data, logger, failures, mod = _prepare_m3u8_engine(tmp_path)
+
+    for _ in range(12):  # 저속 재큐를 상한 이상 반복
+        engine._requeue_slow((7, "segment_007.m4v"), 0)
+
+    monkeypatch.setattr(mod, "get_thread_session", lambda: FakeSession(exception=_http_error(404)))
+    monkeypatch.setattr(mod.tm, "time", TickingClock(1e-6))
+    data.remaining_ranges = []
+    engine._download_segment(index=7, segment="segment_007.m4v", part_num=0, total_ranges=4)
+
+    # 오류 계열의 첫 실패이므로 실패 종료가 아니라 정상 재큐다
+    assert data.remaining_ranges == [(7, "segment_007.m4v")]
+    assert failures == []
+    assert data.model.state is DownloadState.RUNNING
+
+
+# ================================================================ hls_aes 경로 배선
+
+
+def test_hls_aes_permanent_error_fails_at_limit(tmp_path, monkeypatch):
+    """AES 경로도 같은 상한을 탄다 — 세그먼트 403(키·쿠키 만료류) 반복 시 실패로 끝난다."""
+    import core.downloaders.hls_aes_downloader as mod
+    from core.downloaders.hls_aes_downloader import HlsAesDownloader
+
+    data = _make_data(str(tmp_path / "out.mp4"))
+    logger = RecordingLogger()
+    failures: list[BaseException] = []
+    engine = HlsAesDownloader(data, logger, on_failed=failures.append)
+
+    data.model.start()
+    data.threads_progress = [0] * 4
+    data.remaining_ranges = []
+    engine.width = 4
+
+    error = _http_error(403)
+    monkeypatch.setattr(mod, "get_thread_session", lambda: FakeSession(exception=error))
+    monkeypatch.setattr(mod.tm, "time", TickingClock(1e-6))
+
+    for _ in range(2):
+        data.remaining_ranges = []
+        engine._download_segment(index=3, segment="seg_003.ts", part_num=0, total_ranges=4)
+        assert data.remaining_ranges == [(3, "seg_003.ts")]
+
+    data.remaining_ranges = []
+    engine._download_segment(index=3, segment="seg_003.ts", part_num=0, total_ranges=4)
+
+    assert data.remaining_ranges == []
+    assert failures == [error]
+    assert data.model.state is DownloadState.WAITING
+    assert any("requeue limit" in m and "permanent" in m for m in logger.errors)
+
+
+# ================================================================ 실행 루프 재사용 초기화
+
+
+def test_error_counts_reset_between_runs(tmp_path, monkeypatch):
+    """엔진 재사용 시 run()이 카운터를 초기화한다 — 이전 실행의 실패가 이월되지 않는다."""
+    engine, data, logger, failures = _prepare_file_engine(
+        tmp_path, monkeypatch, exception=_http_error(404)
+    )
+    for _ in range(2):
+        data.remaining_ranges = []
+        engine._download_part(0, MB - 1, 0, MB)
+    assert engine._error_requeues == {(0, MB - 1): 2}
+
+    # run()의 재사용 초기화 블록과 동일한 동작 검증 (실행 루프 전체는 띄우지 않는다)
+    with engine.lock:
+        engine._error_requeues = {}
+
+    data.remaining_ranges = []
+    engine._download_part(0, MB - 1, 0, MB)
+    assert data.remaining_ranges == [(0, MB - 1)]  # 초기화 후 첫 실패 — 정상 재큐
+    assert failures == []


### PR DESCRIPTION
**요약**

지금까지는 다운로드 중 세그먼트·파트가 서버에서 사라졌거나(404) 권한이 만료된(403) 경우, 같은 조각을 영원히 다시 시도해서 다운로드가 끝나지도 실패하지도 않았습니다. 이제 조각별로 재시도 횟수에 상한을 두어, 가망 없는 오류는 몇 초 안에 포기하고 다운로드를 실패로 끝내며 원인을 로그에 남깁니다. 속도가 느려서 다시 시도하는 것(정상 동작)은 이 상한에 세지 않으므로, 느린 회선에서도 다운로드는 전과 똑같이 완주합니다.

## 관련 이슈

Closes #131

참조: #128 조사 보고 ④ (https://github.com/honey720/chzzk-vod-downloader-v2/issues/128#issuecomment-5115002323) — 후속 이슈 분할 제안의 2번.

## 변경 내용

- `core/downloaders/base.py`: `_requeue_failed`에 항목별 오류 재큐 상한 도입. 상한 도달 시 재큐 대신 원인을 로그(`requeue limit reached (N requeues, permanent/transient error)`)에 남기고 `_fail_fatally`(실패 콜백 통지 + `model.stop()`)로 다운로드 전체를 종료. `run()`의 재사용 초기화 블록에서 카운터 리셋.
- `_fail_fatally`를 hls_aes에서 base로 승격 (복호화 실패 경로 동작 무변경 — 로그 메시지 매개변수화만).
- `file/m3u8/hls_aes` 다운로더: `_requeue_failed` 호출에 예외 객체 전달 (분류 근거).
- `tests/unit/core/test_requeue_limit.py` 신규 — 완료 조건 4건 전부 커버.

## 판단과 근거 (이슈의 판단 요구 3건)

**1. 저속 재큐와 오류 재큐는 분리한다 — 저속은 상한 없음.**
저속 판정(<100KB/s 연속 6회)은 잘 동작하는 회선에서도 정상적으로 여러 번 발동하는 규칙이다. 같은 카운터로 세면 느린 회선의 정상 다운로드가 상한에 걸려 실패한다 — 완주가 가능한 다운로드를 실패시키는 것은 이 이슈가 고치려는 것(끝나지 않음)보다 나쁜 회귀다. 저속 재큐는 매 시도마다 진행이 있고(파일 경로는 #78 이어받기로 단조 전진) 오류와 달리 "가망 없음" 신호가 아니므로 상한을 두지 않았다. 오류 재큐만 항목별로 센다.

**2. 영구/일시 오류는 구분한다 — 분기 비용이 작고 이득이 명확.**
- 영구(4xx, 단 408·429 제외): **재큐 2회(총 3회 시도)**. 404·403은 같은 요청에 같은 답이 돌아온다. 즉시 포기(0회)하지 않은 것은 CDN 엣지의 순간적 오응답에 대한 저비용 보험이다. HTTP 요청 한 번이면 판정되므로 수 초 안에 실패가 확정된다.
- 일시(5xx·타임아웃·연결 끊김·408·429): **재큐 10회(총 11회 시도)**. 회복 여지가 있어 길게 허용하되, 서버가 계속 5xx인 경우에도 무한하지 않게 상한을 둔다.
- 분기 비용은 base의 순수 함수 `_is_permanent_error` 하나(HTTPError의 상태 코드 검사)다. 이 비용으로 영구 오류의 표면화가 "영원히 안 됨"에서 "수 초"로 줄어들므로 구분이 이득이라고 판단했다.
- 카운터는 항목별 단일 카운터이고 상한은 현재 오류의 분류로 고른다 — 일시·영구가 섞여도 반복 실패 중인 항목이므로 조기 판정이 정당하다.

**3. 상한 도달 시: 실패 종료 + 로그.**
한 항목이 상한에 걸리면 그 항목 없이는 다운로드가 완성될 수 없으므로 전체를 실패로 끝낸다. 방식은 hls_aes 복호화 실패가 이미 쓰던 `_fail_fatally`(실패 콜백 + `model.stop()`) 패턴을 그대로 따랐다 — 새 의미론을 발명하지 않고 기존 동작(회복 불가 워커 오류의 종료 경로)에 맞춘 것. `DownloadTaskModel.fail()`(FAILED 전이)로 보내지 않은 이유: 실행 루프·워커·관측 루프가 모두 WAITING만 종료 신호로 보므로 FAILED 전이는 루프를 끝내지 못하며, FAILED 상태의 배선은 #128 후속 ①(실패 표시 신설)의 범위다.

**예상된 중간 상태**: 실패 콜백은 현재 브리지(`_onEngineFailed`)에서 폐기되므로 이 PR만으로는 유저에게 여전히 "대기"로 보인다. 이는 #128 후속 ①이 해소할 예정이며, 이 PR은 이슈 지시대로 UI를 건드리지 않았다. 엔진 수준에서는 실패 콜백 발화 + run() 종료 + 로그로 실패가 확정된다.

**박제 테스트**: 재큐·저속 판정 규칙의 박제(`test_file_downloader_rules` / `test_m3u8_downloader_rules`)는 "1회 실패 시 재큐"를 고정하는데, 상한(반복 횟수)은 박제 범위 밖이라 **시나리오·단언 무수정**으로 전부 통과한다. 규칙 자체의 변경은 없다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (333 passed, 2 skipped — Windows 로컬, xvfb는 리눅스 CI 전용)
- [x] 새 로직에 대한 테스트 추가됨 (core 변경 시) — `test_requeue_limit.py` 10건:
  - 영구 오류 주입 → 상한(2회)에서 멈추고 실패 콜백·로그로 끝남 (완료 조건 ①·③)
  - 일시 오류 → 10회까지 허용, 11회째 실패 (상한 존재)
  - 저속 재큐 12회 반복 후에도 실패 없이 완주 (완료 조건 ②)
  - 저속 재큐가 오류 허용 횟수를 깎지 않음 (계열 분리)
  - 항목별 카운트·재사용 초기화·오류 분류·hls_aes 경로 배선

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지) — base에 `requests` 추가는 core 기존 의존
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- 상한 값(영구 2·일시 10)은 "영구 오류는 수 초 내 확정, 일시 오류는 불안정 네트워크에 관대하되 유한"을 기준으로 정한 판단값입니다. 조정이 필요하면 `base.py`의 상수 두 개만 바꾸면 됩니다.
- `ruff format --check`에서 걸리는 파일들(hls_aes/m3u8 포함 30개)은 main에서도 원래 미포맷 상태라 이 PR에서 재포맷하지 않았습니다 (무관 변경 배제). 새 파일(`test_requeue_limit.py`)은 포맷 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
