### PR TITLE
fix: 쓰기 불가 경로의 시작 전 실패 + 중지 경로 대기 상한·슬롯 방출 (#137)

### DIFF
--- a/content/manager.py
+++ b/content/manager.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import tempfile
+import threading
 
 from PySide6.QtCore import Qt, Signal, QThreadPool, QObject
 from content.model import ContentListModel
@@ -11,6 +13,48 @@ from content.worker import ContentWorker
 from core.utils.paths import build_output_path, ensure_unique_path
 
 logger = logging.getLogger(__name__)
+
+# 쓰기 프로브 대기 상한(초) (#137). 정상 디스크에서 프로브는 밀리초 수준이라
+# 이 값은 병리 상황(무응답 마운트 — #136)에서만 발동한다. 발동 시 메인 스레드가
+# 이 시간만큼 기다리는 대가가 있지만, 무한 정지(0B 침묵) 대신 유한 대기 후
+# 명확한 실패가 목적이다
+_WRITE_PROBE_TIMEOUT_S = 5.0
+
+
+def probe_writable(directory: str, timeout_s: float = _WRITE_PROBE_TIMEOUT_S) -> tuple[bool, str]:
+    """저장 경로의 존재·쓰기 가능 여부를 제물 스레드로 검사한다 (#137 — #136 제안 ②).
+
+    존재 검사(os.path.isdir)조차 무응답 마운트에서는 매달릴 수 있어, 검사
+    전체를 별도 스레드에서 수행하고 join(timeout)으로 포기한다 — 파이썬에
+    파일 I/O 시간 제한 수단이 없다는 조사(#136)의 상한 적용이다. 갇힌
+    스레드는 회수할 수 없지만(데몬), 프로브는 다운로드 시작 시점 1회뿐인
+    작고 드문 지점이라 누수 비용이 유계다.
+
+    Returns:
+        (쓰기 가능 여부, 사유): 사유는 "" | "missing" | "denied" | "timeout"
+    """
+    outcome: dict[str, str] = {}
+
+    def probe() -> None:
+        try:
+            if not os.path.isdir(directory):
+                outcome["reason"] = "missing"
+                return
+            # 실제 파일 생성·삭제로 확인한다 — os.access는 네트워크 파일시스템의
+            # 권한(예: SFTP 상 ZFS 풀 루트)을 신뢰할 수 없다
+            fd, probe_path = tempfile.mkstemp(prefix=".cvdv2_probe_", dir=directory)
+            os.close(fd)
+            os.remove(probe_path)
+            outcome["reason"] = ""
+        except OSError:
+            outcome["reason"] = "denied"
+
+    worker = threading.Thread(target=probe, daemon=True, name="WriteProbe")
+    worker.start()
+    worker.join(timeout_s)
+    reason = outcome.get("reason", "timeout")
+    return reason == "", reason
+
 
 class ContentManager(QObject):
     # 메타데이터 매니저 UI
@@ -113,8 +157,19 @@ class ContentManager(QObject):
         found, item, index = self.findItem()
         if found:
             try:
-                if not os.path.exists(item.download_path):
+                # 사전 검사 (#137): 존재만 보던 구 검사(os.path.exists)를 존재+쓰기
+                # 프로브로 확장한다. 존재 검사도 프로브 스레드 안에서 수행한다 —
+                # 무응답 마운트에서는 exists조차 메인 스레드를 매달 수 있다 (#136)
+                writable, reason = probe_writable(item.download_path)
+                if reason == "missing":
                     raise ValueError(self.tr("Invalid file path"))
+                if not writable:
+                    # 권한 없음(denied — 예: SFTP 상 ZFS 풀 루트) 또는 무응답
+                    # 마운트(timeout — 권한 오류가 오류로 전파되지 않는 경우).
+                    # 유저에게는 같은 사실이다: 이 경로에는 저장할 수 없다
+                    logger.warning("쓰기 프로브 실패(%s): %s", reason, item.download_path)
+                    self.fail(item, self.tr("Failed to save file"))
+                    return
                 self.onDownload(item)
             except ValueError as e:
                 # 위에서 직접 던진 번역된 안내 — 그대로 카드에 표시한다

--- a/core/services/download_service.py
+++ b/core/services/download_service.py
@@ -250,6 +250,23 @@ class DownloadService:
                 return downloader_cls
         raise ValueError(f"지원하지 않는 컨텐츠 타입: {content.content_type}")
 
+    def abandon(self, handle: DownloadHandle) -> None:
+        """응답 없는 핸들을 큐·활성 집합에서 방출해 슬롯을 회수한다 (#137).
+
+        파일 I/O에 갇힌 엔진 스레드는 중단시킬 수 없다 (#136 조사 — 파이썬
+        스레드는 외부 중단 불가, Windows 파일 I/O에 타임아웃 개념 없음).
+        스레드는 남겨 두되 동시 실행 슬롯만 되돌려, 갇힌 다운로드 하나가
+        이후 다운로드의 시작을 영구히 막지 않게 한다. 갇혔던 스레드가 나중에
+        깨어나 run()이 끝나면 _run_handle finally의 discard는 멱등이라 무해하다.
+        """
+        with self._lock:
+            self._active.discard(handle)
+            try:
+                self._pending.remove(handle)
+            except ValueError:
+                pass
+            self._dispatch_locked()
+
     @property
     def active_count(self) -> int:
         """현재 실행 중인 다운로드 수."""

--- a/download/qt_bridge.py
+++ b/download/qt_bridge.py
@@ -19,6 +19,7 @@ monitor_m3u8.py·manager.py에 분산돼 있던 Qt 어댑터(콜백→Signal 변
 MonitorM3U8Thread의 계산과 동일하다.
 """
 
+import logging
 from time import gmtime, strftime
 
 import requests
@@ -33,6 +34,15 @@ from download.data import DownloadData
 from download.logger import DownloadLogger
 from download.resolvers import resolve_aes_key, resolve_m3u8_base_url
 from download.task import DownloadTask
+
+logger = logging.getLogger(__name__)
+
+# 중지·완료 정리 시 워커 종료를 기다리는 상한(초) (#137 — #136 제안 ①).
+# 정상 종료는 대부분 즉시(워커가 청크 단위로 상태를 확인)지만, 파일 I/O에
+# 갇힌 워커는 영원히 안 끝난다 — 여기는 메인 스레드라 무한 대기가 곧 앱
+# 프리즈였다. 네트워크 read에 막힌 워커(최대 30초)도 UI를 잡아둘 가치가
+# 없어 짧게 둔다
+_HANDLE_WAIT_TIMEOUT_S = 2.0
 
 
 def _failure_message_key(exc: BaseException) -> str | None:
@@ -136,9 +146,20 @@ class QtDownloadBridge(QObject):
         self.stopped.emit(self.item)
 
     def removeThreads(self) -> None:
-        """실행 중인 워커가 끝나기를 기다린 뒤 참조를 정리한다 (구 removeThreads)."""
-        if self.handle is not None:
-            self.handle.wait()
+        """실행 중인 워커의 종료를 상한을 두고 기다린 뒤 참조를 정리한다 (구 removeThreads).
+
+        상한 초과 시(파일 I/O에 갇힌 워커 — #136) 서비스 슬롯을 방출하고
+        참조만 정리한다 (#137). 부분 산출물 정리가 생략되는 것은 아니다 —
+        정리는 wait가 아니라 엔진 스레드(run 꼬리의 _cleanup_partial)가
+        수행하므로, 포기해도 정리는 늦어질 뿐이며 갇힌 스레드가 깨어나면
+        그때 수행된다. 재시작 충돌은 산출물 경로 유일화(#105)가 막는다.
+        """
+        if self.handle is not None and not self.handle.wait(_HANDLE_WAIT_TIMEOUT_S):
+            logger.warning(
+                "워커가 %.0f초 안에 끝나지 않아 대기를 포기한다 — 슬롯 방출 (#137)",
+                _HANDLE_WAIT_TIMEOUT_S,
+            )
+            self._service.abandon(self.handle)
         self.handle = None
         self.task = None
 

--- a/tests/unit/core/test_download_service.py
+++ b/tests/unit/core/test_download_service.py
@@ -7,6 +7,7 @@ test_file_downloader_*·test_m3u8_downloader_*가 박제한다.
 """
 
 import threading
+import time
 
 import pytest
 
@@ -127,6 +128,63 @@ def m3u8_factory(monkeypatch):
 def _finish(engine: FakeEngine):
     """페이크 엔진을 정상 완료 경로로 종료시킨다."""
     engine.release.set()
+
+
+def _wait_until(predicate, timeout: float = WAIT) -> bool:
+    """조건이 참이 될 때까지 폴링한다 (상한 초과 시 False)."""
+    deadline = time.time() + timeout
+    while not predicate():
+        if time.time() > deadline:
+            return False
+        time.sleep(0.01)
+    return True
+
+
+class TestAbandon:
+    """갇힌 핸들의 슬롯 방출 (#137 — #136 부수 발견 ②).
+
+    파일 I/O에 갇힌 엔진 스레드는 중단시킬 수 없으므로(#136 조사), abandon은
+    스레드를 남긴 채 동시 실행 슬롯만 되돌린다. 갇힌 워커는 release를 늦게
+    set하는 페이크 엔진으로 흉내 낸다.
+    """
+
+    def test_abandon_active_handle_releases_slot_for_next(self, file_factory):
+        """활성 핸들을 방출하면 대기 중이던 다음 건이 시작된다 (max_concurrent=1)."""
+        service = DownloadService()
+        first = service.submit(_make_content())
+        assert file_factory.created.wait(WAIT)
+        assert file_factory.instances[0].started.wait(WAIT)  # 첫 건이 슬롯 점유 (갇힘 흉내)
+        second = service.submit(_make_content())
+        assert service.pending_count == 1  # 슬롯이 없어 대기
+
+        service.abandon(first)
+
+        # 두 번째 엔진이 생성·시작된다 — 갇힌 첫 건이 더는 시작을 막지 않는다
+        assert _wait_until(lambda: len(file_factory.instances) == 2)
+        assert file_factory.instances[1].started.wait(WAIT)
+
+        # 갇혔던 첫 워커가 나중에 깨어나는 상황 — finally의 discard는 멱등이라 무해
+        _finish(file_factory.instances[0])
+        _finish(file_factory.instances[1])
+        assert first.wait(WAIT)
+        assert second.wait(WAIT)
+        assert _wait_until(lambda: service.active_count == 0)
+
+    def test_abandon_pending_handle_removes_from_queue(self, file_factory):
+        """대기 중 핸들의 방출은 큐에서 제거한다 — 시작되지 않는다."""
+        service = DownloadService()
+        first = service.submit(_make_content())
+        assert file_factory.created.wait(WAIT)
+        assert file_factory.instances[0].started.wait(WAIT)
+        second = service.submit(_make_content())
+        assert service.pending_count == 1
+
+        service.abandon(second)
+
+        assert service.pending_count == 0
+        _finish(file_factory.instances[0])
+        assert first.wait(WAIT)
+        assert len(file_factory.instances) == 1  # 두 번째 엔진은 생성되지 않았다
 
 
 class TestDownloaderSelection:

--- a/tests/unit/test_qt_bridge.py
+++ b/tests/unit/test_qt_bridge.py
@@ -43,10 +43,14 @@ class FakeService:
 
     def __init__(self):
         self.submissions: list[dict] = []
+        self.abandoned: list = []
 
     def submit(self, content, **kwargs):
         self.submissions.append({"content": content, **kwargs})
         return FakeHandle(kwargs["data"])
+
+    def abandon(self, handle):
+        self.abandoned.append(handle)
 
 
 class FakeLogger:
@@ -244,6 +248,55 @@ class TestCompletion:
         bridge.resume()
 
         assert events == [("paused", item), ("resumed", item)]
+
+
+class StuckHandle(FakeHandle):
+    """파일 I/O에 갇힌 워커 흉내 — wait가 절대 끝나지 않는다 (#136·#137)."""
+
+    def __init__(self, data):
+        super().__init__(data)
+        self.wait_timeouts: list = []
+
+    def wait(self, timeout=None) -> bool:
+        self.wait_timeouts.append(timeout)
+        return False
+
+
+class TestRemoveThreads:
+    """중지·정리 경로의 대기 상한 (#137 — #136 제안 ①).
+
+    구 removeThreads는 타임아웃 없는 wait로, 갇힌 워커 상태에서 유저의
+    유일한 행동(중지·종료)이 앱을 얼렸다. 이제 상한 초과 시 슬롯을
+    방출(service.abandon)하고 참조만 정리한다.
+    """
+
+    def test_stuck_worker_gives_up_and_abandons_slot(self, bridge):
+        item = _make_item()
+        bridge.start(item)
+        stuck = StuckHandle(_submission(bridge)["data"])
+        bridge.handle = stuck
+
+        bridge.removeThreads()  # 갇힌 워커 — 여기서 영원히 기다리면 앱 프리즈다
+
+        assert stuck.wait_timeouts and all(
+            t is not None and t > 0 for t in stuck.wait_timeouts
+        )  # 무한 대기(None) 금지
+        assert bridge._service.abandoned == [stuck]  # 슬롯 방출 — 다음 다운로드가 시작될 수 있다
+        assert bridge.handle is None
+        assert bridge.task is None
+
+    def test_normal_exit_is_not_abandoned(self, bridge):
+        """정상 종료 워커는 방출하지 않는다 — 기존 정리 경로 무변경."""
+        item = _make_item()
+        bridge.start(item)
+        handle = bridge.handle
+
+        bridge.removeThreads()
+
+        assert handle.wait_calls == 1
+        assert bridge._service.abandoned == []
+        assert bridge.handle is None
+        assert bridge.task is None
 
 
 class _FakeHttpResponse:

--- a/tests/unit/test_write_probe.py
+++ b/tests/unit/test_write_probe.py
@@ -1,0 +1,170 @@
+"""시작 전 쓰기 프로브 검증 (#137 — #136 제안 ②).
+
+프로브는 제물 스레드 + join(timeout)으로 감싼다 — 존재 검사조차 무응답
+마운트에서는 메인 스레드를 매달 수 있기 때문이다 (#136 조사). 무응답
+마운트 자체는 실드라이브 없이 재현할 수 없으므로, 프로브 내부의 I/O
+호출(tempfile.mkstemp)을 반환하지 않는 함수로 바꿔 흉내 낸다 — 프로브가
+검사하는 것이 바로 그 호출이므로 대체가 재현으로 유효하다.
+
+downloadItem 연동은 실제 모델·뷰·시그널 배선으로 검증한다 (#125 교훈).
+"""
+
+import threading
+
+import pytest
+
+import content.manager as manager_mod
+from content.data import ContentItem
+from content.manager import ContentManager, probe_writable
+from content.view import ContentListView
+from download.state import DownloadState
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """위젯의 썸네일·파일 크기 조회 스레드가 실네트워크에 나가지 않게 차단한다."""
+
+    class _FailingSession:
+        def head(self, *args, **kwargs):
+            raise RuntimeError("network disabled in tests")
+
+        def get(self, *args, **kwargs):
+            raise RuntimeError("network disabled in tests")
+
+    monkeypatch.setattr("content.widget.get_thread_session", lambda: _FailingSession())
+    monkeypatch.setattr("content.network.get_thread_session", lambda: _FailingSession())
+
+
+class TestProbeWritable:
+    def test_writable_directory_passes_and_leaves_no_residue(self, tmp_path):
+        assert probe_writable(str(tmp_path)) == (True, "")
+        assert list(tmp_path.iterdir()) == []  # 프로브 파일 잔재 없음
+
+    def test_missing_directory(self, tmp_path):
+        assert probe_writable(str(tmp_path / "없는폴더")) == (False, "missing")
+
+    def test_permission_error_is_denied(self, tmp_path, monkeypatch):
+        """권한 오류가 정상적으로 오류로 반환되는 경우 (예: 로컬 읽기 전용)."""
+
+        def deny(*args, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(manager_mod.tempfile, "mkstemp", deny)
+        assert probe_writable(str(tmp_path)) == (False, "denied")
+
+    def test_hanging_io_times_out(self, tmp_path, monkeypatch):
+        """무응답 마운트 흉내 — 파일 생성 호출이 반환하지 않으면 상한에서 포기한다.
+
+        RaiDrive가 SFTP 권한 오류(ZFS 풀 루트)를 Windows 오류로 전파하지
+        못하고 매달리는 실측 증상(#136)의 재현이다. 갇힌 제물 스레드는
+        테스트 종료 전에 release로 깨워 잔류를 막는다.
+        """
+        release = threading.Event()
+
+        def hang(*args, **kwargs):
+            release.wait(5)  # 반환하지 않는 I/O 흉내
+            raise PermissionError(13, "belated")
+
+        monkeypatch.setattr(manager_mod.tempfile, "mkstemp", hang)
+        writable, reason = probe_writable(str(tmp_path), timeout_s=0.2)
+        release.set()
+
+        assert (writable, reason) == (False, "timeout")
+
+
+# ================================================================ downloadItem 연동
+
+
+def _metadata(title: str) -> dict:
+    return {
+        "title": title,
+        "category": "게임",
+        "channelName": "채널",
+        "createdDate": "2026-07-30",
+        "duration": 60,
+    }
+
+
+def _make_item(download_path: str, title: str) -> ContentItem:
+    return ContentItem(
+        "https://chzzk.naver.com/video/1",
+        _metadata(title),
+        [["1080", "http://example.invalid/1080"]],
+        "1080",
+        "http://example.invalid/1080",
+        download_path,
+        "video",
+        None,
+    )
+
+
+@pytest.fixture
+def manager(qapp):
+    view = ContentListView()
+    m = ContentManager(view)
+    yield m, view
+    view.deleteLater()
+    qapp.processEvents()
+
+
+class TestDownloadItemWriteGate:
+    def test_unwritable_path_fails_before_start(self, manager, qapp, tmp_path, monkeypatch):
+        """완료 조건: 쓰기 불가 경로는 다운로드 시작 전에 카드 실패로 끝난다."""
+        m, view = manager
+        # 프로브 판정 자체는 위 단위 테스트가 고정한다 — 여기서는 배선만 본다
+        monkeypatch.setattr(manager_mod, "probe_writable", lambda d: (False, "denied"))
+
+        item = _make_item(str(tmp_path), "쓰기 불가 항목")
+        m.model.addItem(item)
+        qapp.processEvents()
+        requested, finished_all = [], []
+        m.downloadRequested.connect(requested.append)
+        m.finishedAllRequested.connect(lambda: finished_all.append(True))
+
+        m.downloadItem()
+
+        assert requested == []  # 다운로드가 시작되지 않는다
+        assert item.downloadState is DownloadState.FAILED
+        assert item.stateMessage == "Failed to save file"  # 번역기 미설치 — 키 원문
+        assert finished_all == [True]  # 배치는 종료 신호까지 간다
+        widget = view.indexWidget(m.model.index(0, 0))
+        assert widget.statusLabel.text().startswith("Download failed")  # 카드에 명확히 표시
+
+    def test_timeout_probe_fails_the_same_way(self, manager, qapp, tmp_path, monkeypatch):
+        """무응답(timeout)도 같은 안내다 — 유저에게는 '저장할 수 없는 경로'라는 같은 사실."""
+        m, _view = manager
+        monkeypatch.setattr(manager_mod, "probe_writable", lambda d: (False, "timeout"))
+        item = _make_item(str(tmp_path), "무응답 항목")
+        m.model.addItem(item)
+        qapp.processEvents()
+
+        m.downloadItem()
+
+        assert item.downloadState is DownloadState.FAILED
+        assert item.stateMessage == "Failed to save file"
+
+    def test_missing_path_keeps_invalid_path_message(self, manager, qapp, tmp_path):
+        """존재하지 않는 경로는 기존 안내(Invalid file path)를 유지한다 — 실프로브 경유."""
+        m, _view = manager
+        item = _make_item(str(tmp_path / "없는폴더"), "경로 없음 항목")
+        m.model.addItem(item)
+        qapp.processEvents()
+
+        m.downloadItem()
+
+        assert item.downloadState is DownloadState.FAILED
+        assert item.stateMessage == "Invalid file path"
+
+    def test_writable_path_proceeds_to_download(self, manager, qapp, tmp_path):
+        """완료 조건: 정상 경로는 회귀 없음 — 실프로브를 지나 다운로드 요청이 나간다."""
+        m, _view = manager
+        item = _make_item(str(tmp_path), "정상 항목")
+        m.model.addItem(item)
+        qapp.processEvents()
+        requested = []
+        m.downloadRequested.connect(requested.append)
+
+        m.downloadItem()
+
+        assert requested == [item]
+        assert item.downloadState is DownloadState.WAITING  # 시작 전이 — 상태 전이는 브리지 몫


### PR DESCRIPTION
**요약**

저장할 수 없는 경로(예: RaiDrive로 마운트한 ZFS 풀 루트 `Z:/` — 권한 없음)를 지정하면, 지금까지는 0B에서 조용히 멈추고 중지 버튼을 누르면 앱이 응답 없음이 됐습니다. 이제 다운로드를 시작하기 전에 그 경로에 실제로 파일을 만들어 보고, 안 되면 카드에 "다운로드 실패 — 파일 저장에 실패했습니다"로 바로 알립니다. 또 워커가 갇힌 상태에서도 중지·앱 종료가 2초 안에 반응하고, 갇힌 다운로드가 다음 다운로드의 시작을 막지 않습니다.

⚠️ **이 PR은 #135 위에 쌓여 있습니다** — 실패 카드 표시 배선을 재사용하기 때문입니다. #135 머지 전까지 diff에 #135 커밋이 함께 보이며, #135 머지 후 신규 커밋(ea46598)만 남습니다.

## 관련 이슈

Closes #137

참조: #136 조사 보고(https://github.com/honey720/chzzk-vod-downloader-v2/issues/136#issuecomment-5130702765)의 제안 ①·② 구현. **전제 정정 반영**: `Z:/` 루트는 드라이브 루트라서가 아니라 ZFS 데이터풀 집합소로 쓰기 권한이 없는 것이며, 매달림은 RaiDrive가 SFTP 권한 오류를 Windows 오류로 전파하지 못하는 증상이다.

## 변경 내용

**② 시작 전 쓰기 프로브 (`content/manager.py`)**
- 기존 사전 검사(`downloadItem`의 `os.path.exists`)를 **같은 자리에서** 존재+쓰기 프로브(`probe_writable`)로 확장 — 새 구조 없음. 실제 파일 생성·삭제로 확인한다 (`os.access`는 네트워크 파일시스템 권한을 신뢰할 수 없다).
- 검사 전체를 **제물 스레드 + join(5초)** 로 감쌌다 — 존재 검사조차 무응답 마운트에서는 메인 스레드를 매달 수 있다(#136 조사). 결과 구분: 경로 없음(missing) → 기존 "Invalid file path" 유지 / 권한 없음(denied)·무응답(timeout) → "Failed to save file" 카드 실패(#134 배선·기존 번역 키 재사용, 신규 번역 없음).
- 사유(reason)와 경로는 로그로 남는다.

**① 중지·정리 경로의 대기 상한 (`download/qt_bridge.py`)**
- `removeThreads()`의 `handle.wait()`에 상한 2초. 초과 시 경고 로그 + 슬롯 방출 + 참조 정리.
- `DownloadService.abandon(handle)` 신설 (`core/services/download_service.py`): 갇힌 핸들을 큐·활성 집합에서 방출해 슬롯을 회수한다. 갇혔던 스레드가 나중에 깨어나 run()이 끝나면 finally의 discard는 멱등이라 무해하다.

## 판단과 근거

**1. 타임아웃 시 정리 누락은 없다 — 지연될 뿐이다.** 부분 산출물 정리(`_cleanup_partial`)의 수행 주체는 wait가 아니라 **엔진 스레드**(run 꼬리)다. wait는 완료를 관찰만 하므로, 대기를 포기해도 정리는 생략되지 않고 갇힌 스레드가 깨어나는 시점에 수행된다(영원히 갇히면 영원히 안 되지만, 그 경우는 어차피 이전에도 정리가 불가능했다). 포기 후 유저가 곧바로 재시작해도 산출물 경로 유일화(#105 — 같은 제목이면 " (n)" 부여)와 산출물별 임시 폴더가 옛 워커와의 파일 충돌을 막는다.

**2. 상한 2초의 근거.** 정상 중지는 워커가 청크 단위로 상태를 확인해 대부분 즉시 끝난다. 2초를 넘기는 경우는 네트워크 read 블록(최대 30초) 또는 갇힌 I/O인데, 어느 쪽도 메인 스레드가 기다려줄 가치가 없다 — 전자는 스스로 끝나고(finally가 슬롯 정리, abandon과 멱등), 후자는 영원히 안 끝난다.

**3. `abandon`을 서비스에 신설한 것.** 슬롯 영구 점유(#136 부수 발견 ②)는 서비스의 `_active` 집합 문제라 앱 계층에서 풀 수 없다. 추가는 공개 메서드 하나이며 기존 계약(submit/handle) 무변경 — 승인된 #137 범위의 최소 확장으로 판단했다. 스레드 강제 종료는 불가능하므로(#136 조사) "스레드는 남기고 슬롯만 회수"가 상한이다.

**4. 프로브의 제물 스레드 비용 수용.** 이슈의 판단대로 감당 가능하다고 본다 — 프로브는 다운로드 시작 시점 1회뿐이고, 누수는 무응답 경로를 반복 지정할 때만 시도당 데몬 스레드 1개다. 추가 대가: 무응답 경로에서 메인 스레드가 프로브 상한(5초)만큼 대기한다 — 무한 침묵 대신 유한 대기 후 명확한 실패라는 교환이고, 배치에 무응답 경로 항목이 여럿이면 항목당 5초씩 순차 지연된다(카드마다 실패가 표시되므로 진행은 보인다).

**5. ⓪(단계 debug 로그)는 이번에 넣지 않았다.** 프로브가 시작 시점 사례(#136 실측)를 흡수하므로 완료 조건에 불필요하다. 전송 **중간**에 매달리는 경우의 진단 수단으로는 여전히 유용하니, 필요해지면 #136 제안 3(무진행 워치독)과 함께 별도 판단을 요청드린다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] `uv run pytest` 전체 통과 (356 passed, 2 skipped — Windows 로컬)
- [x] 새 로직에 대한 테스트 추가됨:
  - `test_write_probe.py` (신규): 프로브 정상/missing/denied/**무응답(반환하지 않는 mkstemp) → timeout 포기** + downloadItem 실배선(쓰기 불가 → 시작 전 카드 실패·배치 종료 신호, 정상 경로 → 다운로드 요청 회귀 없음)
  - `test_qt_bridge.py`: 갇힌 핸들(wait가 끝나지 않음)에서 removeThreads가 유한 시간 내 반환·슬롯 방출 / 정상 종료는 방출하지 않음 / **무한 대기(timeout=None) 금지 박제**
  - `test_download_service.py`: abandon이 활성 슬롯을 회수해 다음 건이 시작됨(max_concurrent=1) / 대기 중 핸들은 큐에서 제거됨 / 늦게 깨어난 워커와의 멱등성
- 무응답 마운트의 재현 근거: 프로브가 검사하는 I/O 호출 자체를 반환하지 않는 함수로 대체 — #136 조사에서 원인이 "반환하지 않는 syscall"로 특정됐으므로 대체가 유효한 재현이다 (실드라이브 스모크는 오너 검증 요청).

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호: #137 (`DownloadService.abandon` 공개 메서드 추가 — 기존 계약 무변경의 최소 확장, 근거는 판단 3)

## 리뷰어에게

- **실드라이브 스모크 요청**: ① ZFS 풀 루트(`Z:/`)를 지정하고 다운로드 → 5초 내 카드에 "다운로드 실패 — 파일 저장에 실패했습니다"가 떠야 합니다. ② (가능하면) 다운로드 중 마운트를 끊고 0B 정지 상태를 만든 뒤 중지 버튼 → 앱이 2초 내 반응하고, 다른 항목의 다운로드가 시작되어야 합니다.
- 프로브 상한 5초·대기 상한 2초는 조정 가능한 상수입니다 (`content/manager.py`, `download/qt_bridge.py` 상단).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
