### PR TITLE
fix: 출력 파일 OSError 봉쇄 — 통지 없는 스레드 사망·실패 후 무한 루프 해소 (#147)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -365,6 +365,7 @@ class BaseDownloader(ABC):
                         for part_num in range(self.s.adjust_threads):
                             if not self.s.remaining_ranges:
                                 break
+                            submitted = None
                             with self.lock:
                                 if part_num not in self.future_dict:
                                     item = self.s.remaining_ranges.pop(0)
@@ -374,9 +375,14 @@ class BaseDownloader(ABC):
                                         self._peak_threads, self.s.future_count
                                     )
                                     self._log_item_start(part_num, item)
-                                    future = executor.submit(self._download_item, item, part_num)
-                                    future.add_done_callback(self._download_completed_callback)
-                                    self.future_dict[part_num] = (item, future)
+                                    submitted = executor.submit(self._download_item, item, part_num)
+                                    self.future_dict[part_num] = (item, submitted)
+                            if submitted is not None:
+                                # 콜백 등록은 락 밖에서 한다 (#147) — 이미 끝난 future의
+                                # 콜백은 등록 시점에 이 스레드에서 동기 실행되는데,
+                                # 콜백의 슬롯 정리가 같은 락을 잡으므로(비재진입 락)
+                                # 락 안에서 등록하면 즉시 실패하는 작업에서 교착한다
+                                submitted.add_done_callback(self._download_completed_callback)
 
                     # (2) 주기적으로 상태 확인 (non-blocking)
                     tm.sleep(0.1)
@@ -459,22 +465,34 @@ class BaseDownloader(ABC):
     # ============ 다운로드 조정 및 콜백 메서드 ============
 
     def _download_completed_callback(self, future):
+        """future 종료 콜백 — 성공·실패 모든 경로에서 슬롯을 반드시 정리한다 (#147 E2).
+
+        정리를 finally로 보장하는 이유: 실패 경로에서 future_dict 항목이
+        남으면 실행 루프의 종료 조건(잔여 작업·활성 future 없음)이 영원히
+        성립하지 않아, 실패를 통지하고도 루프가 무한 회전했다(#146 감사에서
+        워커 OSError 주입으로 실측). 실패 시 part_num을 얻을 수 없으므로
+        future 동일성으로 등록 항목을 찾는다.
         """
-        특정 future(스레드)가 끝났을 때 호출되는 콜백.
-        """
+        part_num = None
         try:
             part_num = future.result()
-            # part_num 식별 후 future_dict에서 제거
-            with self.lock:
-                if part_num in self.future_dict:
-                    del self.future_dict[part_num]
-                    self.s.future_count -= 1
-            self.update_progress()  # 즉각적 진행도 반영
-
         except Exception as e:
-            # 일부 스레드가 오류로 중단된 경우
-            self._on_failed(e)
-            self.logger.log_error("Thread failed", e)
+            # 여기까지 오는 예외는 워커가 잡지 않은 것 — 네트워크 오류는
+            # 워커가 이미 잡아 재큐 규칙(#131)을 태우므로, 남는 것은 출력
+            # 파일 OSError(디스크 부족·마운트 해제·잠금) 등 파일시스템류다.
+            # 재시도해도 같은 결과라 재큐 상한(#131)에 태우지 않고 즉시
+            # 전체 실패로 보낸다 — 상한(10회)까지 도는 것은 유저가 보는
+            # 멈춤 시간일 뿐이다.
+            self._fail_fatally(e, "Thread failed — failing download")
+        finally:
+            with self.lock:
+                for pn, (_item, fut) in list(self.future_dict.items()):
+                    if fut is future:
+                        del self.future_dict[pn]
+                        self.s.future_count -= 1
+                        break
+        if part_num is not None:
+            self.update_progress()  # 즉각적 진행도 반영
 
     def _requeue_failed(self, item, part_num: int, exc: BaseException) -> None:
         """예외 발생 시 작업을 다시 다운로드할 수 있도록 remaining_ranges에 등록.

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -39,8 +39,15 @@ class FileDownloader(BaseDownloader):
 
     run_thread_name = "DownloadThread"
     worker_pool_prefix = "DownloadWorker"
-    # 구 코드와 동일하게 요청 예외만 실패로 처리한다 — 그 외 예외는 전파
-    _failure_exceptions = (requests.RequestException,)
+    # OSError를 실패 처리에 추가한다 (#147 E1). 구 코드(요청 예외만)는 run
+    # 스레드의 출력 파일 I/O 오류(이어받기 스캔·수신 준비 — 디스크 부족·
+    # 마운트 해제)를 실패 처리 밖으로 흘려보냈다: 통지·로그·부분 산출물
+    # 정리가 전부 생략된 채 스레드만 죽었다(#146 감사 실측). 엔진에서 잡는
+    # 쪽이 _cleanup_partial까지 수행해 정리 품질이 높다. Exception 전체로
+    # 넓히지 않는 것은 selections 명시 거부(NotImplementedError)의 전파를
+    # 박제 계약대로 보존하기 위함이다 — 그 밖의 예상 밖 예외는 서비스의
+    # 최후 방어선(_run_handle)이 실패로 환원한다.
+    _failure_exceptions = (requests.RequestException, OSError)
 
     def __init__(self, data, logger, **callbacks):
         super().__init__(data, logger, **callbacks)

--- a/core/services/download_service.py
+++ b/core/services/download_service.py
@@ -333,7 +333,17 @@ class DownloadService:
                     handle.logger.save_and_close()
                     return
 
-            engine.run()
+            try:
+                engine.run()
+            except Exception as e:
+                # 엔진이 스스로 실패 처리하지 못한 예외의 최후 방어선 (#147 E1).
+                # 여기서 잡지 않으면 이 워커 스레드만 죽고 통지·로그가 모두
+                # 사라져, 카드가 영원히 '다운로드 중'으로 남는다(#146 감사에서
+                # ENOSPC 주입으로 실측). 다운로더별 _failure_exceptions 설정과
+                # 무관하게 "실행 스레드의 침묵 사망" 부류 전체를 막는다.
+                handle._relay_failed(e)
+                handle.logger.log_exception("Download failed", e)
+                handle.logger.save_and_close()
         finally:
             handle._done.set()
             with self._lock:

--- a/tests/unit/core/test_engine_oserror_containment.py
+++ b/tests/unit/core/test_engine_oserror_containment.py
@@ -1,0 +1,226 @@
+"""출력 파일 OSError의 봉쇄 검증 (#147 — #146 감사 E1·E2).
+
+감사 실측(#146)에서 확인된 두 결함을 고정한다:
+- E1: run 스레드에서 난 OSError(이어받기 스캔·수신 준비)가 file 다운로더의
+  실패 처리를 통과해 스레드 밖으로 탈출 — 통지·로그 없이 카드가 영구
+  '다운로드 중'으로 남는다
+- E2: 워커에서 난 OSError는 통지는 되지만 future 슬롯이 정리되지 않아
+  실행 루프가 영원히 끝나지 않는다
+
+주입 지점은 감사와 동일하게 출력 파일의 open이다. builtins.open 전역 패치
+대신 file_downloader 모듈 전역에 open을 얹는다(모듈 스코프 섀도잉) — 주입이
+엔진 코드에만 미치고 pytest 내부 파일 I/O에는 영향이 없다. 첫 open
+(_prepare_output의 'wb')은 정상으로 두고 'r+b'(스캔·워커 쓰기)만 센다.
+
+서비스 계층(_run_handle)의 최후 방어선은 별도로 검증한다 — 엔진이 어떤
+예외를 흘리더라도(다운로더 구현 실수 포함) 통지·로그·슬롯 반환이 보장돼야
+한다는 부류 전체의 계약이다.
+"""
+
+import os
+import threading
+import time
+
+from core.models.download_state import DownloadState
+from core.services.download_service import DownloadService
+
+import core.downloaders.file_downloader as fd_module
+from core.downloaders.file_downloader import FileDownloader
+from download.data import DownloadData
+
+MB = 1024 * 1024
+TOTAL_SIZE = 4 * MB  # 해상도 144 → 파트 1MB → 4파트
+
+
+def _content_bytes(total: int) -> bytes:
+    pattern = bytes(range(251))
+    return (pattern * (total // len(pattern) + 1))[:total]
+
+
+CONTENT = _content_bytes(TOTAL_SIZE)
+
+
+class RecordingLogger:
+    """엔진·서비스 로거 인터페이스의 기록용 최소 구현 — 그 외 호출은 무시한다."""
+
+    def __init__(self):
+        self.errors: list[str] = []
+        self.closed = 0
+
+    def log_error(self, message, exception=None):
+        self.errors.append(message)
+
+    def log_exception(self, message, exception=None):
+        self.errors.append(message)
+
+    def save_and_close(self):
+        self.closed += 1
+
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+class RangeResponse:
+    """Range 요청 구간을 청크로 흘리는 가짜 응답 (run 하네스와 동일 최소 인터페이스)."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i : i + chunk_size]
+
+
+class RangeSession:
+    """head/get(Range)을 지원하는 가짜 세션 — 실네트워크 없음."""
+
+    def __init__(self, content: bytes):
+        self._content = content
+        self.headers = {"content-length": str(len(content))}
+
+    def head(self, url, **kwargs):
+        return self
+
+    def raise_for_status(self):
+        pass
+
+    def get(self, url, headers=None, **kwargs):
+        start, end = map(int, (headers or {})["Range"].removeprefix("bytes=").split("-"))
+        return RangeResponse(self._content[start : end + 1])
+
+
+def _make_engine(tmp_path, monkeypatch):
+    """가짜 세션이 연결된 엔진과 (data, logger, output, failures)를 준비한다."""
+    output = str(tmp_path / "out.mp4")
+    data = DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output,
+        resolution=144,
+        content_type="video",
+    )
+    logger = RecordingLogger()
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: RangeSession(CONTENT))
+    failures: list[BaseException] = []
+    engine = FileDownloader(data, logger, on_failed=failures.append)
+    return engine, data, logger, output, failures
+
+
+def _inject_output_oserror(monkeypatch, output: str, fail_from: int) -> None:
+    """출력 파일의 'r+b' open을 fail_from번째 호출부터 OSError(ENOSPC)로 만든다.
+
+    1회차 = _get_remaining_ranges의 이어받기 스캔(run 스레드), 2회차부터 =
+    워커의 파트 쓰기 — fail_from으로 E1/E2 지점을 선택한다.
+    """
+    calls = {"n": 0}
+    real_open = open
+
+    def guarded_open(file, mode="r", *args, **kwargs):
+        if file == output and mode == "r+b":
+            calls["n"] += 1
+            if calls["n"] >= fail_from:
+                raise OSError(28, "No space left on device (테스트 주입)")
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(fd_module, "open", guarded_open, raising=False)
+
+
+# ================================================================ E1 — run 스레드
+
+
+def test_run_thread_oserror_is_contained_as_failure(tmp_path, monkeypatch):
+    """run 스레드의 OSError는 실패 콜백·로그·부분 산출물 정리로 귀결된다 (E1).
+
+    고장 커밋에서는 OSError가 run() 밖으로 그대로 전파되어 이 테스트가
+    예외로 실패한다 — 실제 앱에서는 통지 없는 스레드 사망이었다.
+    """
+    engine, data, logger, output, failures = _make_engine(tmp_path, monkeypatch)
+    _inject_output_oserror(monkeypatch, output, fail_from=1)
+
+    data.model.start()
+    engine.run()
+
+    assert len(failures) >= 1 and isinstance(failures[0], OSError)
+    assert any("Download failed" in m for m in logger.errors)
+    assert not os.path.exists(output)  # 부분 산출물 정리(_cleanup_partial)
+
+
+# ================================================================ E2 — 워커
+
+
+def test_worker_oserror_stops_loop_and_notifies(tmp_path, monkeypatch):
+    """워커의 OSError는 전체 실패로 종결되고 실행 루프가 끝난다 (E2).
+
+    고장 커밋에서는 future 슬롯이 정리되지 않아 루프가 영원히 돌았다 —
+    join 타임아웃 단언이 그 회귀를 잡는다. 파일시스템 오류는 재큐(#131)에
+    태우지 않고 즉시 실패시킨다 — 디스크 부족·마운트 해제는 재시도해도
+    같은 결과라, 상한(10회)까지 도는 것은 유저가 보는 멈춤 시간일 뿐이다.
+    """
+    engine, data, logger, output, failures = _make_engine(tmp_path, monkeypatch)
+    _inject_output_oserror(monkeypatch, output, fail_from=2)  # 스캔 1회는 허용
+
+    data.model.start()
+    thread = threading.Thread(target=engine.run, daemon=True)
+    thread.start()
+    thread.join(timeout=15)
+
+    assert not thread.is_alive()  # 루프 종료 — 고장 커밋에서는 여기서 실패
+    assert len(failures) >= 1 and isinstance(failures[0], OSError)
+    assert engine.future_dict == {}  # 슬롯 잔류 없음 (finally 정리)
+    assert engine.state is DownloadState.WAITING  # _fail_fatally의 중단 경로
+    assert not os.path.exists(output)  # 부분 산출물 정리
+
+
+# ================================================================ 서비스 최후 방어선
+
+
+class _ExplodingEngine:
+    """어떤 이유로든 run()이 예외를 흘리는 엔진 — 부류 전체의 대역."""
+
+    run_thread_name = "DownloadThread"
+    requires_base_url_resolution = False
+    requires_key_resolution = False
+
+    def __init__(self, **kwargs):
+        pass
+
+    def run(self):
+        raise RuntimeError("엔진이 처리하지 못한 예외 (테스트 주입)")
+
+
+def test_service_relays_unexpected_engine_exception(tmp_path, monkeypatch):
+    """엔진이 흘린 예외도 서비스가 실패로 통지하고 로그·슬롯을 정리한다 (E1 근본).
+
+    다운로더별 _failure_exceptions가 어떻게 설정돼 있든, 실행 스레드가
+    통지 없이 죽는 부류 전체를 _run_handle의 방어선이 막아야 한다.
+    고장 커밋에서는 on_failed가 오지 않아 단언이 실패한다.
+    """
+    data = DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=str(tmp_path / "out.mp4"),
+        resolution=144,
+        content_type="video",
+    )
+    service = DownloadService()
+    monkeypatch.setattr(
+        DownloadService, "_select_downloader", lambda self, content: _ExplodingEngine
+    )
+    logger = RecordingLogger()
+    failures: list[BaseException] = []
+
+    handle = service.submit(data.content, data=data, task_logger=logger, on_failed=failures.append)
+
+    assert handle.wait(10)
+    assert len(failures) == 1 and isinstance(failures[0], RuntimeError)
+    assert any("Download failed" in m for m in logger.errors)
+    assert logger.closed >= 1
+    # 슬롯 반환은 _done.set() 직후 같은 finally에서 일어난다 — wait 반환과
+    # 미세한 시차가 있어 짧게 기다린 뒤 단언한다
+    deadline = time.time() + 2
+    while service.active_count and time.time() < deadline:
+        time.sleep(0.01)
+    assert service.active_count == 0  # 슬롯 반환


### PR DESCRIPTION
다운로드 중 디스크가 가득 차거나 외장 드라이브가 빠지는 등 저장에 실패하면, 지금까지는 앱이 실패를 알려주지 못하고 카드가 영원히 "다운로드 중"으로 남거나(전송 전) 실패 표시 후에도 내부적으로 계속 도는(전송 중) 문제가 있었습니다. 이제 어느 시점에 나든 실패가 카드에 표시되고, 로그에 원인이 남고, 다음 다운로드를 막지 않습니다. #146 저장 경로 감사에서 주입 실측으로 확인된 결함(E1·E2)의 수정입니다.

## 관련 이슈

Closes #147

## 변경 내용

**근본 — 서비스 최후 방어선** (`core/services/download_service.py`): `_run_handle`이 `engine.run()`을 감싸지 않아, 엔진이 흘린 예외는 무엇이든 워커 스레드만 죽이고 통지·로그가 모두 사라졌습니다. 지금은 OSError가 문제지만 예상 못한 어떤 예외든 같은 부류입니다 — try/except로 실패 통지(`_relay_failed`)·로그(`log_exception`)·로거 정리를 보장합니다.

**보강 — 엔진 실패 분류** (`core/downloaders/file_downloader.py`): `_failure_exceptions`에 `OSError`를 추가합니다. 엔진에서 잡히면 `_cleanup_partial`(부분 산출물 삭제)까지 수행돼 서비스 방어선보다 정리 품질이 높습니다. `Exception` 전체로 넓히지 않은 이유: selections 명시 거부(`NotImplementedError`)의 전파를 단언하는 박제 계약(tests/unit/core/test_download_plan.py)을 보존하기 위함이며, 그 밖의 예상 밖 예외는 위 방어선이 받습니다.

**E2 — 워커 실패 시 슬롯 정리를 finally로 보장** (`core/downloaders/base.py`): 실패 경로에서 `future_dict`가 정리되지 않아 실행 루프의 종료 조건이 영원히 성립하지 않았습니다. 정리를 finally로 옮기고(실패 시 part_num을 얻을 수 없어 future 동일성으로 탐색), 워커의 파일시스템 오류는 `_fail_fatally`로 **즉시 전체 실패**시킵니다.

**#131 재큐 상한과의 상호작용 (판단 근거)**: 네트워크 오류는 워커(`_download_item`)가 잡아 기존 재큐 규칙(영구 2회·일시 10회)을 그대로 탑니다 — 이 PR은 그 분류를 건드리지 않습니다. 콜백까지 올라오는 예외는 워커가 잡지 않은 파일시스템류뿐이고, 디스크 부족·마운트 해제는 재시도해도 같은 결과라 재큐 상한에 태우지 않고 즉시 실패시킵니다 — 상한(10회)까지 도는 것은 유저가 보는 멈춤 시간일 뿐입니다.

**수정 중 발견한 교착 회피** (`core/downloaders/base.py`): 실행 루프가 `self.lock`을 쥔 채 `add_done_callback`을 등록하는데, 이미 끝난 future는 콜백을 등록 시점에 같은 스레드에서 동기 실행합니다. 새 finally 정리가 같은 락(비재진입)을 잡으므로 즉시 실패하는 작업에서 교착했습니다 — 콜백 등록을 락 밖으로 옮겼습니다.

## 검증

- [x] `uv run ruff check .` 통과
- [x] 전체 테스트 통과 — `359 passed, 2 skipped` (Windows 로컬)
- [x] 새 로직에 대한 테스트 추가됨 — `tests/unit/core/test_engine_oserror_containment.py` 3건. **고장 커밋에서 3건 전부 실패함을 먼저 확인**(E1: OSError 전파로 에러, E2: join 타임아웃, 서비스: on_failed 미도달) 후 수정을 적용해 통과로 전환.
- [x] 수정 후 #146 감사의 원 주입 스크립트 재실행으로 확인:
  - E1(ENOSPC, run 스레드): `스레드 생존 False / on_failed 1회(OSError 28) / 로그 'Download failed'`
  - E2(ENOSPC, 워커): `스레드 생존 False / 상태 WAITING / on_failed 1회 / future_dict 잔류 0`

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- 근본 vs 보강의 구분은 위 변경 내용에 명시했습니다 — 방어선이 부류 전체를 막고, `_failure_exceptions` 확대는 정리 품질(부분 산출물 삭제)을 위한 것입니다.
- `Thread failed` 로그 줄은 `Thread failed — failing download`로 바뀝니다. `scripts/summarize_download_log.py`의 파싱 계약에는 이 줄이 없음을 확인했습니다.
- 참고: 대응 이슈 #147은 #146 감사(승인 라벨 미부착 상태)의 ⓐ 항목을 오너 지시로 착수한 것입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
