### PR TITLE
test: 저장 경로 특성별 remux 실측 케이스 — 3-OS 릴리즈 게이트 편입 (#146)

### DIFF
--- a/tests/unit/core/test_ffmpeg_output_paths.py
+++ b/tests/unit/core/test_ffmpeg_output_paths.py
@@ -1,0 +1,181 @@
+"""저장 경로 특성별 remux 파이프라인 실측 (#145 — #144·#146 조사 후속).
+
+pytest tmp_path 베이스에는 세 OS 모두 공백이 없어(리눅스 /tmp/..., Windows
+%LOCALAPPDATA%\\Temp, macOS /private/var/folders/...) 기존 테스트 전체가
+공백 경로를 한 번도 밟지 않는 사각지대가 있었다(#146 감사: 긴 디렉토리
+프리픽스·산출물 이름 충돌·NFC/NFD도 동일). 이 파일은 그 경로 특성들에서
+경로 조립(build_output_path/temp_dir_for)과 실제 ffmpeg remux까지 —
+다운로드 꼬리 구간 — 를 실행으로 고정한다.
+
+파일 이름에 "ffmpeg"를 넣은 이유: release.yml의 "Verify ffmpeg (3-OS)"
+스텝이 `pytest -q -k ffmpeg`를 Windows·macOS·리눅스에서 릴리즈마다
+실행하므로, 여기 담긴 케이스는 macOS·리눅스 실측이 영구적으로 따라온다.
+
+케이스 구분(#144 조사 ⑤ · #145 확장):
+- 공용(3-OS): 내부 공백·다중 공백, Windows에서도 합법인 특수문자 조합,
+  긴 디렉토리 프리픽스(제목 절단 경로), 산출물 이름 충돌(" (n)" 회피)
+- 공용이되 확인 대상: U+00A0·U+3000 — Windows NTFS 실측은 통과했고
+  macOS·리눅스는 이 테스트의 CI 실행이 확정한다. 특정 OS에서 폴더 생성
+  자체가 실패하면(테스트 설계 문제, 앱 결함 아님) 그 OS만 조건부 skip으로
+  내린다
+- Windows skip: 후행 공백 — Windows는 생성 시 조용히 절단한다(실측)
+- macOS 전용: NFC/NFD 정규화 무관 조회 단언
+- 다루지 않는 것: 실제 권한 거부(러너별 권한 구성이 달라 불안정 — 모의
+  방식의 tests/unit/test_write_probe.py가 담당), OS 장경로 설정 의존 구간
+  (전체 260자 초과는 러너 레지스트리 설정에 좌우된다)
+"""
+
+import os
+import subprocess
+import sys
+import unicodedata
+
+import pytest
+
+from core.utils.ffmpeg import get_ffmpeg_exe, read_in_chunks, remux_stream
+from core.utils.paths import build_output_path, temp_dir_for
+
+
+@pytest.fixture(scope="module")
+def fmp4_input(tmp_path_factory):
+    """1초짜리 h264 fMP4 — remux 공급용(모듈당 1회 생성).
+
+    fMP4를 쓰는 이유: 리눅스 동봉 빌드의 mpegts demux SIGSEGV(#94)를 타지
+    않아 3-OS 전부에서 스킵 없이 돈다. libx264는 동봉 GPL 빌드 3-OS 공통
+    (tests/unit/core/test_ffmpeg_utils.py의 _generate와 같은 근거).
+    """
+    path = str(tmp_path_factory.mktemp("space-src") / "src.mp4")
+    subprocess.run(
+        [
+            get_ffmpeg_exe(),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=duration=1:size=64x64:rate=10",
+            "-c:v",
+            "libx264",
+            "-movflags",
+            "frag_keyframe+empty_moov",
+            "-f",
+            "mp4",
+            path,
+        ],
+        check=True,
+    )
+    return path
+
+
+def _run_download_tail(directory: str, fmp4_input: str) -> str:
+    """다운로드 꼬리 구간을 실경로로 실행한다: 조립 → 임시 폴더 → remux → 크기 확인."""
+    out = build_output_path(directory, "제목 스페이스 검증", 1080)
+    temp_dir = temp_dir_for(out)
+    os.makedirs(temp_dir)  # 엔진과 동일하게 exist_ok 없이 (m3u8 _prepare_output과 같은 조건)
+    remux_stream(read_in_chunks(fmp4_input), out)
+    assert os.path.getsize(out) > 0
+    return out
+
+
+# 공용(3-OS) 케이스 — id에 코드포인트를 명시한다(화면 표기로는 U+00A0과
+# U+0020을 구분할 수 없다). U+00A0은 macOS에서 Option+Space로 쉽게 입력되는
+# 문자라 #144류 제보 재현의 핵심 후보다.
+PORTABLE_DIRNAMES = [
+    pytest.param("test test", id="space-U+0020"),
+    pytest.param("test  test", id="double-space"),
+    pytest.param("test\u00a0test", id="nbsp-U+00A0"),
+    pytest.param("test\u3000test", id="ideographic-space-U+3000"),
+    pytest.param("test #1", id="hash-with-space"),
+    pytest.param("test (1)", id="parens-with-space"),
+    pytest.param("my test&run", id="ampersand-with-space"),
+    pytest.param("한글 폴더", id="hangul-with-space"),
+]
+
+
+@pytest.mark.parametrize("dirname", PORTABLE_DIRNAMES)
+def test_ffmpeg_remux_into_special_char_dir(tmp_path, fmp4_input, dirname):
+    """공백·특수문자 폴더에서 경로 조립→임시 폴더→remux가 완주한다 (#144)."""
+    directory = tmp_path / dirname
+    directory.mkdir()
+
+    _run_download_tail(str(directory), fmp4_input)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows는 생성 시 후행 공백을 조용히 절단한다(실측) — POSIX 전용 케이스",
+)
+def test_ffmpeg_remux_into_trailing_space_dir(tmp_path, fmp4_input):
+    """후행 공백 폴더(POSIX 합법)에서도 파이프라인이 완주한다."""
+    directory = tmp_path / "trail test "
+    directory.mkdir()
+
+    _run_download_tail(str(directory), fmp4_input)
+
+
+# ================================================================ 긴 디렉토리 프리픽스
+
+
+def test_ffmpeg_remux_into_long_directory_prefix(tmp_path, fmp4_input):
+    """긴 폴더 경로에서 제목 절단(~해시) 경로로 remux가 완주한다 (#146 감사 확장).
+
+    디렉토리를 210자 이상으로 만들어 전체 경로 상한(_MAX_FULLPATH=240)에
+    걸리게 한다 — 제목이 " ~해시" 표식으로 절단되는 경로가 실행된다.
+    260자를 넘기지는 않는다: 그 구간은 OS 장경로 설정(레지스트리)에
+    좌우되어 러너별 결과가 달라진다(문서화된 미커버 구간).
+    """
+    # 목표 길이를 정확히 맞춘다 — 러너마다 tmp_path 베이스 길이가 달라,
+    # 고정 폭 세그먼트를 쌓으면 총길이가 튀어 Windows 기본 상한(260)을
+    # 장경로 설정 여부에 따라 넘나들 수 있다
+    # 225 = 전체 경로가 상한(_MAX_FULLPATH=240)을 확실히 넘도록 하는 값
+    # (파일명 "제목 스페이스 검증 1080p.mp4" ≈ 20자 → 총 246자 → 절단 발동).
+    # 절단 후 임시 폴더까지 260자 미만이라 Windows 장경로 설정과 무관하다
+    target = 225
+    directory = tmp_path
+    while len(str(directory)) < target:
+        directory = directory / ("d" * min(50, target - len(str(directory)) - 1))
+    directory.mkdir(parents=True)
+
+    out = _run_download_tail(str(directory), fmp4_input)
+
+    assert "~" in os.path.basename(out)  # 절단 표식 경로를 실제로 지났다
+    assert len(out) <= 260  # Windows 기본 MAX_PATH 안 — 장경로 설정 무의존
+
+
+# ================================================================ 산출물 이름 충돌
+
+
+def test_ffmpeg_remux_output_collision_gets_suffix(tmp_path, fmp4_input):
+    """같은 이름 산출물이 이미 있으면 " (1)"로 회피한 경로에 remux가 완주한다."""
+    directory = tmp_path / "collision test"
+    directory.mkdir()
+    first = build_output_path(str(directory), "제목 스페이스 검증", 1080)
+    with open(first, "wb") as f:
+        f.write(b"existing")
+
+    out = _run_download_tail(str(directory), fmp4_input)
+
+    assert out != first and out.endswith(" (1).mp4")
+    assert os.path.getsize(first) == 8  # 기존 파일은 덮어쓰지 않는다 (#105)
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="macOS 파일 시스템의 정규화 무관 조회 검증 — 타 OS는 코드포인트 그대로 저장되어 성립하지 않는다(실측)",
+)
+def test_ffmpeg_space_path_nfd_dir_visible_via_nfc(tmp_path, fmp4_input):
+    """NFD로 만든 한글 폴더가 NFC 경로 문자열로도 보이고 파이프라인이 완주한다.
+
+    macOS 로컬 디스크(APFS/HFS+)의 정규화 무관 조회가 실제로 성립하는지의
+    실측이다. 이 단언이 깨지는 환경(정규화 민감 마운트 등)이라면 "겉보기
+    같은 경로가 존재하지 않음"류 증상(#144)이 코드 결함 없이 발생할 수 있다.
+    """
+    nfc_name = "한글 테스트"
+    nfd_name = unicodedata.normalize("NFD", nfc_name)
+    (tmp_path / nfd_name).mkdir()
+
+    nfc_path = str(tmp_path / nfc_name)
+    assert os.path.isdir(nfc_path)
+    _run_download_tail(nfc_path, fmp4_input)


### PR DESCRIPTION
지금까지 테스트는 공백이나 특수문자가 든 저장 폴더를 한 번도 사용해 본 적이 없었습니다 — #144(macOS 공백 경로 제보) 조사에서 드러난 사각지대입니다. 이 PR은 공백·특수 공백 문자·긴 경로·이름 충돌 같은 경로 특성들을 실제 ffmpeg 변환까지 실행하는 테스트로 고정하고, 릴리즈 때마다 Windows·macOS·리눅스 세 OS에서 자동으로 돌게 만듭니다.

## 관련 이슈

Closes #146

> #145는 #146(저장 경로 감사)에 흡수되어 닫혔습니다(오너 확인). 이 PR은 #146의 남은 실행 항목(테스트 확장)이며, 머지 시 #146이 종결됩니다 — 감사의 ⓑ 목록은 #146 마무리 코멘트에 Phase 5 이관으로 기록되어 있습니다.

## 변경 내용

`tests/unit/core/test_ffmpeg_output_paths.py` 신규 (승인된 #145의 확장 범위 — 공백 한정에서 저장 경로 전반으로):

- **공용(3-OS)**: 내부 공백·2연속 공백·`test #1`·`test (1)`·`my test&run`·한글, **확인 대상** U+00A0·U+3000(소스에 ` `/`　` 명시 표기 — 육안 구분 불가 문자), **긴 디렉토리 프리픽스**(경로 상한 240 초과 → 제목 `~해시` 절단 경로 실행, 총길이는 260 미만으로 설계해 Windows 장경로 설정과 무관), **산출물 이름 충돌**(`" (1)"` 회피 + 기존 파일 무손상 단언)
- **Windows skip**: 후행 공백(생성 시 절단 실측), **macOS 전용**: NFD 폴더의 NFC 조회 단언
- 입력은 fMP4 — 리눅스 동봉 빌드 mpegts SIGSEGV(#94) 스킵을 타지 않아 3-OS 무스킵
- 다루지 않는 것(파일 docstring에 문서화): 실제 권한 거부(러너별 불안정 — 모의 방식의 test_write_probe가 담당), 260자 초과 구간(러너 레지스트리 의존)

## 검증

- [x] `uv run ruff check .` 통과
- [x] 전체 테스트 통과 — `376 passed, 4 skipped` (Windows 로컬; skip 4 = 본 파일의 win32/darwin 마커 2 + 기존 2)
- [x] `-k ffmpeg` 매칭 실측: `pytest -q -k ffmpeg --collect-only`에서 본 파일 12건 전부 수집 확인 — release.yml "Verify ffmpeg (3-OS)" 스텝에 자동 포함됨
- [x] 긴 경로 케이스는 절단 미발동 상태(210자)에서 실패를 먼저 확인한 뒤 발동 길이(225자)로 확정 — 단언이 실제로 절단 경로를 지나는지 검증함

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- U+00A0·U+3000은 macOS·리눅스에서 미실측이라 "확인 대상"으로 공용에 넣었습니다 — 다음 릴리즈의 Verify ffmpeg 스텝이 첫 실측이 됩니다. 특정 OS에서 폴더 **생성 자체가** 실패하면(앱 결함 아님) 그 케이스만 조건부 skip으로 내리는 후속을 제안하겠습니다.
- macOS 전용 NFC/NFD 단언이 깨지면 릴리즈가 차단되지만, 깨진다는 사실 자체가 #144류 증상의 원인 확정이라 조사 가치가 있습니다(이슈 본문 리스크 항목 참조).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

