### PR TITLE
chore: CI 3-OS 매트릭스 + 실패 GUI 스크린샷 아티팩트 (#154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             exit 1
           fi
 
-  lint-test:
+  test:
     strategy:
       fail-fast: false
       matrix:
@@ -82,3 +82,16 @@ jobs:
           path: test-screenshots/
           if-no-files-found: ignore
           retention-days: 14
+  # 룰셋(protect main branch)의 필수 체크 'lint-test'로 보고하는 집계 관문.
+  # 매트릭스 OS가 하나라도 실패·취소되면 실패한다
+  lint-test:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All OS jobs passed
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "::error::매트릭스 결과: ${{ needs.test.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,12 @@ jobs:
           fi
 
   lint-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -33,19 +37,48 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install Qt system deps
+      - name: Install Qt system deps (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             xvfb libegl1 libgl1 libxkbcommon-x11-0 libxcb-icccm4 \
             libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-shape0 libxcb-xinerama0 libxcb-cursor0 libdbus-1-3
+            libxcb-shape0 libxcb-xinerama0 libxcb-cursor0 libdbus-1-3 \
+            fonts-noto-cjk
 
       - name: Sync dependencies
         run: uv sync
 
       - name: Lint
+        if: runner.os == 'Linux'
         run: uv run ruff check .
 
-      - name: Test
+      # 리눅스: 기존 검증 구성(xvfb) 유지 — 실플랫폼(xcb)에 가장 근접
+      - name: Test (Linux, xvfb)
+        if: runner.os == 'Linux'
+        env:
+          CVDV2_SHOT_DIR: test-screenshots
         run: xvfb-run -a uv run pytest --maxfail=5 -q
+
+      # Windows·macOS: offscreen — release.yml 기동 스모크와 같은 방식.
+      # QT_QPA_FONTDIR 지정 필수: offscreen은 시스템 폰트를 자동으로 쓰지
+      # 않아 미지정 시 한글이 전부 □로 렌더된다 (#154 실측)
+      - name: Test (Windows/macOS, offscreen)
+        if: runner.os != 'Linux'
+        env:
+          QT_QPA_PLATFORM: offscreen
+          QT_QPA_FONTDIR: ${{ runner.os == 'Windows' && 'C:\Windows\Fonts' || '/System/Library/Fonts' }}
+          CVDV2_SHOT_DIR: test-screenshots
+        run: uv run pytest --maxfail=5 -q
+
+      # 실패한 GUI 테스트의 위젯 캡처(conftest 훅)를 OS별 아티팩트로.
+      # 실패가 없으면 업로드 자체가 생략된다
+      - name: Upload GUI screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-screenshots-${{ matrix.os }}
+          path: test-screenshots/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@
 어느 위치에서 pytest를 실행하든 import할 수 있게 한다.
 """
 
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -25,3 +27,44 @@ def load_mock_response():
         return (MOCK_RESPONSES_DIR / name).read_text(encoding="utf-8")
 
     return _load
+
+
+# ============ 실패 GUI 테스트 스크린샷 (#154) ============
+# 실패한 테스트의 최상위 위젯을 grab해 PNG로 남긴다. 기본은 실패 시에만,
+# CVDV2_SHOT_ALL=1이면 성공 테스트도 찍는다(전체 갤러리용).
+# offscreen에서도 실픽셀이 렌더됨은 실측 확인 — 단 폰트는 QT_QPA_FONTDIR 필요.
+SHOT_DIR = Path(os.environ.get("CVDV2_SHOT_DIR", "test-screenshots"))
+SHOT_ALL = os.environ.get("CVDV2_SHOT_ALL") == "1"
+
+
+def _screenshot_slug(nodeid: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", nodeid)[:120]
+
+
+def _capture_screenshots(nodeid: str, outcome: str) -> list[str]:
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        return []
+    SHOT_DIR.mkdir(parents=True, exist_ok=True)
+    saved = []
+    for n, w in enumerate(app.topLevelWidgets()):
+        if not w.isVisible() or w.width() == 0 or w.height() == 0:
+            continue
+        name = f"{sys.platform}-{outcome}-{_screenshot_slug(nodeid)}-{n}.png"
+        if w.grab().save(str(SHOT_DIR / name), "PNG"):
+            saved.append(name)
+    return saved
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    if rep.when != "call":
+        return
+    if rep.failed or SHOT_ALL:
+        saved = _capture_screenshots(item.nodeid, "FAIL" if rep.failed else "PASS")
+        if saved:
+            rep.sections.append(("screenshots", "\n".join(saved)))


### PR DESCRIPTION
지금까지 PR 테스트는 리눅스에서만 돌아 macOS·Windows 문제를 릴리즈 때에야 발견했습니다. 이제 세 OS에서 PR마다 전체 테스트가 돌고, GUI 테스트가 실패하면 그 화면이 스크린샷 아티팩트로 남아 무엇이 깨졌는지 눈으로 확인할 수 있습니다.

## 관련 이슈

Closes #154

## 변경 내용

- **`ci.yml` lint-test를 3-OS 매트릭스로 확장** — 리눅스는 기존 검증 구성(xvfb) 유지, Windows·macOS는 offscreen(release.yml 기동 스모크와 같은 방식). `QT_QPA_FONTDIR` 지정 필수: offscreen은 시스템 폰트를 자동으로 쓰지 않아 미지정 시 한글이 전부 □로 렌더됨을 실측으로 확인(#154 조사). 리눅스에는 `fonts-noto-cjk` 추가. Lint는 ubuntu에서 1회.
- **`tests/conftest.py`에 실패 스크린샷 훅** — 실패한 테스트의 최상위 위젯을 `QWidget.grab()`으로 캡처(offscreen에서 실픽셀 렌더 실측 확인). 기본은 실패 시에만(성공 갤러리는 `CVDV2_SHOT_ALL=1`), 파일명 `{os}-{FAIL|PASS}-{테스트명}.png`, OS별 아티팩트 `retention-days: 14`, 실패 없으면 업로드 생략.

## 검증

- [x] `uv run ruff check .` 통과 (훅 import 위치 E402 수정 포함)
- [x] 로컬 전체 테스트 통과 — `376 passed, 4 skipped` (훅 추가 후, Windows)
- [x] 훅은 고의 실패 GUI 테스트로 `win32-FAIL-...png` 생성·성공 시 무캡처를 사전 검증 (#154 조사)
- [ ] **이 PR의 CI 자체가 3-OS 첫 실행** — Windows·macOS 결과를 이 PR에서 확인

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역 변경 없음 — `.github/`은 소유자 본인 계정으로 작성·푸시됨 (protected-paths 조건 충족)

## 리뷰어에게

- 첫 3-OS 실행에서 OS별 조정(폰트 경로·타이밍)이 나올 수 있습니다 — 그 발견이 이 확장의 목적이므로, 실패 시 로그와 함께 스크린샷 아티팩트를 먼저 확인해 주세요.
- macOS의 `QT_QPA_FONTDIR=/System/Library/Fonts`는 이 PR의 CI가 첫 실측입니다. 한글이 □로 나오면 폰트 경로만 조정하면 됩니다.
- 병렬 3-OS 기준 예상 벽시계 시간 약 3~6분(Windows uv sync가 병목, setup-uv 캐시로 2회차부터 단축).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
