### PR TITLE
fix: 기본 저장 경로를 저장된 경로→시스템 다운로드 폴더→cwd로 — 첫 실행 저장 실패 해소 (#159)

### DIFF
--- a/application/mainWindow.py
+++ b/application/mainWindow.py
@@ -4,7 +4,7 @@ import platform
 import config.config as config
 
 from PySide6.QtWidgets import QMainWindow, QMessageBox, QFileDialog, QApplication
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import QStandardPaths, QTimer
 
 from config.dialog import SettingDialog
 from content.data import ContentItem
@@ -14,6 +14,26 @@ from download.state import DownloadState
 from ui.mainWindow import Ui_VodDownloader
 
 logger = logging.getLogger(__name__)
+
+
+def _default_download_path() -> str:
+    """시작 시 저장 경로 입력창의 초기값을 정한다 (#159 — #157 실측 근거).
+
+    cwd는 실행 방식에 따라 임의다 — macOS .app을 Finder/Dock으로 실행하면
+    cwd가 '/'(쓰기 불가)임을 CI에서 실측했고(#157), Windows도 바로가기의
+    '시작 위치' 설정에 좌우된다. 우선순위:
+    ① 유저가 마지막으로 쓴 경로(설정, 실존할 때만 — 외장 드라이브 분리 대비)
+    ② 시스템 다운로드 폴더(실존할 때만)
+    ③ cwd — 소스 실행(개발) 관례를 유지하는 최후 폴백
+    """
+    saved = config.load_config().get("downloadPath", "")
+    if saved and os.path.isdir(saved):
+        return saved
+    downloads = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.DownloadLocation)
+    if downloads and os.path.isdir(downloads):
+        return downloads
+    return os.getcwd()
+
 
 
 class VodDownloader(QMainWindow, Ui_VodDownloader):
@@ -45,7 +65,7 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
         """
         self.total_downloads = 0
         self.completed_downloads = 0
-        self.downloadPathInput.setText(os.getcwd())  # 초기 경로 설정
+        self.downloadPathInput.setText(_default_download_path())  # 초기 경로 (#159)
         self.downloadCountLabel.setText(self.downloadCountLabel.text().format(self.completed_downloads, self.total_downloads))  # 초기값 설정
 
     def setupThreadSignals(self):
@@ -126,6 +146,8 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
             QMessageBox.warning(self, self.tr("Warning"), self.tr("Path does not exist."))
             return
         # TODO:  코드 수정 및 테스트 예정
+        # 검증을 통과해 실사용되는 경로만 보존한다 — 다음 실행의 초기값 ① (#159)
+        self._rememberDownloadPath(downloadPath)
 
         self.contentManager.fetchContent(vod_url, cookies, downloadPath)
 
@@ -177,6 +199,13 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
             # 들어갔는가"를 로그로 재구성할 수 있게 한다
             logger.info("저장 경로 선택(경로 찾기): %r", downloadPath)
             self.downloadPathInput.setText(downloadPath)
+
+    def _rememberDownloadPath(self, path: str) -> None:
+        """실사용된 저장 경로를 설정에 보존한다 (#159) — _default_download_path의 ①."""
+        cfg = config.load_config()
+        if cfg.get("downloadPath") != path:
+            cfg["downloadPath"] = path
+            config.save_config(cfg)
 
     def onStop(self):
         """

--- a/config/config.py
+++ b/config/config.py
@@ -60,7 +60,10 @@ DEFAULT_CONFIG = {
         "NID_SES": ""
     },
     "afterDownload": "none",
-    "language": "en_US"
+    "language": "en_US",
+    # 유저가 마지막으로 쓴 저장 경로 (#159). 빈 값 = 미설정 → 시스템 다운로드
+    # 폴더 폴백. reorder_config가 여기 없는 키를 삭제하므로 등재가 보존의 전제다
+    "downloadPath": ""
 }
 
 # 설정 로드 함수

--- a/tests/unit/test_default_download_path.py
+++ b/tests/unit/test_default_download_path.py
@@ -1,0 +1,165 @@
+"""시작 시 기본 저장 경로 결정·보존 검증 (#159 — #157 실측 후속).
+
+#157 실측: macOS .app을 Finder/Dock으로 실행하면 cwd='/'(쓰기 불가)라
+기본값 os.getcwd()로는 첫 실행 유저의 첫 다운로드가 반드시 실패했다.
+초기값 우선순위(저장된 경로 → 시스템 다운로드 폴더 → cwd)와 실사용 경로의
+설정 보존을 실배선(윈도우 생성·버튼 클릭)으로 검증한다.
+
+config 로드·저장은 메모리로 격리한다 — 실유저 config.json 무접촉.
+"""
+
+import os
+
+import pytest
+
+import application.mainWindow as mw_mod
+import config.config as config_mod
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """조회·위젯 스레드가 실네트워크에 나가지 않게 차단한다."""
+
+    class _FailingSession:
+        def head(self, *args, **kwargs):
+            raise RuntimeError("network disabled in tests")
+
+        def get(self, *args, **kwargs):
+            raise RuntimeError("network disabled in tests")
+
+    monkeypatch.setattr("content.widget.get_thread_session", lambda: _FailingSession())
+    monkeypatch.setattr("content.network.get_thread_session", lambda: _FailingSession())
+    monkeypatch.setattr("content.network._session", _FailingSession())
+    monkeypatch.setattr("core.api.session._session", _FailingSession())
+
+
+@pytest.fixture
+def config_store(monkeypatch):
+    """config 로드·저장을 메모리 딕셔너리로 격리하고 저장 이력을 기록한다."""
+    store = {"cookies": {"NID_AUT": "", "NID_SES": ""}}
+    saves: list[dict] = []
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: dict(store))
+
+    def _save(cfg):
+        saves.append(dict(cfg))
+        store.clear()
+        store.update(cfg)
+
+    monkeypatch.setattr(config_mod, "save_config", _save)
+    return store, saves
+
+
+@pytest.fixture
+def window_factory(qapp, monkeypatch, config_store):
+    """팝업을 기록으로 대체한 실물 메인 윈도우를 만든다 (offscreen 실배선)."""
+    warnings = []
+    monkeypatch.setattr(
+        mw_mod.QMessageBox,
+        "warning",
+        lambda parent, title, text, *a, **k: warnings.append(text),
+    )
+    # 차단된 네트워크의 조회 실패는 critical로 온다 — 실모달이 뜨면
+    # offscreen 이벤트 루프가 영원히 대기하므로 기록으로 대체한다
+    monkeypatch.setattr(
+        mw_mod.QMessageBox,
+        "critical",
+        lambda parent, title, text, *a, **k: warnings.append(text),
+    )
+    made = []
+
+    def _make():
+        win = mw_mod.VodDownloader()
+        made.append(win)
+        return win
+
+    yield _make, warnings
+    for win in made:
+        win.close()
+        win.deleteLater()
+    qapp.processEvents()
+
+
+def test_downloadpath_key_registered_in_default_config():
+    """reorder_config가 DEFAULT_CONFIG 미등재 키를 삭제하므로 등재가 보존의 전제다."""
+    assert "downloadPath" in config_mod.DEFAULT_CONFIG
+    assert config_mod.DEFAULT_CONFIG["downloadPath"] == ""  # 빈 값 = 미설정
+
+
+def test_saved_path_wins(window_factory, config_store, tmp_path):
+    """저장된 경로가 실존하면 초기값 ①로 쓰인다."""
+    store, _saves = config_store
+    store["downloadPath"] = str(tmp_path)
+    make, _ = window_factory
+
+    assert make().downloadPathInput.text() == str(tmp_path)
+
+
+def test_missing_saved_falls_back_to_standard_downloads(
+    window_factory, config_store, tmp_path, monkeypatch
+):
+    """저장된 경로가 사라졌으면(외장 분리 등) 시스템 다운로드 폴더 ②로 간다."""
+    store, _saves = config_store
+    store["downloadPath"] = str(tmp_path / "분리된 드라이브")
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+
+    class _StubPaths:
+        StandardLocation = mw_mod.QStandardPaths.StandardLocation
+
+        @staticmethod
+        def writableLocation(kind):
+            return str(downloads)
+
+    monkeypatch.setattr(mw_mod, "QStandardPaths", _StubPaths)
+    make, _ = window_factory
+
+    assert make().downloadPathInput.text() == str(downloads)
+
+
+def test_standard_missing_falls_back_to_cwd(window_factory, config_store, tmp_path, monkeypatch):
+    """표준 폴더까지 없으면 cwd ③ — 소스 실행(개발) 관례 유지."""
+
+    class _StubPaths:
+        StandardLocation = mw_mod.QStandardPaths.StandardLocation
+
+        @staticmethod
+        def writableLocation(kind):
+            return str(tmp_path / "없는 폴더")
+
+    monkeypatch.setattr(mw_mod, "QStandardPaths", _StubPaths)
+    make, _ = window_factory
+
+    assert make().downloadPathInput.text() == os.getcwd()
+
+
+def test_used_path_is_persisted_on_fetch(window_factory, config_store, tmp_path, qapp):
+    """조회 관문을 통과해 실사용된 경로가 설정에 저장된다 — 버튼 클릭 실배선."""
+    _store, saves = config_store
+    make, _warnings = window_factory
+    win = make()
+    used = tmp_path / "space dir"
+    used.mkdir()
+    win.downloadPathInput.setText(str(used))
+    win.urlInput.setText("https://chzzk.naver.com/video/1")
+
+    win.fetchButton.click()
+    win.contentManager.threadpool.waitForDone(8000)
+    qapp.processEvents()
+
+    assert saves and saves[-1]["downloadPath"] == str(used)
+
+
+def test_rejected_path_is_not_persisted(window_factory, config_store, tmp_path, qapp):
+    """관문에서 거부된 경로는 저장되지 않는다."""
+    _store, saves = config_store
+    make, warnings = window_factory
+    win = make()
+    win.downloadPathInput.setText(str(tmp_path / "없는 폴더"))
+    win.urlInput.setText("https://chzzk.naver.com/video/1")
+
+    win.fetchButton.click()
+    qapp.processEvents()
+
+    assert "Path does not exist." in warnings
+    assert all("downloadPath" not in s or s["downloadPath"] == "" for s in saves)


### PR DESCRIPTION
macOS에서 앱을 처음 실행하면 저장 경로가 쓸 수 없는 곳(`/`)으로 잡혀 첫 다운로드가 반드시 실패했습니다(#157에서 CI 실측으로 확인). 이제 기본 저장 경로가 시스템 다운로드 폴더로 잡히고, 한 번 사용한 경로는 다음 실행에도 유지됩니다. 매번 경로를 다시 입력하던 불편도 함께 사라집니다.

## 관련 이슈

Closes #159

## 변경 내용

**초기값 결정** (`application/mainWindow.py::_default_download_path`): ① 마지막으로 실사용된 경로(실존할 때만 — 외장 분리 대비) → ② 시스템 다운로드 폴더(`QStandardPaths.DownloadLocation`, 실존할 때만) → ③ cwd.

**실사용 경로 보존**: 조회 관문(존재 검사)을 통과해 실제로 쓰인 경로만 `config.json`의 `downloadPath`에 저장 — 거부된 입력은 저장하지 않습니다.

**판단 근거 (지시된 판단 항목):**
- **표준 폴더 기본값 + 전 OS 적용**을 택했습니다. cwd는 실행 방식에 따라 임의라는 것이 실측 근거입니다 — macOS Finder/Dock은 `/`(#157: `W_OK=False`), Windows도 바로가기 '시작 위치'에 좌우됩니다. "cwd가 쓰기 불가할 때만 폴백"하는 macOS 한정 수정은 Windows의 같은 부류를 남기고, 관문(exists)과 프로브(mkstemp)를 시작 시점에 또 돌려야 해 기각했습니다. cwd는 ③ 최후 폴백으로 남겨 소스 실행(개발) 관례를 보존합니다.
- **config 스키마 판단**: `downloadPath` 키를 `DEFAULT_CONFIG`에 추가했지만 **CONFIG_VERSION 범프·마이그레이션은 하지 않았습니다.** 근거: 읽기가 `.get(기본값)`으로 부재를 허용해 구 config(v2)가 그대로 동작하고, 구 버전 앱이 새 config를 읽어도 무해합니다(추가 키 무시… 단 구 버전의 `reorder_config`가 미등재 키를 삭제하므로 다운그레이드 시 저장 경로만 초기화 — 데이터 손상 없음). 즉 값 이관이 필요한 변경이 아니라 마이그레이션의 대상이 아닙니다. `DEFAULT_CONFIG` 등재는 현 버전 `reorder_config`의 미등재 키 삭제로부터 보존하기 위한 필수 조치입니다(테스트로 고정).
- **기존 유저 영향**: Windows에서 exe 더블클릭 유저의 체감 기본값이 "exe 폴더" → "다운로드 폴더"로 한 번 바뀝니다. 이후에는 실사용 경로가 보존되므로 첫 조회 한 번이면 기존 습관이 그대로 유지됩니다. 소스 실행(개발)은 저장 경로가 없고 다운로드 폴더도 있는 환경이라 ②로 가는데, 개발 중엔 경로를 명시 입력하는 흐름이라 실영향 미미 — 순수 cwd 의존이 필요한 헤드리스 스크립트는 무변경입니다(`--output` 또는 cwd, CLI 관례 유지).

## 검증

- [x] `uv run ruff check .` 통과
- [x] 전체 테스트 통과 — `382 passed, 4 skipped` (Windows 로컬)
- [x] 새 로직 테스트 6건(`tests/unit/test_default_download_path.py`) — 실배선(윈도우 생성·fetchButton.click), config 로드·저장은 메모리 격리로 실유저 config 무접촉. **고장 커밋에서 5건 실패 확인**(1건은 "거부 경로 미저장"이라 구코드에서 공허 참) 후 수정 적용으로 통과 전환. `DEFAULT_CONFIG` 등재 여부도 테스트로 고정(등재 누락 시 `reorder_config`가 키를 삭제하는 회귀 방지).

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지 — 변경은 app 계층과 config뿐)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- 보존 시점을 "조회 관문 통과 시"로 잡았습니다 — 다운로드 완료 시점보다 이르지만, 검증(존재)을 통과해 실사용이 확정된 순간이고 카드별 경로 편집(다운로드 직전 변경)까지 쫓지 않는 최소 구현입니다. Phase 5 관문 통합 때 보존 시점도 일원화 대상입니다.
- 관련 플레이크 수정(#160)은 성격이 달라(제품 동작 변경 vs 테스트 안정화) 별도 PR로 분리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
