### PR TITLE
test: 저속 재큐 임계 주입으로 pause/resume 테스트의 러너 속도 의존 제거 (#160)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -145,6 +145,11 @@ class BaseDownloader(ABC):
     postprocess_kind: str = "remux"
     # run()이 실패 콜백으로 환원할 예외 타입 — 그 외 예외는 전파한다
     _failure_exceptions: tuple[type[BaseException], ...] = (Exception,)
+    # 저속 재큐 판정 임계(KB/s) — 기본값 100은 구 규칙 그대로 불변.
+    # 속성으로 둔 이유(#160): pause/resume 통합 테스트가 느린 CI 러너에서
+    # 정상적인 저속 재큐를 유발해 간헐 실패했다(3회 중 2회). 테스트가 0으로
+    # 두면 판정이 비활성화되어 러너 속도와 무관해진다. 제품 동작 무변경
+    _slow_speed_threshold_kb_s: float = 100.0
 
     def __init__(
         self,

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -163,7 +163,7 @@ class FileDownloader(BaseDownloader):
                                     total_size,
                                     speed_kb_s,
                                 )
-                                if speed_kb_s < 100:
+                                if speed_kb_s < self._slow_speed_threshold_kb_s:
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -231,7 +231,7 @@ class HlsAesDownloader(BaseDownloader):
                             self._check_speed_and_update_progress(
                                 part_num, downloaded_size, total_ranges, speed_kb_s
                             )
-                            if speed_kb_s < 100:
+                            if speed_kb_s < self._slow_speed_threshold_kb_s:
                                 slow_count += 1
                                 if slow_count > 5:
                                     # 속도가 너무 느리면 스레드 재시작

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -174,7 +174,7 @@ class M3U8Downloader(BaseDownloader):
                                 self._check_speed_and_update_progress(
                                     part_num, downloaded_size, total_ranges, speed_kb_s
                                 )
-                                if speed_kb_s < 100:
+                                if speed_kb_s < self._slow_speed_threshold_kb_s:
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작

--- a/tests/unit/core/test_file_downloader_run.py
+++ b/tests/unit/core/test_file_downloader_run.py
@@ -215,6 +215,12 @@ def test_pause_resume_then_complete(tmp_path, monkeypatch):
     engine, data, logger, output, finished, failures = _make_engine(
         tmp_path, monkeypatch, throttle=0.005
     )
+    # 저속 재큐 판정 비활성 (#160) — 느린 CI 러너에서는 스로틀된 가짜
+    # 다운로드의 측정 속도가 임계(100KB/s) 아래로 떨어져 정상적인 저속
+    # 재큐가 발동, 재큐 순환으로 완료 상한(60초)을 넘겼다(macOS 실측).
+    # 이 테스트의 검증 대상은 일시정지·재개이지 저속 규칙이 아니다 —
+    # 저속 규칙은 test_file_downloader_rules.py가 가짜 시계로 박제한다
+    engine._slow_speed_threshold_kb_s = 0
 
     data.model.start()
     thread = _run_in_thread(engine)

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -293,6 +293,11 @@ def test_pause_resume_then_complete(tmp_path, monkeypatch):
     engine, data, logger, output, finished, failures, merge_starts = _make_engine(
         tmp_path, monkeypatch, chunks_per_segment=120, throttle=0.005
     )
+    # 저속 재큐 판정 비활성 (#160) — 느린 CI 러너에서는 위 오탐 회피
+    # (누적 바이트 키우기)로도 부족해 정상적인 저속 재큐 warning이 남아
+    # "전이 warning 0건" 단언이 깨졌다(macOS 실측). 검증 대상은 일시정지·
+    # 재개이지 저속 규칙이 아니다 — 저속 규칙은 rules 테스트가 박제한다
+    engine._slow_speed_threshold_kb_s = 0
 
     data.model.start()
     thread = _run_in_thread(engine)


### PR DESCRIPTION
3-OS CI(#154 적용) 이후 macOS에서 pause/resume 테스트 2건이 3회 실행 중 2회 간헐 실패해 CI 신뢰도를 깎았습니다. 원인은 앱이 아니라 테스트가 러너 속도에 의존하는 구조였고, 이제 러너가 아무리 느려도 결정적으로 통과합니다.

## 관련 이슈

Closes #160

## 변경 내용

- **저속 재큐 판정 임계를 주입 가능하게** (`core/downloaders/base.py`): 세 다운로더에 하드코딩돼 있던 `100`(KB/s)을 `BaseDownloader._slow_speed_threshold_kb_s = 100.0` 클래스 속성으로 승격. **기본값 불변 — 제품 동작 무변경.** 저속 규칙 자체의 박제(tests/unit/core/test_*_rules.py — 가짜 시계 주입 방식)는 시나리오·단언 무수정 그대로다.
- **pause/resume 테스트 2건이 임계 0 주입**: 이 테스트들의 검증 대상은 일시정지·재개이지 저속 규칙이 아니다 — 느린 러너에서 정상적인 저속 재큐가 발동하며 m3u8은 "전이 warning 0건" 단언과 충돌하고, file은 재큐 순환으로 완료 상한(60초)을 초과했다(macOS CI 실측, PR #156 코멘트).

**인과·면역의 실측 증명 (로컬):**
1. 임계 기본값을 `1e9`(항상 저속 판정 = 병리적으로 느린 러너와 등가)로 강제 → **미수정 테스트 2건이 macOS CI와 동일한 방식으로 실패** (file: 60초 상한 소진, m3u8: warning 단언) — 인과 확정
2. 같은 조건에서 **수정된 테스트는 2건 모두 4초에 통과** — 러너 속도 면역 확정
3. 기본값 100 복원 후 전체 스위트 `376 passed, 4 skipped`

## 검증

- [x] `uv run ruff check .` 통과
- [x] 전체 테스트 통과 — `376 passed, 4 skipped` (Windows 로컬)
- [x] 고장 재현·수정 검증은 위 실측 증명 1·2 (병리 조건에서 fail → pass 전환)

## 아키텍처 체크

- [x] core → app import 없음 (단방향 의존 유지)
- [x] view에서 core 직접 호출 없음 (viewmodel 경유)
- [x] 제안 구역(구조/의존성/플러그인 인터페이스) 변경 없음 — 있다면 승인된 이슈 번호:

## 리뷰어에게

- 기본 저장 경로 수정(#159, PR #161)과 별도 PR로 분리했습니다 — 제품 동작 변경 vs 테스트 안정화로 성격과 리버트 단위가 다르기 때문입니다.
- 대안으로 "타임아웃 연장"을 검토했으나 기각 — file 실패의 뿌리가 대기 부족이 아니라 저속 재큐 무한 순환이라 연장으로는 못 잡습니다(재현 실측에서 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
