### PR TITLE
chore: v2.9.3

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # 빌드 실행 파일은 이 상수를 쓴다. 정본과의 불일치는 단위 테스트
 # (tests/unit/test_download_log_phases.py)가 잡는다 — 버전을 올릴 때는
 # pyproject.toml과 이 상수를 함께 갱신할 것.
-APP_VERSION = "2.9.3-rc1"
+APP_VERSION = "2.9.3"
 
 
 @functools.lru_cache(maxsize=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cvdv2"
-version = "2.9.3-rc1"
+version = "2.9.3"
 description = "Chzzk VOD Downloader v2"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "cvdv2"
-version = "2.9.3rc1"
+version = "2.9.3"
 source = { virtual = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },


### PR DESCRIPTION
## 요약

버전을 `2.9.3`으로 올립니다. 코드 변경은 없습니다.

- `pyproject.toml` version + `uv.lock` + `config/config.py` APP_VERSION 동반 갱신
- **이 PR을 머지하면 태그 `v2.9.3`이 자동 생성되고 릴리즈 빌드가 시작됩니다** (같은 버전의 rc 프리릴리즈는 Auto Tag가 정리)

v2.9.3-rc1 검증 완료에 따른 정식 승격입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)