### PR TITLE
fix: 저장 경로 보존 시점을 유저 의사표시 3곳으로 확장 — 조회 없이도 기억 (#165)

### DIFF
--- a/application/mainWindow.py
+++ b/application/mainWindow.py
@@ -96,6 +96,7 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
         self.urlInput.returnPressed.connect(self.onFetch)
         self.fetchButton.clicked.connect(self.onFetch)
         self.downloadPathButton.clicked.connect(self.onFindPath)
+        self.downloadPathInput.editingFinished.connect(self._rememberPathIfValid)
         self.settingButton.clicked.connect(self.onSetting)
         self.clearFinishedButton.clicked.connect(self.contentManager.clrearFinishedItems)
         self.downloadButton.clicked.connect(self.onDownloadPause)
@@ -199,6 +200,20 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
             # 들어갔는가"를 로그로 재구성할 수 있게 한다
             logger.info("저장 경로 선택(경로 찾기): %r", downloadPath)
             self.downloadPathInput.setText(downloadPath)
+            self._rememberPathIfValid()
+
+    def _rememberPathIfValid(self) -> None:
+        """입력창의 경로가 실존 폴더면 보존한다 (#165).
+
+        보존 시점은 유저의 의사표시 세 곳 — 경로 찾기 선택, 입력 확정
+        (editingFinished), 창 닫기 — 이라 조회 없이 경로만 바꿔도 다음
+        실행의 초기값 ①이 된다. isdir 관문은 커밋된 미완성·오타 경로가
+        초기값을 오염시키지 않게 한다. 조회(exists)·다운로드(probe) 관문과의
+        기준 통합은 Phase 5 관문 통합(#146 ⓑ1)에서 viewmodel로 옮길 때 함께.
+        """
+        path = self.downloadPathInput.text().strip()
+        if path and os.path.isdir(path):
+            self._rememberDownloadPath(path)
 
     def _rememberDownloadPath(self, path: str) -> None:
         """실사용된 저장 경로를 설정에 보존한다 (#159) — _default_download_path의 ①."""
@@ -206,6 +221,7 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
         if cfg.get("downloadPath") != path:
             cfg["downloadPath"] = path
             config.save_config(cfg)
+            logger.info("저장 경로 보존: %r", path)
 
     def onStop(self):
         """
@@ -356,4 +372,6 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
                 return
             else:
                 self.stopDownload()
+        # 확정(포커스 이탈) 없이 바로 닫는 경우의 보존 (#165)
+        self._rememberPathIfValid()
         event.accept()  # 창 닫기 진행

--- a/tests/unit/test_default_download_path.py
+++ b/tests/unit/test_default_download_path.py
@@ -163,3 +163,73 @@ def test_rejected_path_is_not_persisted(window_factory, config_store, tmp_path, 
 
     assert "Path does not exist." in warnings
     assert all("downloadPath" not in s or s["downloadPath"] == "" for s in saves)
+
+
+def test_find_path_selection_is_persisted_without_fetch(
+    window_factory, config_store, tmp_path, monkeypatch
+):
+    """경로 찾기로 폴더를 고르면 조회 없이도 저장된다 (#165).
+
+    다이얼로그 선택은 그 자체가 의사표시고 실존 폴더만 반환되므로,
+    조회 관문을 기다릴 이유가 없다 — "마지막으로 사용한 위치가
+    기억됩니다"(v2.9.3 릴리즈 노트)의 실체화.
+    """
+    _store, saves = config_store
+    make, _warnings = window_factory
+    win = make()
+    chosen = tmp_path / "고른 폴더"
+    chosen.mkdir()
+    monkeypatch.setattr(
+        mw_mod.QFileDialog,
+        "getExistingDirectory",
+        staticmethod(lambda *a, **k: str(chosen)),
+    )
+
+    win.downloadPathButton.click()
+
+    assert saves and saves[-1]["downloadPath"] == str(chosen)
+
+
+def test_committed_valid_path_is_persisted(window_factory, config_store, tmp_path):
+    """입력 확정(editingFinished)된 실존 폴더는 조회 없이 저장된다 (#165)."""
+    _store, saves = config_store
+    make, _warnings = window_factory
+    win = make()
+    typed = tmp_path / "타이핑 폴더"
+    typed.mkdir()
+    win.downloadPathInput.setText(str(typed))
+
+    win.downloadPathInput.editingFinished.emit()
+
+    assert saves and saves[-1]["downloadPath"] == str(typed)
+
+
+def test_committed_missing_path_is_not_persisted(window_factory, config_store, tmp_path):
+    """미실존(입력 중·오타) 경로는 확정돼도 저장되지 않는다 — 초기값 오염 방지 (#165)."""
+    _store, saves = config_store
+    make, _warnings = window_factory
+    win = make()
+    win.downloadPathInput.setText(str(tmp_path / "입력 중"))
+
+    win.downloadPathInput.editingFinished.emit()
+
+    assert all("downloadPath" not in s or s["downloadPath"] == "" for s in saves)
+
+
+def test_valid_path_is_persisted_on_close(window_factory, config_store, tmp_path):
+    """확정(포커스 이탈) 없이 창을 닫아도 실존 폴더면 저장된다 (#165).
+
+    "경로를 바꾸고 다운로드 없이 앱을 껐다 켠다"는 제보 시나리오 그대로 —
+    setText는 editingFinished를 발생시키지 않으므로 closeEvent 보존이
+    마지막 그물이다.
+    """
+    _store, saves = config_store
+    make, _warnings = window_factory
+    win = make()
+    typed = tmp_path / "닫기 전 폴더"
+    typed.mkdir()
+    win.downloadPathInput.setText(str(typed))
+
+    win.close()
+
+    assert saves and saves[-1]["downloadPath"] == str(typed)


### PR DESCRIPTION
## 요약

Closes #165

저장 경로를 바꾸고 조회(다운로드) 없이 앱을 재실행하면 바꾼 경로가 사라지던 문제를 고칩니다. 보존 시점이 조회 관문 통과 시(`onFetch`) 한 곳뿐이었던 것을, 유저의 의사표시 세 곳으로 확장합니다. v2.9.3 릴리즈 노트의 "마지막으로 사용한 위치가 기억됩니다"가 문자 그대로 사실이 됩니다.

## 구현

`_rememberPathIfValid()` 헬퍼 하나를 추가하고 세 지점에서 호출합니다. 실제 저장은 기존 `_rememberDownloadPath`(변경 시에만 기록) 재사용:

1. **경로 찾기 선택 직후** (`onFindPath`) — 다이얼로그는 실존 폴더만 반환하므로 가장 확실한 의사표시
2. **입력 확정 시** (`downloadPathInput.editingFinished`) — Enter·포커스 이탈 시에만 발화하므로 타이핑 중에는 절대 저장되지 않고, `isdir` 관문이 커밋된 미완성·오타 경로를 이중으로 거른다
3. **창 닫기 시** (`closeEvent`) — `setText`는 `editingFinished`를 발생시키지 않으므로, "바꾸고 바로 종료" 시나리오(제보 증상 그대로)의 마지막 그물

부수: `_rememberDownloadPath`가 실제로 값을 바꿀 때 `logger.info("저장 경로 보존: %r", ...)` 한 줄을 남깁니다(#148 유저 행위 층과 같은 결, repr 병기).

## 리뷰어에게

- **미완성 경로 미저장 제약**: "커밋 시점만 포착(editingFinished) + isdir 관문" 조합으로 달성했습니다. 글자 단위 `textChanged`는 쓰지 않습니다.
- **관문 기준의 비대칭이 남습니다**: 조회 관문은 `exists`(파일도 통과), 보존 관문은 `isdir`, 다운로드 게이트는 쓰기 프로브 — 기준 통합은 이 PR에서 하지 않습니다. **Phase 5 관문 통합(#146 ⓑ1)에서 판정 기준·실패 문구를 viewmodel 단일 지점으로 옮길 때, 이 보존 로직(`_rememberPathIfValid`)도 그 지점으로 흡수**되는 것이 예정 경로입니다.
- 입력창을 비우고 종료하면 저장하지 않습니다(빈 값 = 미설정 의미 유지) — 다음 실행은 기존 저장 경로 → 다운로드 폴더 순.
- 검증: 신규 테스트 4건(경로 찾기 보존 / 확정 보존 / 미실존 확정 미보존 / 닫기 보존) 중 보존을 단언하는 3건은 수정 전 코드에서 실패를 먼저 확인했습니다(미보존 단언 1건은 성격상 수정 전에도 통과). 전체 스위트 386 passed, 4 skipped(전부 기존 OS 설계 스킵) — 로컬 Windows offscreen 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)