### PR TITLE
refactor: app/viewmodels 신설, LOADING을 core enum에서 앱 계층 ItemState로 분리 (#167)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""app 패키지 — UI와 core 사이의 앱 계층 (Phase 5, #167).
+
+viewmodel·앱 전용 상태가 여기에 놓인다. core의 불변 규칙(PySide6 금지)은
+app에 적용되지 않지만, app은 ui/ 위젯을 직접 알지 않는다.
+"""

--- a/app/viewmodels/__init__.py
+++ b/app/viewmodels/__init__.py
@@ -1,0 +1,5 @@
+"""viewmodel 계층 — 뷰 무의존 표시 로직·앱 전용 상태 (Phase 5, #167)."""
+
+from app.viewmodels.item_state import ItemState
+
+__all__ = ["ItemState"]

--- a/app/viewmodels/item_state.py
+++ b/app/viewmodels/item_state.py
@@ -1,0 +1,19 @@
+"""앱 계층 항목 상태 — core 태스크 생명주기에 없는 표시 전용 상태 (#167).
+
+LOADING(메타데이터 조회 중, #124)은 다운로드 태스크가 만들어지기 전의
+카드 표시 상태다. core 전이 규칙(download_task)에 등장하지 않는데도
+core DownloadState에 얹혀 있던 것을 여기로 분리했다.
+
+ContentItem.downloadState에는 core DownloadState와 ItemState가 병존한다.
+Enum 멤버는 클래스가 다르면 절대 같지 않으므로(==/in 비교 안전) 기존
+비교식은 타입이 섞여도 오동작하지 않는다 — 이 성질은
+tests/unit/test_item_state.py가 고정한다.
+"""
+
+from enum import Enum
+
+
+class ItemState(Enum):
+    """다운로드 태스크 이전의 카드 표시 상태."""
+
+    LOADING = "loading"  # 메타데이터 조회 중 — findItem이 건너뛴다 (#124)

--- a/content/manager.py
+++ b/content/manager.py
@@ -9,6 +9,7 @@ from content.view import ContentListView
 from content.delegate import ContentListDelegate
 from content.data import ContentItem
 from download.state import DownloadState
+from app.viewmodels.item_state import ItemState
 from content.worker import ContentWorker
 from core.utils.paths import build_output_path, ensure_unique_path
 
@@ -95,7 +96,7 @@ class ContentManager(QObject):
             {'title': vod_url, 'category': '', 'channelName': '', 'createdDate': '', 'duration': 0},
             [], None, '', downloadPath, '', None,
         )
-        placeholder.downloadState = DownloadState.LOADING
+        placeholder.downloadState = ItemState.LOADING
         self.model.addItem(placeholder)
         self.insertItemRequested.emit(self.model.rowCount())
 
@@ -255,7 +256,7 @@ class ContentManager(QObject):
             index = self.model.index(row, 0)
             item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
             # LOADING은 메타데이터가 아직 없어 다운로드 대상이 아니다 (#124)
-            if item.downloadState not in [DownloadState.FINISHED, DownloadState.FAILED, DownloadState.LOADING]:
+            if item.downloadState not in [DownloadState.FINISHED, DownloadState.FAILED, ItemState.LOADING]:
                 return True, item, index
         return False, None, None
 
@@ -264,7 +265,7 @@ class ContentManager(QObject):
         for row in range(self.model.rowCount()):
             index = self.model.index(row, 0)
             item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-            if item.downloadState == DownloadState.LOADING:
+            if item.downloadState == ItemState.LOADING:
                 return True
         return False
 

--- a/content/widget.py
+++ b/content/widget.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import Qt, QSize, Signal, QUrl, QDir, QProcess
 from content.data import ContentItem
 from content.network import REQUEST_TIMEOUT, get_thread_session
 from download.state import DownloadState
+from app.viewmodels.item_state import ItemState
 from ui.contentItemWidget import Ui_ContentItemWidget
 from time import strftime, gmtime
 import platform
@@ -169,7 +170,7 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         self.titleLabel.setText(item.title)
         self.directoryLabel.setText(item.download_path)
 
-        if self.item.downloadState == DownloadState.LOADING:
+        if self.item.downloadState == ItemState.LOADING:
             self.statusLabel.setText(self.tr("Loading information..."))
             self.fileSizeLabel.setText("")
             self.progressLabel.setText(" ")

--- a/core/models/download_state.py
+++ b/core/models/download_state.py
@@ -15,7 +15,6 @@ class DownloadState(Enum):
     PAUSED = 2  # 다운로드 중지(일시정지)
     FINISHED = 3  # 다운로드 완료
     FAILED = 4  # 다운로드 실패
-    # 메타데이터 조회 중 — 다운로드 대상이 아닌 선행 상태 (#124).
-    # 태스크 전이 규칙(download_task)에는 등장하지 않는다: 조회가 끝나
-    # WAITING이 된 뒤에야 태스크가 만들어질 수 있다.
-    LOADING = 5
+    # 값 5는 재사용 금지 — 조회 중 표시 상태(구 LOADING)가 쓰던 자리다.
+    # 전이 규칙에 없는 표시 전용 상태라 app/viewmodels/item_state.py의
+    # ItemState.LOADING으로 분리됐다 (#167)

--- a/tests/unit/test_item_state.py
+++ b/tests/unit/test_item_state.py
@@ -1,0 +1,37 @@
+"""앱 계층 항목 상태 분리 검증 (#167 — Phase 5).
+
+LOADING은 core 전이 규칙(download_task)에 등장하지 않는 표시 전용
+상태라(#124) 앱 계층 ItemState로 분리됐다. core enum이 태스크 생명주기
+5개만 갖는 것과, 병존 비교의 안전성(Enum 멤버는 클래스가 다르면 절대
+같지 않다)을 고정한다. LOADING 게이트의 행동 자체는 기존
+tests/unit/test_content_manager.py가 무수정으로 계속 검증한다.
+"""
+
+from app.viewmodels.item_state import ItemState
+from core.models.download_state import DownloadState
+
+
+def test_core_enum_has_only_task_lifecycle_states():
+    """core DownloadState는 태스크 생명주기 5개만 갖는다 — LOADING 재유입 방지."""
+    assert {m.name for m in DownloadState} == {
+        "WAITING",
+        "RUNNING",
+        "PAUSED",
+        "FINISHED",
+        "FAILED",
+    }
+
+
+def test_value_five_is_not_reused():
+    """값 5(구 LOADING 자리)는 재사용하지 않는다 — 로그·직렬화 혼동 방지."""
+    assert all(m.value != 5 for m in DownloadState)
+
+
+def test_item_state_never_equals_core_states():
+    """병존 비교의 안전성: ItemState 멤버는 어떤 core 상태와도 같지 않다.
+
+    ContentItem.downloadState에 두 타입이 섞여 들어가도 기존 ==/in
+    비교식이 오동작하지 않는 근거다.
+    """
+    assert all(ItemState.LOADING != m for m in DownloadState)
+    assert ItemState.LOADING not in list(DownloadState)


### PR DESCRIPTION
## 요약

Closes #167 — Phase 5 viewmodel 단계의 1번 작업.

`app/viewmodels/` 패키지를 신설하고, core 전이 규칙에 등장하지 않는 표시 전용 상태 LOADING을 core `DownloadState`에서 앱 계층 `ItemState`로 분리합니다. UI 무변경.

## 구현

- **`app/viewmodels/item_state.py`**: `ItemState.LOADING` 신설. `app/__init__.py`에 계층 규칙(app은 ui/ 위젯을 직접 알지 않는다) 명시
- **`core/models/download_state.py`**: `LOADING = 5` 제거. 값 5 재사용 금지를 주석으로 못박음
- **content 치환 4곳**: `manager.py:98`(쓰기)·`:258`·`:267`, `widget.py:172`(읽기) — `DownloadState.LOADING` → `ItemState.LOADING`
- **가드 테스트 신설**(`tests/unit/test_item_state.py`, 3건): core 멤버 집합이 생명주기 5개뿐 / 값 5 미재사용 / ItemState는 어떤 core 상태와도 같지 않음(병존 비교 안전성)

## 리뷰어에게

- **설계 선택 — 병존(coexistence) 방식**: `ContentItem.downloadState`에 core `DownloadState`(생명주기)와 `ItemState`(표시 전용)가 병존합니다. 앱 enum 슈퍼셋 방식은 기존 `== DownloadState.FINISHED`류 비교와 테스트 다수를 깨므로 기각했습니다. Enum 멤버는 클래스가 다르면 절대 같지 않아 병존 비교는 안전하며, 이 성질을 테스트로 고정했습니다.
- **`download/state.py` re-export는 무접촉**: `test_download_task_adapter.py:52-53`의 동일성 박제(`download.state.DownloadState is core...DownloadState`)를 보존합니다. re-export 정리는 #171의 몫입니다.
- content↔download 패키지 순환(사이클 A)의 완전 해소도 #171에서 import 치환과 함께 이뤄집니다 — 이 PR은 그 전제(앱 상태의 새 거처)만 마련합니다.

## 검증 — "UI 무변화"

- **기존 테스트 386개 전부 무수정 통과** (389 passed = 386 + 신규 3, 4 skipped는 기존 OS 설계 스킵) — 실배선 GUI 40개(test_default_download_path 10 · test_failure_display 5 · test_content_manager 10 · test_write_probe 4 · test_path_action_logging 5 등) 포함
- 착수 전/후 `CVDV2_SHOT_ALL=1` 스크린샷 갤러리 대조: 파일 수·각 이미지 크기 동일, 동일 테스트 쌍 육안 대조 일치 (로컬 Windows offscreen)
- LOADING 게이트 행동(#124: 조회 중 다운로드 제외, hasLoadingItems)은 기존 test_content_manager가 무수정으로 계속 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)