### PR TITLE
refactor: 카드 위젯 raw 스레드를 Signal 중계로 — 워커 스레드 위젯 조작 제거 (#168)

### DIFF
--- a/content/widget.py
+++ b/content/widget.py
@@ -20,14 +20,25 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
     textChanged = Signal(str)
     deleteRequest = Signal()
 
+    # 워커 스레드 → 메인 스레드 중계 (#168). 위젯·아이템 조작은 반드시 메인
+    # 스레드 슬롯에서 한다 — download 경로가 qt_bridge로 세운 스레드 경계
+    # 규칙을 content 경로에도 적용한다
+    _repSizeFetched = Signal(int, str)  # (해상도 index, 크기 텍스트 — 세그먼트 기반이면 "")
+    _imageFetched = Signal(object, object, str, int, str)  # (label, bytes, url, maxHeight, type)
+
     def __init__(self, item: ContentItem, index=0, parent=None):
         super().__init__(parent)
         self.item = item  # ContentItem 저장
         self.index = index  # 인덱스 저장
         self.isEditing = False
         self.setupUi(self)  # TODO: 테마별 스타일시트 설정하기
+        self._setupThreadRelays()  # setupDynamicUi가 스레드를 띄우기 전에 연결돼야 한다 (#168)
         self.setupDynamicUi()  # TODO: 테마별 스타일시트 설정하기
         self.setupSignals()  # 시그널 연결
+
+    def _setupThreadRelays(self):
+        self._repSizeFetched.connect(self._onRepSizeFetched)
+        self._imageFetched.connect(self._onImageFetched)
 
     def setupDynamicUi(self):
         self.loadImageFromUrl(self.channelImageLabel, self.item.channel_image_url, 30, "channel")
@@ -83,8 +94,10 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         self.buttons.append(button)
 
         def update_button_text():
-            try:
-                if not self.item.is_segment_based:
+            # 네트워크만 담당한다 — 위젯·아이템 반영은 _onRepSizeFetched(메인 스레드)로 (#168)
+            size_text = ""
+            if not self.item.is_segment_based:
+                try:
                     resp = get_thread_session().head(base_url, timeout=REQUEST_TIMEOUT)
                     resp.raise_for_status()
                     size = int(resp.headers.get('content-length', 0))
@@ -93,18 +106,28 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
                         resp.raise_for_status()
                         size = int(resp.headers.get('content-length', 0))
                         resp.close()
-                
                     size_text = self.setSize(size)
-                    self.item.unique_reps[index][-1] = size_text
-                    button.setToolTip(size_text)
-                if len(self.item.unique_reps) - 1 == index:
-                    self.setresolutionUrlSize(resolution, base_url, index, button)
-
-            except Exception:
-                pass
+                except Exception:
+                    # 기존 동작 유지: 조회 실패는 조용히 "Checking..."으로 남는다
+                    return
+            try:
+                self._repSizeFetched.emit(index, size_text)
+            except RuntimeError:
+                pass  # 위젯이 이미 파괴된 뒤의 늦은 완료
 
         thread = threading.Thread(target=update_button_text, daemon=True)
         thread.start()
+
+    def _onRepSizeFetched(self, index, size_text):
+        """해상도 크기 조회 결과를 위젯·아이템에 반영한다 — 메인 스레드 (#168)."""
+        if index >= len(self.buttons) or index >= len(self.item.unique_reps):
+            return  # setData로 아이템이 교체된 뒤의 늦은 완료
+        if size_text:
+            self.item.unique_reps[index][-1] = size_text
+            self.buttons[index].setToolTip(size_text)
+        if len(self.item.unique_reps) - 1 == index:
+            resolution, base_url = self.item.unique_reps[index][0], self.item.unique_reps[index][1]
+            self.setresolutionUrlSize(resolution, base_url, index, self.buttons[index])
 
     def setresolutionUrlSize(self, resolution, base_url, index=None, button:QPushButton = None):
         if self.item.downloadState == DownloadState.WAITING:
@@ -133,27 +156,41 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         thread.start()
 
     def fetchImage(self, label, url, maxHeight, type):
+        """이미지 바이트를 받아 메인 스레드로 중계한다 — 워커 스레드 (#168).
+
+        QPixmap 생성·스케일·setPixmap은 GUI 스레드 전용이라 여기서 하지
+        않는다. 디코드 이후는 _onImageFetched(메인 스레드)가 담당한다.
+        """
         try:
             response = get_thread_session().get(url, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
+            self._imageFetched.emit(label, response.content, url, maxHeight, type)
+        except RuntimeError:
+            pass  # 위젯이 이미 파괴된 뒤의 늦은 완료
+        except Exception as e:
+            logger.error(f"Error loading image from {url}: {e}")
+
+    def _onImageFetched(self, label, data, url, maxHeight, type):
+        """이미지 디코드·스케일·표시 — 메인 스레드 (#168)."""
+        try:
             image = QPixmap()
-            image.loadFromData(response.content)
-            
+            image.loadFromData(data)
+
             # 원본 이미지의 비율 계산
             original_width = image.width()
             original_height = image.height()
-            
+
             if type == "channel" and original_height > original_width:
                 # 가로 높이를 고정하고 세로 크기를 비율에 맞게 계산
                 aspect_ratio = original_height / original_width
                 new_width = maxHeight
                 new_height = int(maxHeight * aspect_ratio)
-            else:      
-                # 세로 높이를 고정하고 가로 크기를 비율에 맞게 계산      
+            else:
+                # 세로 높이를 고정하고 가로 크기를 비율에 맞게 계산
                 aspect_ratio = original_width / original_height
                 new_height = maxHeight
                 new_width = int(new_height * aspect_ratio)
-            
+
             scaled_image = image.scaled(
                 new_width, new_height, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation
             )

--- a/content/worker.py
+++ b/content/worker.py
@@ -41,29 +41,6 @@ class ContentWorker(QObject):
             logger.exception("컨텐츠 요청 실패: %s", self.vod_url)
             self.error.emit(self._user_message(e))
 
-    def fetchVideo(self, video_no: str) -> tuple:
-        """VOD 조회를 core 서비스에 위임한다 (기존 시그니처·예외 형식 유지).
-
-        core의 fetch_video는 (result, 암호화 여부)를 돌려주지만(#57), 이 어댑터의
-        반환 계약은 result tuple 그대로다 — 암호화 타입 분기는 fetch_content가 한다.
-        """
-        try:
-            result, _encrypted = metadata_service.fetch_video(
-                self.vod_url, video_no, self.cookies, self.downloadPath, api=NetworkManager
-            )
-            return result
-        except MetadataError as e:
-            raise ValueError(self._user_message(e)) from e
-
-    def fetchClip(self, clip_no: str) -> tuple:
-        """클립 조회를 core 서비스에 위임한다 (기존 시그니처·예외 형식 유지)."""
-        try:
-            return metadata_service.fetch_clip(
-                self.vod_url, clip_no, self.cookies, self.downloadPath, api=NetworkManager
-            )
-        except MetadataError as e:
-            raise ValueError(self._user_message(e)) from e
-
     def _user_message(self, e: Exception) -> str:
         """예외를 사용자 표시용 메시지로 바꾼다. MetadataError는 i18n 키를 번역한다.
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,12 +1,15 @@
-"""ContentWorker.fetchVideo의 권한·암호화 분기 검증 (#55) + 어댑터 계약 검증 (#72).
+"""ContentWorker의 권한·암호화 분기 검증 (#55) + 어댑터 계약 검증 (#72).
 
 조회 로직은 core/services/metadata_service.py로 이동했다(#72). 이 테스트는
-어댑터를 통과한 끝단 동작(기존 ValueError 메시지·시그널 형식)이 유지되는지 본다.
+어댑터를 통과한 끝단 동작(시그널 페이로드·에러 메시지 형식)이 유지되는지 본다.
 분기 자체의 단위 테스트는 tests/unit/core/test_metadata_service.py에 있다.
 
-- 암호화(encryptionType != null) VOD는 권한 유무와 무관하게 매니페스트 요청 전에
-  "Encrypted content is not supported" 안내로 조기 실패해야 한다 (1차 방어).
-- 멤버십 전용(MEMBER_ONLY) + inKey null이면 raw 401 대신 멤버십 안내 에러를 던져야 한다.
+죽은 동기 API(fetchVideo/fetchClip)가 제거되어(#168) 모든 경로가 프로덕션과
+동일한 run() → finished/error Signal로 검증된다 — 단언하는 메시지 키·result
+tuple 형식은 종전 그대로다.
+
+- 암호화(encryptionType != null) VOD는 권한이 있으면 SEA 경로로 조회된다 (#57).
+- 멤버십 전용(MEMBER_ONLY) + inKey null이면 raw 401 대신 멤버십 안내 에러가 나와야 한다.
 - 성인 VOD(adult=True, videoId 없음)의 기존 "Invalid cookies value" 동작은 유지돼야 한다.
 - 정상 경로에서는 등록된 쿠키가 매니페스트 요청까지 전달돼야 한다.
 """
@@ -26,6 +29,19 @@ VOD_URL = "https://chzzk.naver.com/video/13714380"
 def _make_worker() -> ContentWorker:
     """테스트용 ContentWorker를 생성한다 (QApplication 불필요)."""
     return ContentWorker(VOD_URL, COOKIES, "downloads")
+
+
+def _run_and_capture(worker: ContentWorker) -> tuple[list, list]:
+    """run()을 실행해 finished/error Signal 페이로드를 수집한다.
+
+    같은 스레드 emit은 direct 배달이라 QApplication 없이 동작한다.
+    """
+    results: list[tuple] = []
+    errors: list[str] = []
+    worker.finished.connect(lambda result, content_type: results.append((result, content_type)))
+    worker.error.connect(errors.append)
+    worker.run()
+    return results, errors
 
 
 @pytest.mark.parametrize(
@@ -57,11 +73,13 @@ def test_encrypted_vod_with_entitlement_takes_sea_path(
         ),
     )
 
-    worker = _make_worker()
-    result = worker.fetchVideo("13714380")
+    results, errors = _run_and_capture(_make_worker())
 
+    assert errors == []
+    ((result, content_type),) = results
     assert result[0] == VOD_URL
     assert result[4] == "https://example.invalid/media.m3u8"
+    assert content_type == "hls_aes"  # AES(SEA) 경로로 분기됐다 (#57)
 
 
 def test_encrypted_vod_without_entitlement_raises_membership_error(
@@ -71,10 +89,10 @@ def test_encrypted_vod_without_entitlement_raises_membership_error(
     body = load_mock_response("video_member_only_13714380.json")
     monkeypatch.setattr(network._session, "get", lambda url, **kwargs: MockResponse(text=body))
 
-    worker = _make_worker()
+    results, errors = _run_and_capture(_make_worker())
 
-    with pytest.raises(ValueError, match="Channel membership required"):
-        worker.fetchVideo("13714380")
+    assert results == []
+    assert errors == [f"{VOD_URL}\nChannel membership required"]
 
 
 def test_member_only_without_in_key_raises_membership_error(monkeypatch):
@@ -94,10 +112,10 @@ def test_member_only_without_in_key_raises_membership_error(monkeypatch):
 
     monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
 
-    worker = _make_worker()
+    results, errors = _run_and_capture(_make_worker())
 
-    with pytest.raises(ValueError, match="Channel membership required"):
-        worker.fetchVideo("13714380")
+    assert results == []
+    assert errors == [f"{VOD_URL}\nChannel membership required"]
 
 
 def test_adult_without_video_id_keeps_invalid_cookies_error(monkeypatch):
@@ -117,10 +135,10 @@ def test_adult_without_video_id_keeps_invalid_cookies_error(monkeypatch):
 
     monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
 
-    worker = _make_worker()
+    results, errors = _run_and_capture(_make_worker())
 
-    with pytest.raises(ValueError, match="Invalid cookies value"):
-        worker.fetchVideo("13714380")
+    assert results == []
+    assert errors == [f"{VOD_URL}\nInvalid cookies value"]
 
 
 def test_dash_path_passes_cookies_to_manifest_request(monkeypatch):
@@ -146,14 +164,16 @@ def test_dash_path_passes_cookies_to_manifest_request(monkeypatch):
     monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
     monkeypatch.setattr(NetworkManager, "get_video_dash_manifest", fake_get_dash_manifest)
 
-    worker = _make_worker()
-    result = worker.fetchVideo("13714380")
+    results, errors = _run_and_capture(_make_worker())
 
+    assert errors == []
+    ((result, content_type),) = results
     assert manifest_calls == [("video-id", "in-key", COOKIES)]
     # 반환 tuple 형식 유지: (vod_url, metadata, reps, resolution, base_url, path, liveRewindPlaybackJson)
     assert result[0] == VOD_URL
     assert result[3] == 1080
     assert result[6] is None
+    assert content_type == "video"
 
 
 def test_run_emits_error_signal_in_legacy_format():


### PR DESCRIPTION
## 요약

Closes #168 — Phase 5 viewmodel 단계의 2번 작업.

qt_bridge가 다운로드 경로에 세운 스레드 경계 규칙("워커 스레드에서 위젯을 만지지 않는다")을 content 경로에도 적용하고, 프로덕션 호출부가 없던 동기 API를 제거해 조회 계약을 Signal 하나로 일원화합니다. UI 무변경.

## 구현

**`content/widget.py` — raw 스레드 2개를 Signal 중계로**
- 내부 시그널 2개 신설: `_repSizeFetched(index, size_text)` · `_imageFetched(label, bytes, url, maxHeight, type)`. 워커 스레드는 네트워크만 담당하고 emit까지, 위젯·아이템 반영(`setToolTip`·`unique_reps` 변조·`setPixmap`·`setresolutionUrlSize`)은 메인 스레드 슬롯(`_onRepSizeFetched`/`_onImageFetched`)에서 합니다
- **부수 발견·동시 수정**: 기존 `fetchImage`는 워커 스레드에서 `QPixmap`을 생성·스케일했는데, QPixmap은 GUI 스레드 전용이라 이것 자체가 잠재 위반이었습니다. 디코드·스케일도 메인 스레드 슬롯으로 이동했습니다(스레드는 바이트 수신까지만)
- 시그널 연결은 `setupDynamicUi()`(이미지 스레드 기동 지점)보다 먼저 — 연결 전 emit 유실 경합 차단
- 동작 보존: 크기 조회 실패는 종전대로 조용히 "Checking..." 유지, 이미지 실패는 같은 로그 한 줄. 위젯 파괴 뒤 늦은 완료는 RuntimeError 무시(종전에는 광역 except가 삼키던 경우)

**`content/worker.py` — 죽은 동기 API 제거**
- `fetchVideo`/`fetchClip` 삭제. 프로덕션 호출부 0곳(사용처는 test_worker뿐)이었고, tuple 반환+ValueError라는 별도 계약이 Signal 계약을 이중화하고 있었습니다. 조회는 이제 프로덕션과 동일한 `run()` → `finished`/`error` 경로 하나입니다

## 손댄 테스트 (#168 계획에 명시했던 그대로)

- `tests/unit/test_worker.py`: fetchVideo 직접 호출 5건을 `run()`+Signal 수집으로 재작성 — **단언하는 메시지 키·result tuple 인덱스 형식은 종전 그대로**이고, `content_type`("hls_aes"/"video") 단언이 추가로 강해졌습니다
- **무수정 유지**: 오류 형식 박제 2건 — `test_run_emits_error_signal_in_legacy_format`("<url>\n<메시지>"), `test_run_error_hides_raw_exception_details`(#126)
- 실배선 5파일의 `no_network` 픽스처가 의존하는 진입점(`content.widget.get_thread_session`)은 모듈 경로·함수명 무변경

## 검증 — "UI 무변화"

- 전체 스위트 389 passed, 4 skipped(기존 OS 설계 스킵) — test_worker 재작성분 외 **전부 무수정 통과**, 실배선 GUI 40개 포함
- main(#172 머지 후) 기준 갤러리 vs 본 브랜치 `CVDV2_SHOT_ALL=1` 갤러리: 테스트별 캡처 목록 동일, 10건 전원 이미지 치수 동일(QImage 전수 비교), 동일 테스트 쌍 육안 대조 일치 — 로컬 Windows offscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)