### PR TITLE
refactor: ContentViewModel 추출 — manager 2분할·뷰 직접 호출 반전·관문 단일 지점화 (#169)

### DIFF
--- a/app/viewmodels/content_viewmodel.py
+++ b/app/viewmodels/content_viewmodel.py
@@ -1,0 +1,283 @@
+"""content 조회·다운로드 오케스트레이션 viewmodel — 뷰 무의존 (#169).
+
+구 ContentManager의 로직 절반이다: 모델 소유·워커 오케스트레이션·다운로드
+게이트·배치 체인·항목 상태 전이. 뷰에는 시그널(itemStarted 등)로만 말하고
+위젯 타입을 import하지 않는다 — 뷰 바인딩(시그널↔뷰 메서드 연결)은
+content/manager.py의 ContentManager가 맡는다.
+
+의존성 주입 3종은 바인더가 넘긴다:
+- worker_factory: content.manager 모듈 전역 ContentWorker를 조회하는 함수
+  (테스트의 monkeypatch 지점 보존)
+- probe: content.manager.probe_writable (동상)
+- messages: 실패 문구 콜러블 — tr() 리터럴은 번역 컨텍스트("ContentManager")와
+  lupdate 스캔 대상(project.json sources)이 걸려 있어 바인더에 남는다
+"""
+
+import logging
+import os
+
+from PySide6.QtCore import QObject, Qt, QThreadPool, Signal
+
+from app.viewmodels.item_state import ItemState
+from app.viewmodels.path_gates import check_download_path
+from content.data import ContentItem
+from content.model import ContentListModel
+from core.utils.paths import build_output_path, ensure_unique_path
+from download.state import DownloadState
+
+# 유저 행위·관문 로그의 로거 이름은 "content.manager"를 유지한다 — 제보
+# 진단 절차와 기존 테스트(caplog)가 이 이름을 알고 있고, 로직의 거처가
+# 바뀌었다고 로그 소비자의 주소까지 바꾸지 않는다. 로거 재편은 셸 단계에서
+logger = logging.getLogger("content.manager")
+
+
+class _WorkerRelay(QObject):
+    """워커 1개의 finished/error를 워커 식별자와 함께 중계한다 — sender() 대체 (#169).
+
+    바운드 메서드 연결 요구(#124: partial/lambda 연결은 소유가 워커 쪽이 되어
+    워커 파괴 시 큐에 남은 전달이 유실된다)를 지키면서 워커→자리표시 매핑을
+    명시적으로 만든다. 릴레이 참조는 viewmodel의 _relays에 담겨 결과 도착까지
+    살아 있다.
+    """
+
+    def __init__(self, viewmodel: "ContentViewModel", worker):
+        super().__init__(viewmodel)
+        self._viewmodel = viewmodel
+        self._worker = worker
+
+    def onFinished(self, result, content_type):
+        self._viewmodel._workerFinished(self._worker, result, content_type)
+
+    def onError(self, error_message):
+        self._viewmodel._workerError(self._worker, error_message)
+
+
+class ContentViewModel(QObject):
+    downloadRequested = Signal(object)
+    stopRequested = Signal(object)
+    insertItemRequested = Signal(int)
+    deleteItemRequested = Signal(object, int)
+    finishedRequested = Signal(object)
+    finishedAllRequested = Signal()
+    fetchRequested = Signal(str)
+    contentError = Signal(str)
+
+    # 뷰 방향 시그널 — 구 ContentManager의 view 직접 호출 6곳을 반전한 것.
+    # 바인더가 view.onDownload*에 연결한다
+    itemStarted = Signal(object)
+    itemStopped = Signal(object)
+    itemPaused = Signal(object)
+    itemResumed = Signal(object)
+    itemFinished = Signal(object, bool)
+
+    def __init__(self, worker_factory, probe, messages: dict, parent=None):
+        super().__init__(parent)
+        self._worker_factory = worker_factory
+        self._probe = probe
+        self._messages = messages
+
+        self.model = ContentListModel()
+        self.downloadPath = ""
+        self.threadpool = QThreadPool()
+        # 조회 중인 워커 → 자리표시 아이템. 결과가 도착할 때까지 워커의 파이썬
+        # 참조를 잡아 두는 역할도 한다 — 참조가 없으면 run() 종료 직후 워커가
+        # 파괴되어 큐에 남은 finished/error 전달이 유실된다 (#124)
+        self._pendingPlaceholders = {}
+        self._relays = {}
+
+    def fetchContent(self, vod_url: str, cookies: dict, downloadPath: str) -> None:
+        # 조회가 끝나기 전에도 카드가 보이도록 LOADING 상태의 자리표시 아이템을
+        # 즉시 추가한다. LOADING 아이템은 findItem이 건너뛰므로 다운로드되지 않는다 (#124)
+        placeholder = ContentItem(
+            vod_url,
+            {'title': vod_url, 'category': '', 'channelName': '', 'createdDate': '', 'duration': 0},
+            [], None, '', downloadPath, '', None,
+        )
+        placeholder.downloadState = ItemState.LOADING
+        self.model.addItem(placeholder)
+        self.insertItemRequested.emit(self.model.rowCount())
+
+        worker = self._worker_factory(vod_url, cookies, downloadPath)
+        relay = _WorkerRelay(self, worker)
+        self._pendingPlaceholders[worker] = placeholder
+        self._relays[worker] = relay
+
+        worker.finished.connect(relay.onFinished)
+        worker.error.connect(relay.onError)
+
+        self.threadpool.start(lambda: worker.run())
+
+    def _workerFinished(self, worker, result, content_type):
+        # result는 (vod_url, metadata, unique_reps, resolution, base_url, downloadPath, liveRewindPlaybackJson) 형식
+        placeholder = self._pendingPlaceholders.pop(worker, None)
+        self._relays.pop(worker, None)
+        if placeholder is None:
+            return
+        vod_url, metadata, unique_reps, resolution, base_url, downloadPath, liveRewindPlaybackJson = result
+        self.downloadPath = downloadPath
+        row = self.model.getRow(placeholder)
+        if row is None:
+            # 조회 중 유저가 카드를 삭제한 경우 — 결과를 버린다
+            return
+        # 완성된 아이템으로 같은 자리에서 교체한다. 행 삭제→삽입을 거쳐야
+        # 해상도 버튼·썸네일이 붙은 위젯이 새로 만들어진다
+        item = ContentItem(vod_url, metadata, unique_reps, resolution, base_url, downloadPath, content_type, liveRewindPlaybackJson)
+        self.model.removeRows(row, 1)
+        self.model.addItem(item, row)
+
+    def _workerError(self, worker, error_message):
+        placeholder = self._pendingPlaceholders.pop(worker, None)
+        self._relays.pop(worker, None)
+        if placeholder is not None:
+            row = self.model.getRow(placeholder)
+            if row is not None:
+                self.model.removeRows(row, 1)
+                self.deleteItemRequested.emit(placeholder, self.model.rowCount())
+        self.contentError.emit(error_message)
+
+    def clrearFinishedItems(self):
+        if not self.model.isEmpty():
+            for row in reversed(range(self.model.rowCount())):
+                index = self.model.index(row, 0)
+                item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
+                # 아이템이 완료 상태이면 삭제
+                if item.downloadState == DownloadState.FINISHED:
+                    self.removeItem(item)
+
+    def removeItem(self, item: ContentItem):
+        row = self.model.getRow(item)
+        if row is not None:
+            self.model.removeRows(row, 1)
+            index = self.model.rowCount()
+            self.deleteItemRequested.emit(item, index)
+
+    def downloadItem(self):
+        found, item, index = self.findItem()
+        if found:
+            try:
+                # 사전 검사 (#137): 존재+쓰기 프로브. 판정은 path_gates가 단일
+                # 지점으로 담당하고(#169 — #146 ⓑ1), 프로브 수단은 주입받는다.
+                # 존재 검사도 프로브 스레드 안에서 수행한다 — 무응답 마운트에서는
+                # exists조차 메인 스레드를 매달 수 있다 (#136)
+                writable, reason = check_download_path(item.download_path, self._probe)
+                if reason == "missing":
+                    raise ValueError(self._messages["invalid_path"]())
+                if not writable:
+                    # 권한 없음(denied — 예: SFTP 상 ZFS 풀 루트) 또는 무응답
+                    # 마운트(timeout — 권한 오류가 오류로 전파되지 않는 경우).
+                    # 유저에게는 같은 사실이다: 이 경로에는 저장할 수 없다
+                    # 경로는 repr로 남긴다 (#148) — 공백 유사 문자(U+00A0 등)를
+                    # 육안 구분할 수 있는 유일한 표기다 (#144 실측)
+                    logger.warning("쓰기 프로브 실패(%s): %r", reason, item.download_path)
+                    self.fail(item, self._messages["save_failed"]())
+                    return
+                self.onDownload(item)
+            except ValueError as e:
+                # 위에서 직접 던진 번역된 안내 — 그대로 카드에 표시한다.
+                # 이 거부는 지금까지 로그가 전혀 없어 제보 진단이 불가능했다 (#148)
+                logger.warning(
+                    "다운로드 시작 거부 — 존재하지 않는 저장 경로: %r", item.download_path
+                )
+                self.fail(item, str(e))
+            except Exception:
+                # 경로 조립(OSError 등)의 원시 문자열에는 전체 경로가 섞여 있어
+                # 유저에게 보내지 않는다 (#134) — 상세는 로그로만 남긴다
+                logger.exception("다운로드 준비 실패: %s", item.title)
+                self.fail(item, self._messages["save_failed"]())
+        else:
+            self.finishedAllRequested.emit()
+
+    def onDownload(self, item: ContentItem):
+        """해상도가 정해진 아이템의 산출물 경로를 조립하고 다운로드를 요청한다."""
+        if item:
+            # 조립·중복 회피는 core가 단일 지점으로 담당한다 — 같은 제목이
+            # 이미 있으면 " (n)"이 붙은 새 경로를 받는다 (#105)
+            item.output_path = build_output_path(item.download_path, item.title, item.resolution)
+        else:
+            item.output_path = ensure_unique_path(os.path.join(item.download_path, "video.mp4"))
+
+        if item.output_path:
+            # 다운로드 요청 시그널 발행
+            self.downloadRequested.emit(item)
+
+    def update_progress(self, rem, size, spd, prog, item: ContentItem):
+        item.download_remain_time = rem
+        item.download_size = size
+        item.download_speed = spd
+        item.download_progress = prog
+
+        row = self.model.getRow(item)
+        index = self.model.index(row, 0)
+        self.model.dataChanged.emit(index, index)
+
+    def start(self, item):
+        self.itemStarted.emit(item)
+
+    def stop(self, item):
+        self.itemStopped.emit(item)
+
+    def pause(self, item):
+        self.itemPaused.emit(item)
+
+    def resume(self, item):
+        self.itemResumed.emit(item)
+
+    def finish(self, item: ContentItem, download_time):
+        item.download_time = download_time
+        self.itemFinished.emit(item, True)
+        self.emitFinishedRequest(item)
+
+    def fail(self, item: ContentItem, message: str = ""):
+        """아이템을 실패 상태로 표시하고 배치 체인을 계속 진행한다 (#134).
+
+        message는 카드의 실패 사유로 렌더된다 — 키 기반 매핑을 거친 번역
+        문자열만 넣는다 (원시 예외 문자열 금지). emitFinishedRequest가 완료
+        경로와 동일하게 다음 항목의 다운로드를 이어 간다.
+        """
+        item.stateMessage = message
+        item.downloadState = DownloadState.FAILED
+        self.itemFinished.emit(item, False)
+        self.emitFinishedRequest(item)
+
+    def emitStopRequested(self, item: ContentItem):
+        self.stopRequested.emit(item)
+
+    def emitFinishedRequest(self, item: ContentItem):
+        self.finishedRequested.emit(item)
+        self.downloadItem()
+
+    def findItem(self):
+        row_count = self.model.rowCount()
+        for row in range(row_count):
+            index = self.model.index(row, 0)
+            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
+            # LOADING은 메타데이터가 아직 없어 다운로드 대상이 아니다 (#124)
+            if item.downloadState not in [DownloadState.FINISHED, DownloadState.FAILED, ItemState.LOADING]:
+                return True, item, index
+        return False, None, None
+
+    def hasLoadingItems(self):
+        """메타데이터 조회가 끝나지 않은 아이템이 있는지 여부."""
+        for row in range(self.model.rowCount()):
+            index = self.model.index(row, 0)
+            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
+            if item.downloadState == ItemState.LOADING:
+                return True
+        return False
+
+    def downloadResultCounts(self) -> tuple[int, int]:
+        """화면(모델)의 (완료, 실패) 항목 수를 센다 — 배치 종료 안내 분기용 (#134).
+
+        별도 배치 장부를 두지 않고 화면 상태를 그대로 센다: 안내의 역할은
+        "지금 화면에 보이는 결과"와 모순되지 않는 것이고, 배치의 경계는
+        항목 추가·삭제가 진행 중에도 가능해 정확한 장부가 존재하지 않는다.
+        """
+        finished = failed = 0
+        for row in range(self.model.rowCount()):
+            index = self.model.index(row, 0)
+            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
+            if item.downloadState == DownloadState.FINISHED:
+                finished += 1
+            elif item.downloadState == DownloadState.FAILED:
+                failed += 1
+        return finished, failed

--- a/app/viewmodels/path_gates.py
+++ b/app/viewmodels/path_gates.py
@@ -1,0 +1,37 @@
+"""저장 경로 관문 판정의 단일 지점 (#169 — #146 ⓑ1).
+
+네 관문(조회·보존 #165·다운로드 게이트 #137·카드 편집 #148)의 '판정'이
+이 모듈에 모인다. 실패 문구·팝업·로그는 호출자(UI 계층)에 남는다 —
+문구 재설계는 UI 무변화 원칙상 셸 단계(2.10.0)의 몫이다.
+
+판정 기준이 관문마다 다른 것(exists / isdir / 쓰기 프로브)은 현행 동작
+보존을 위해 의도적으로 유지한다. 기준 통일(예: 조회 관문이 파일 경로를
+통과시키는 문제)은 동작 변경이므로 셸 단계에서 문구와 함께 재검토한다.
+"""
+
+import os
+
+
+def check_fetch_path(path: str) -> bool:
+    """조회 관문: 존재만 본다 — 파일이어도 통과, 쓰기 여부는 다운로드 게이트가 판정."""
+    return os.path.exists(path)
+
+
+def check_remember_path(path: str) -> bool:
+    """보존 관문 (#165): 실존 폴더만 — 커밋된 미완성·오타 경로가 초기값을 오염시키지 않게."""
+    return bool(path) and os.path.isdir(path)
+
+
+def check_card_edit_path(path: str) -> bool:
+    """카드 편집 관문 (#148): 존재만 본다."""
+    return bool(path) and os.path.exists(path)
+
+
+def check_download_path(path: str, probe) -> tuple[bool, str]:
+    """다운로드 게이트 (#137): 존재+쓰기 프로브.
+
+    probe는 content.manager.probe_writable을 주입받는다 — 무응답 마운트
+    대비 제물 스레드 방식(#136)은 그쪽이 정본이고, 여기는 판정 배치만
+    담당한다. 반환은 (쓰기 가능 여부, "" | "missing" | "denied" | "timeout").
+    """
+    return probe(path)

--- a/application/mainWindow.py
+++ b/application/mainWindow.py
@@ -6,6 +6,7 @@ import config.config as config
 from PySide6.QtWidgets import QMainWindow, QMessageBox, QFileDialog, QApplication
 from PySide6.QtCore import QStandardPaths, QTimer
 
+from app.viewmodels.path_gates import check_fetch_path, check_remember_path
 from config.dialog import SettingDialog
 from content.data import ContentItem
 from content.manager import ContentManager
@@ -140,7 +141,8 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
         # 결과 처리
         downloadPath = self.downloadPathInput.text().strip() or os.getcwd()
 
-        if not os.path.exists(downloadPath):
+        # 판정은 path_gates가 단일 지점으로 담당한다 (#169 — #146 ⓑ1)
+        if not check_fetch_path(downloadPath):
             # 유일한 안내가 팝업뿐이라 제보 진단이 불가능했다 (#146 감사) —
             # 입력값을 repr로 남겨 공백 유사 문자·오염(따옴표 등)을 식별한다 (#148)
             logger.warning("조회 거부 — 존재하지 않는 저장 경로: %r", downloadPath)
@@ -207,12 +209,11 @@ class VodDownloader(QMainWindow, Ui_VodDownloader):
 
         보존 시점은 유저의 의사표시 세 곳 — 경로 찾기 선택, 입력 확정
         (editingFinished), 창 닫기 — 이라 조회 없이 경로만 바꿔도 다음
-        실행의 초기값 ①이 된다. isdir 관문은 커밋된 미완성·오타 경로가
-        초기값을 오염시키지 않게 한다. 조회(exists)·다운로드(probe) 관문과의
-        기준 통합은 Phase 5 관문 통합(#146 ⓑ1)에서 viewmodel로 옮길 때 함께.
+        실행의 초기값 ①이 된다. isdir 관문(판정은 path_gates 단일 지점,
+        #169)은 커밋된 미완성·오타 경로가 초기값을 오염시키지 않게 한다.
         """
         path = self.downloadPathInput.text().strip()
-        if path and os.path.isdir(path):
+        if check_remember_path(path):
             self._rememberDownloadPath(path)
 
     def _rememberDownloadPath(self, path: str) -> None:

--- a/content/manager.py
+++ b/content/manager.py
@@ -1,17 +1,31 @@
+"""ContentViewModel의 뷰 바인더 (#169 — Phase 5).
+
+로직(모델 소유·워커 오케스트레이션·다운로드 게이트·배치 체인)은
+app/viewmodels/content_viewmodel.py로 이동했다. 이 클래스는 기존 공개
+계약(생성자·시그널·메서드·속성)을 그대로 유지한 채 viewmodel에 위임하고,
+뷰 방향 시그널을 view.onDownload* 메서드에 연결한다.
+
+이 모듈에 남는 것과 그 이유:
+- probe_writable — OS 수준 쓰기 프로브(#137)의 정본. 테스트가
+  `from content.manager import probe_writable`로 import하고 monkeypatch
+  지점도 이 모듈이다
+- ContentWorker 전역 참조(_make_worker) — 테스트의 monkeypatch 지점
+- tr() 리터럴(실패 문구) — 번역 컨텍스트("ContentManager")와 lupdate 스캔
+  대상(project.json sources)이 이 파일에 걸려 있다
+"""
+
 import logging
 import os
 import tempfile
 import threading
 
-from PySide6.QtCore import Qt, Signal, QThreadPool, QObject
-from content.model import ContentListModel
-from content.view import ContentListView
-from content.delegate import ContentListDelegate
+from PySide6.QtCore import QObject
+
+from app.viewmodels.content_viewmodel import ContentViewModel
 from content.data import ContentItem
-from download.state import DownloadState
-from app.viewmodels.item_state import ItemState
+from content.delegate import ContentListDelegate
+from content.view import ContentListView
 from content.worker import ContentWorker
-from core.utils.paths import build_output_path, ensure_unique_path
 
 logger = logging.getLogger(__name__)
 
@@ -57,231 +71,130 @@ def probe_writable(directory: str, timeout_s: float = _WRITE_PROBE_TIMEOUT_S) ->
     return reason == "", reason
 
 
-class ContentManager(QObject):
-    # 메타데이터 매니저 UI
-    downloadRequested = Signal(object)
-    stopRequested = Signal(object)
-    insertItemRequested = Signal(int)
-    deleteItemRequested = Signal(object, int)
-    finishedRequested = Signal(object)
-    finishedAllRequested = Signal()
-    fetchRequested = Signal(str)
-    contentError = Signal(str)  # ✅ UI에서 오류를 처리할 수 있도록 signal 추가
+def _make_worker(vod_url: str, cookies: dict, downloadPath: str):
+    """모듈 전역 ContentWorker를 조회해 생성한다 — 테스트의 monkeypatch 지점."""
+    return ContentWorker(vod_url, cookies, downloadPath)
 
-    def __init__(self, view: ContentListView, parent = None):
+
+class ContentManager(QObject):
+    def __init__(self, view: ContentListView, parent=None):
         super().__init__(parent)
-        
+        self._vm = ContentViewModel(
+            worker_factory=_make_worker,
+            probe=lambda directory: probe_writable(directory),
+            messages={
+                "invalid_path": self._invalidPathMessage,
+                "save_failed": self._saveFailedMessage,
+            },
+            parent=self,
+        )
+        # 바운드 시그널 재노출 — download/manager.py 파사드와 같은 방식.
+        # 기존 소비자(mainWindow·view·테스트)의 connect가 무변경으로 동작한다
+        self.downloadRequested = self._vm.downloadRequested
+        self.stopRequested = self._vm.stopRequested
+        self.insertItemRequested = self._vm.insertItemRequested
+        self.deleteItemRequested = self._vm.deleteItemRequested
+        self.finishedRequested = self._vm.finishedRequested
+        self.finishedAllRequested = self._vm.finishedAllRequested
+        self.fetchRequested = self._vm.fetchRequested
+        self.contentError = self._vm.contentError
+
         self.view = view
-        self.model = ContentListModel()
         self.view.setModel(self.model)
         self.view.setItemDelegate(ContentListDelegate())
         self.view.deleteRequest.connect(self.removeItem)
         self.view.fetchRequested.connect(self.fetchReuest)
 
-        self.downloadPath = ""
-        self.threadpool = QThreadPool()
-        # 조회 중인 워커 → 자리표시 아이템. 결과가 도착할 때까지 워커의 파이썬
-        # 참조를 잡아 두는 역할도 한다 — 참조가 없으면 run() 종료 직후 워커가
-        # 파괴되어 큐에 남은 finished/error 전달이 유실된다 (#124)
-        self._pendingPlaceholders = {}
+        # 구 view 직접 호출 6곳의 반전 (#169): viewmodel은 시그널로 말하고,
+        # 뷰 연결은 바인더가 담당한다
+        self._vm.itemStarted.connect(self.view.onDownloadStarted)
+        self._vm.itemStopped.connect(self.view.onDownloadStoped)
+        self._vm.itemPaused.connect(self.view.onDownloadPaused)
+        self._vm.itemResumed.connect(self.view.onDownloadResumed)
+        self._vm.itemFinished.connect(self.view.onDownloadFinished)
+
+    # ---- 실패 문구 — tr() 리터럴은 이 클래스에 남긴다 (컨텍스트·lupdate) ----
+
+    def _invalidPathMessage(self) -> str:
+        return self.tr("Invalid file path")
+
+    def _saveFailedMessage(self) -> str:
+        return self.tr("Failed to save file")
+
+    # ---- viewmodel 상태 재노출 ----
+
+    @property
+    def model(self):
+        return self._vm.model
+
+    @property
+    def threadpool(self):
+        return self._vm.threadpool
+
+    @property
+    def downloadPath(self):
+        return self._vm.downloadPath
+
+    @downloadPath.setter
+    def downloadPath(self, value):
+        self._vm.downloadPath = value
+
+    @property
+    def _pendingPlaceholders(self):
+        return self._vm._pendingPlaceholders
+
+    # ---- 공개 API 위임 ----
 
     def fetchReuest(self, urls):
         self.fetchRequested.emit(urls)
 
     def fetchContent(self, vod_url: str, cookies: dict, downloadPath: str) -> None:
-        # 조회가 끝나기 전에도 카드가 보이도록 LOADING 상태의 자리표시 아이템을
-        # 즉시 추가한다. LOADING 아이템은 findItem이 건너뛰므로 다운로드되지 않는다 (#124)
-        placeholder = ContentItem(
-            vod_url,
-            {'title': vod_url, 'category': '', 'channelName': '', 'createdDate': '', 'duration': 0},
-            [], None, '', downloadPath, '', None,
-        )
-        placeholder.downloadState = ItemState.LOADING
-        self.model.addItem(placeholder)
-        self.insertItemRequested.emit(self.model.rowCount())
-
-        worker = ContentWorker(vod_url, cookies, downloadPath)
-        self._pendingPlaceholders[worker] = placeholder
-
-        # 시그널/슬롯 연결 — 반드시 바운드 메서드로 연결한다. partial/lambda로
-        # 연결하면 연결의 소유가 워커(발신자) 쪽이 되어, 워커가 파괴되는 순간
-        # 큐에 남은 전달이 함께 사라진다 (#124 스모크 실패의 원인)
-        worker.finished.connect(self.onWorkerFinished)  # 결과 처리 슬롯
-        worker.error.connect(self.onWorkerError)           # 에러 처리 슬롯
-
-        self.threadpool.start(lambda: worker.run())
-
-    def onWorkerFinished(self, result, content_type):
-        # result는 (vod_url, metadata, unique_reps, resolution, base_url, downloadPath, liveRewindPlaybackJson) 형식
-        placeholder = self._pendingPlaceholders.pop(self.sender(), None)
-        if placeholder is None:
-            return
-        vod_url, metadata, unique_reps, resolution, base_url, downloadPath, liveRewindPlaybackJson = result
-        self.downloadPath = downloadPath
-        row = self.model.getRow(placeholder)
-        if row is None:
-            # 조회 중 유저가 카드를 삭제한 경우 — 결과를 버린다
-            return
-        # 완성된 아이템으로 같은 자리에서 교체한다. 행 삭제→삽입을 거쳐야
-        # 해상도 버튼·썸네일이 붙은 위젯이 새로 만들어진다
-        item = ContentItem(vod_url, metadata, unique_reps, resolution, base_url, downloadPath, content_type, liveRewindPlaybackJson)
-        self.model.removeRows(row, 1)
-        self.model.addItem(item, row)
-
-    def onWorkerError(self, error_message):
-        placeholder = self._pendingPlaceholders.pop(self.sender(), None)
-        if placeholder is not None:
-            row = self.model.getRow(placeholder)
-            if row is not None:
-                self.model.removeRows(row, 1)
-                self.deleteItemRequested.emit(placeholder, self.model.rowCount())
-        self.contentError.emit(error_message)
+        self._vm.fetchContent(vod_url, cookies, downloadPath)
 
     def clrearFinishedItems(self):
-        if not self.model.isEmpty():
-            for row in reversed(range(self.model.rowCount())):
-                index = self.model.index(row, 0)
-                item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-                # 아이템이 완료 상태이면 삭제
-                if item.downloadState == DownloadState.FINISHED:
-                    self.removeItem(item)
-
+        self._vm.clrearFinishedItems()
 
     def removeItem(self, item: ContentItem):
-        row = self.model.getRow(item)  # ✅ 객체의 row 찾기
-        if row is not None:
-            self.model.removeRows(row, 1)  # ✅ 올바른 삭제 요청
-            index = self.model.rowCount()
-            self.deleteItemRequested.emit(item, index)
+        self._vm.removeItem(item)
 
     def downloadItem(self):
-        found, item, index = self.findItem()
-        if found:
-            try:
-                # 사전 검사 (#137): 존재만 보던 구 검사(os.path.exists)를 존재+쓰기
-                # 프로브로 확장한다. 존재 검사도 프로브 스레드 안에서 수행한다 —
-                # 무응답 마운트에서는 exists조차 메인 스레드를 매달 수 있다 (#136)
-                writable, reason = probe_writable(item.download_path)
-                if reason == "missing":
-                    raise ValueError(self.tr("Invalid file path"))
-                if not writable:
-                    # 권한 없음(denied — 예: SFTP 상 ZFS 풀 루트) 또는 무응답
-                    # 마운트(timeout — 권한 오류가 오류로 전파되지 않는 경우).
-                    # 유저에게는 같은 사실이다: 이 경로에는 저장할 수 없다
-                    # 경로는 repr로 남긴다 (#148) — 공백 유사 문자(U+00A0 등)를
-                    # 육안 구분할 수 있는 유일한 표기다 (#144 실측)
-                    logger.warning("쓰기 프로브 실패(%s): %r", reason, item.download_path)
-                    self.fail(item, self.tr("Failed to save file"))
-                    return
-                self.onDownload(item)
-            except ValueError as e:
-                # 위에서 직접 던진 번역된 안내 — 그대로 카드에 표시한다.
-                # 이 거부는 지금까지 로그가 전혀 없어 제보 진단이 불가능했다 (#148)
-                logger.warning(
-                    "다운로드 시작 거부 — 존재하지 않는 저장 경로: %r", item.download_path
-                )
-                self.fail(item, str(e))
-            except Exception:
-                # 경로 조립(OSError 등)의 원시 문자열에는 전체 경로가 섞여 있어
-                # 유저에게 보내지 않는다 (#134) — 상세는 로그로만 남긴다
-                logger.exception("다운로드 준비 실패: %s", item.title)
-                self.fail(item, self.tr("Failed to save file"))
-        else:
-            self.finishedAllRequested.emit()
+        self._vm.downloadItem()
 
     def onDownload(self, item: ContentItem):
-        """
-        해상도 버튼 클릭 시 다운로드 진행.
-        """
-        if item:
-            # 조립·중복 회피는 core가 단일 지점으로 담당한다 — 같은 제목이
-            # 이미 있으면 " (n)"이 붙은 새 경로를 받는다 (#105)
-            item.output_path = build_output_path(item.download_path, item.title, item.resolution)
-        else:
-            item.output_path = ensure_unique_path(os.path.join(item.download_path, "video.mp4"))
-
-        if item.output_path:
-            # 다운로드 요청 시그널 발행
-            self.downloadRequested.emit(item)
+        self._vm.onDownload(item)
 
     def update_progress(self, rem, size, spd, prog, item: ContentItem):
-        item.download_remain_time = rem
-        item.download_size = size
-        item.download_speed = spd
-        item.download_progress = prog
-        
-        row = self.model.getRow(item)
-        index = self.model.index(row, 0)
-        self.model.dataChanged.emit(index, index)
+        self._vm.update_progress(rem, size, spd, prog, item)
 
     def start(self, item):
-        self.view.onDownloadStarted(item)
+        self._vm.start(item)
 
     def stop(self, item):
-        self.view.onDownloadStoped(item)
+        self._vm.stop(item)
 
     def pause(self, item):
-        self.view.onDownloadPaused(item)
+        self._vm.pause(item)
 
     def resume(self, item):
-        self.view.onDownloadResumed(item)
+        self._vm.resume(item)
 
     def finish(self, item: ContentItem, download_time):
-        item.download_time = download_time
-        self.view.onDownloadFinished(item, True)
-        self.emitFinishedRequest(item)
-    
-    def fail(self, item: ContentItem, message: str = ""):
-        """아이템을 실패 상태로 표시하고 배치 체인을 계속 진행한다 (#134).
+        self._vm.finish(item, download_time)
 
-        message는 카드의 실패 사유로 렌더된다 — 키 기반 매핑을 거친 번역
-        문자열만 넣는다 (원시 예외 문자열 금지). emitFinishedRequest가 완료
-        경로와 동일하게 다음 항목의 다운로드를 이어 간다.
-        """
-        item.stateMessage = message
-        item.downloadState = DownloadState.FAILED
-        self.view.onDownloadFinished(item, False)
-        self.emitFinishedRequest(item)
+    def fail(self, item: ContentItem, message: str = ""):
+        self._vm.fail(item, message)
 
     def emitStopRequested(self, item: ContentItem):
-        self.stopRequested.emit(item)
-    
+        self._vm.emitStopRequested(item)
+
     def emitFinishedRequest(self, item: ContentItem):
-        self.finishedRequested.emit(item)
-        self.downloadItem()
+        self._vm.emitFinishedRequest(item)
 
     def findItem(self):
-        row_count = self.model.rowCount()
-        for row in range(row_count):
-            index = self.model.index(row, 0)
-            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-            # LOADING은 메타데이터가 아직 없어 다운로드 대상이 아니다 (#124)
-            if item.downloadState not in [DownloadState.FINISHED, DownloadState.FAILED, ItemState.LOADING]:
-                return True, item, index
-        return False, None, None
+        return self._vm.findItem()
 
     def hasLoadingItems(self):
-        """메타데이터 조회가 끝나지 않은 아이템이 있는지 여부."""
-        for row in range(self.model.rowCount()):
-            index = self.model.index(row, 0)
-            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-            if item.downloadState == ItemState.LOADING:
-                return True
-        return False
+        return self._vm.hasLoadingItems()
 
     def downloadResultCounts(self) -> tuple[int, int]:
-        """화면(모델)의 (완료, 실패) 항목 수를 센다 — 배치 종료 안내 분기용 (#134).
-
-        별도 배치 장부를 두지 않고 화면 상태를 그대로 센다: 안내의 역할은
-        "지금 화면에 보이는 결과"와 모순되지 않는 것이고, 배치의 경계는
-        항목 추가·삭제가 진행 중에도 가능해 정확한 장부가 존재하지 않는다.
-        """
-        finished = failed = 0
-        for row in range(self.model.rowCount()):
-            index = self.model.index(row, 0)
-            item: ContentItem = self.model.data(index, Qt.ItemDataRole.UserRole)
-            if item.downloadState == DownloadState.FINISHED:
-                finished += 1
-            elif item.downloadState == DownloadState.FAILED:
-                failed += 1
-        return finished, failed
+        return self._vm.downloadResultCounts()

--- a/content/widget.py
+++ b/content/widget.py
@@ -7,6 +7,7 @@ from content.data import ContentItem
 from content.network import REQUEST_TIMEOUT, get_thread_session
 from download.state import DownloadState
 from app.viewmodels.item_state import ItemState
+from app.viewmodels.path_gates import check_card_edit_path
 from ui.contentItemWidget import Ui_ContentItemWidget
 from time import strftime, gmtime
 import platform
@@ -314,7 +315,8 @@ class ContentItemWidget(QWidget, Ui_ContentItemWidget):
         self.directoryEdit.setVisible(False)
         self.directoryLabel.setVisible(True)
         new_path = self.directoryEdit.text().strip()
-        if new_path and os.path.exists(new_path):
+        # 판정은 path_gates가 단일 지점으로 담당한다 (#169 — #146 ⓑ1)
+        if check_card_edit_path(new_path):
             self.directoryLabel.setText(new_path)  # ✅ UI 업데이트
             self.item.download_path = new_path  # ✅ 데이터 업데이트
             self.textChanged.emit(new_path)  # ✅ 모델에도 반영하도록 시그널 전송


### PR DESCRIPTION
## 요약

Closes #169 — Phase 5 viewmodel 단계의 3번 작업(본 단계 최대 난이도).

ContentManager를 2분할합니다: 로직은 뷰 무의존 `ContentViewModel`(app/viewmodels/)로, `content/manager.py`의 ContentManager는 기존 공개 계약을 그대로 유지하는 **뷰 바인더**로 남습니다. 경로 관문 4곳의 판정을 `path_gates.py` 단일 지점으로 모았습니다. UI 무변경 — **기존 테스트 389개 전부 무수정 통과**(계획에서 수정 불가피로 예측했던 `_pendingPlaceholders` 단언 4곳까지 위임 프로퍼티로 보존).

## 구현

**`app/viewmodels/content_viewmodel.py` — 로직 절반**
- 모델 소유·워커 오케스트레이션·다운로드 게이트·배치 체인·항목 상태 전이. 위젯 타입 import 없음
- **뷰 직접 호출 6곳 반전**: `view.onDownload*` 직접 호출 → `itemStarted/itemStopped/itemPaused/itemResumed/itemFinished` 시그널. 바인더가 view 메서드에 연결
- **`self.sender()` 역추적 제거**: 워커별 `_WorkerRelay`(바운드 메서드 연결)로 워커→자리표시 매핑을 명시화. #124의 "partial/lambda 연결 금지" 제약(연결 소유가 발신자 쪽이 되어 워커 파괴 시 큐 전달 유실)을 릴레이 객체의 바운드 메서드로 지켰고, 릴레이 참조는 결과 도착까지 `_relays`에 보관됩니다

**`app/viewmodels/path_gates.py` — 관문 판정 단일 지점(#146 ⓑ1)**
- 조회(exists)·보존(isdir, #165)·다운로드 게이트(쓰기 프로브, #137)·카드 편집(exists, #148)의 판정 함수 4개가 한 모듈에 모입니다. mainWindow·widget·viewmodel이 이걸 호출합니다
- **기준·문구·로그는 현행 그대로** — 관문별 기준이 다른 것(exists vs isdir)은 의도적으로 보존했고, 기준 통일·문구 재설계는 동작 변경이므로 셸 단계(2.10.0)로 명시 유보(모듈 docstring에 기록)

**`content/manager.py` — 뷰 바인더**
- 생성자·시그널(바운드 재노출, download/manager.py 파사드와 같은 방식)·공개 메서드·`model`/`threadpool`/`_pendingPlaceholders` 프로퍼티 전부 기존 계약 유지

## 리뷰어에게 — 남긴 것과 그 이유

- **`probe_writable`은 manager에 남습니다**: 테스트가 `from content.manager import probe_writable`로 import하고 monkeypatch 지점도 이 모듈입니다. viewmodel은 이를 주입받습니다(`lambda directory: probe_writable(directory)` — 호출 시점 모듈 전역 조회라 monkeypatch가 계속 듣습니다). core/utils/paths 이동 검토는 #171 이후로
- **tr() 리터럴(실패 문구)도 manager에 남습니다**: 번역 컨텍스트가 `"ContentManager"`(ko/en .ts 실측)이고 lupdate `-no-obsolete`의 스캔 대상이 project.json sources(이 파일 포함)라, viewmodel로 옮기면 **번역이 소실**됩니다. viewmodel은 문구 콜러블을 주입받습니다
- **유저 행위 로그의 로거 이름은 `content.manager` 유지**: viewmodel 모듈이 명시적으로 `logging.getLogger("content.manager")`를 씁니다 — 제보 진단 절차와 기존 caplog 테스트가 이 이름을 알고 있고, 로직의 거처가 바뀌었다고 로그 소비자의 주소까지 바꾸지 않습니다. 로거 재편은 셸 단계에서
- **worker 생성은 `_make_worker`(모듈 전역 조회) 주입**: `monkeypatch.setattr(manager_mod, "ContentWorker", FakeWorker)`가 무변경으로 동작합니다
- linkStatusLabel(#146 ⓑ2)은 이 PR 범위가 아닙니다 — 조회 오케스트레이션의 단일 소유자(viewmodel)가 마련됐다는 기반까지이고, 라벨 수명주기 연결은 셸 단계입니다
- 죽은 else 분기(`onDownload`의 `ensure_unique_path` 경로)는 동작 보존 원칙에 따라 그대로 옮겼습니다 — 정리는 #171에서 판단

## 검증 — "UI 무변화"

- 전체 스위트 **389 passed, 4 skipped — 테스트 파일 수정 0건** (실배선 GUI 40개 포함: 실패 카드 스타일시트 `#FF6969`·statusLabel 문구·큐 전달 경로까지 기존 단언 그대로)
- main 기준 갤러리 vs 본 브랜치 `CVDV2_SHOT_ALL=1` 갤러리: 10건 전원 이미지 치수 동일(QImage 전수 비교), 추가·누락 없음 — 로컬 Windows offscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)