### PR TITLE
refactor: download/state·data re-export 제거 — core.models 직접 import 일괄 치환 (#171)

### DIFF
--- a/app/viewmodels/content_viewmodel.py
+++ b/app/viewmodels/content_viewmodel.py
@@ -23,7 +23,7 @@ from app.viewmodels.path_gates import check_download_path
 from content.data import ContentItem
 from content.model import ContentListModel
 from core.utils.paths import build_output_path, ensure_unique_path
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 # 유저 행위·관문 로그의 로거 이름은 "content.manager"를 유지한다 — 제보
 # 진단 절차와 기존 테스트(caplog)가 이 이름을 알고 있고, 로직의 거처가

--- a/application/mainWindow.py
+++ b/application/mainWindow.py
@@ -11,7 +11,7 @@ from app.viewmodels.path_gates import check_fetch_path, check_remember_path
 from config.dialog import SettingDialog
 from content.data import ContentItem
 from content.manager import ContentManager
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 from ui.mainWindow import Ui_VodDownloader
 
 logger = logging.getLogger(__name__)

--- a/content/data.py
+++ b/content/data.py
@@ -1,4 +1,4 @@
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 # 세그먼트 단위로 받는 타입 — 전체 크기를 미리 알 수 없어 진행률·표시가
 # 세그먼트 수 기반이다 (m3u8: 라이브 다시보기, hls_aes: AES 암호화 VOD #57)

--- a/content/widget.py
+++ b/content/widget.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QPixmap, QDesktopServices
 from PySide6.QtCore import Qt, QSize, Signal, QUrl, QDir, QProcess
 from content.data import ContentItem
 from content.network import REQUEST_TIMEOUT, get_thread_session
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 from app.viewmodels.item_state import ItemState
 from app.viewmodels.path_gates import check_card_edit_path
 from ui.contentItemWidget import Ui_ContentItemWidget

--- a/core/models/download_data.py
+++ b/core/models/download_data.py
@@ -13,8 +13,8 @@
 
 #75에서 download/data.py에서 core로 이주했다 — DownloadService가 Content만 받아
 엔진 공유 데이터를 core 안에서 만들 수 있어야 하기 때문이다("core만으로 다운로드").
-이 모듈은 원래부터 core 모델만 참조하는 순수 코드였고, 기존 앱 계층 import 경로
-(download.data)는 re-export로 유지된다.
+이 모듈은 원래부터 core 모델만 참조하는 순수 코드였다. 구 앱 계층 import 경로
+(download.data)의 re-export는 #171에서 제거됐다 — 이곳이 유일한 정의처다.
 """
 
 from core.models.content import Content, ContentType

--- a/download/data.py
+++ b/download/data.py
@@ -1,9 +1,0 @@
-"""하위 호환 re-export — DownloadData 정의는 core/models/download_data.py로 이주 (#75).
-
-기존 호출부(download 모듈, 테스트)의 import 경로를 유지하기 위한 파일이다.
-새 코드는 core.models.download_data에서 직접 import할 것.
-"""
-
-from core.models.download_data import DownloadData
-
-__all__ = ["DownloadData"]

--- a/download/qt_bridge.py
+++ b/download/qt_bridge.py
@@ -30,7 +30,7 @@ from core.downloaders.base import PostprocessError
 from core.downloaders.hls_aes_downloader import DecryptionError
 from core.models.events import ProgressEvent
 from core.services.download_service import DownloadService
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 from download.logger import DownloadLogger
 from download.resolvers import resolve_aes_key, resolve_m3u8_base_url
 from download.task import DownloadTask

--- a/download/state.py
+++ b/download/state.py
@@ -1,9 +1,0 @@
-"""하위 호환 re-export — DownloadState 정의는 core/models/download_state.py로 이주 (#60).
-
-기존 호출부(application, content, download 모듈)의 import 경로를 유지하기 위한 파일이다.
-새 코드는 core.models.download_state에서 직접 import할 것.
-"""
-
-from core.models.download_state import DownloadState
-
-__all__ = ["DownloadState"]

--- a/download/task.py
+++ b/download/task.py
@@ -11,7 +11,7 @@ import threading
 from content.data import ContentItem
 from core.models.download_state import DownloadState
 from core.models.download_task import InvalidStateTransitionError
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 from download.logger import DownloadLogger
 
 

--- a/scripts/headless_download.py
+++ b/scripts/headless_download.py
@@ -50,7 +50,7 @@ from core.services import metadata_service  # noqa: E402
 from core.services.download_service import DownloadService  # noqa: E402
 from core.services.metadata_service import MetadataError  # noqa: E402
 from core.utils.paths import build_output_path  # noqa: E402
-from download.data import DownloadData  # noqa: E402
+from core.models.download_data import DownloadData  # noqa: E402
 from download.logger import DownloadLogger  # noqa: E402
 from download.resolvers import resolve_aes_key, resolve_m3u8_base_url  # noqa: E402
 from download.task import DownloadTask  # noqa: E402

--- a/tests/unit/core/test_download_plan.py
+++ b/tests/unit/core/test_download_plan.py
@@ -22,7 +22,7 @@ from core.downloaders.file_downloader import FileDownloader
 from core.downloaders.m3u8_downloader import M3U8Downloader
 from core.downloaders.ranges import split_ranges
 from core.models.plan import DownloadPlan, TimeRange
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 

--- a/tests/unit/core/test_engine_oserror_containment.py
+++ b/tests/unit/core/test_engine_oserror_containment.py
@@ -26,7 +26,7 @@ from core.services.download_service import DownloadService
 
 import core.downloaders.file_downloader as fd_module
 from core.downloaders.file_downloader import FileDownloader
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 TOTAL_SIZE = 4 * MB  # 해상도 144 → 파트 1MB → 4파트

--- a/tests/unit/core/test_file_downloader_rules.py
+++ b/tests/unit/core/test_file_downloader_rules.py
@@ -19,7 +19,7 @@
 import pytest
 import requests
 
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 

--- a/tests/unit/core/test_file_downloader_run.py
+++ b/tests/unit/core/test_file_downloader_run.py
@@ -14,7 +14,7 @@ import time
 import core.downloaders.file_downloader as fd_module
 from core.downloaders.file_downloader import FileDownloader
 from core.models.download_state import DownloadState
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 TOTAL_SIZE = 4 * MB  # 해상도 144 → 파트 1MB → 4파트

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -19,7 +19,7 @@ from core.api.dash import is_supported_sea, parse_sea_manifest
 from core.downloaders.decrypt import AES_BLOCK_SIZE, TS_PACKET_SIZE, sequence_iv
 from core.downloaders.hls_aes_downloader import DecryptionError, HlsAesDownloader
 from core.models.content import Content, ContentType
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 KEY = bytes(range(16))  # 테스트용 더미 키
 KEY_URI = "https://api.chzzk.naver.com/service/v1/encryption/videos/VID/aes_key"

--- a/tests/unit/core/test_m3u8_downloader_rules.py
+++ b/tests/unit/core/test_m3u8_downloader_rules.py
@@ -21,7 +21,7 @@
 import pytest
 import requests
 
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -17,7 +17,7 @@ import core.downloaders.base as base_module
 import core.downloaders.m3u8_downloader as m3u8_module
 from core.downloaders.m3u8_downloader import M3U8Downloader
 from core.models.download_state import DownloadState
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 CHUNK = 8192
 SEGMENT_COUNT = 6

--- a/tests/unit/core/test_requeue_limit.py
+++ b/tests/unit/core/test_requeue_limit.py
@@ -17,7 +17,7 @@ import requests
 
 from core.downloaders.base import _is_permanent_error
 from core.models.download_state import DownloadState
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 MB = 1024 * 1024
 CHUNK = 8192

--- a/tests/unit/test_app_layer_imports.py
+++ b/tests/unit/test_app_layer_imports.py
@@ -1,0 +1,54 @@
+"""app/(viewmodel 계층)의 "뷰 무의존" 불변 규칙 검증 (#171 — Phase 5).
+
+app/ 내 모든 .py 파일을 AST로 파싱해 위젯 계층 import가 없음을 확인한다.
+core의 "PySide6 금지"(tests/unit/core/test_no_qt_import.py)와 같은 방식이다 —
+app은 QtCore(QObject·Signal)는 쓸 수 있지만, 위젯(QtWidgets·QtGui)과
+뷰 모듈(ui, content.view, content.widget)을 알면 viewmodel 분리가 무너진다.
+content/download → ui 방향 위반을 잡는 자동 게이트가 없던 공백(#146 감사)을
+app 계층에 한해 메운다.
+"""
+
+import ast
+from pathlib import Path
+
+import app
+
+APP_DIR = Path(app.__file__).resolve().parent
+
+# app에서 import가 금지된 모듈 (최상위 또는 정확한 모듈 경로)
+FORBIDDEN_TOP_LEVEL = {"ui"}
+FORBIDDEN_MODULES = {"PySide6.QtWidgets", "PySide6.QtGui", "content.view", "content.widget"}
+
+
+def _iter_import_violations(py_file: Path) -> list[str]:
+    """파일 하나를 파싱해 금지 모듈 import 라인 목록을 반환한다."""
+    py_file = py_file.resolve()
+    tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module] if node.module else []
+        else:
+            continue
+        for name in names:
+            if name.split(".")[0] in FORBIDDEN_TOP_LEVEL or any(
+                name == m or name.startswith(m + ".") for m in FORBIDDEN_MODULES
+            ):
+                violations.append(f"{py_file.relative_to(APP_DIR.parent)}:{node.lineno}: {name}")
+    return violations
+
+
+def test_app_layer_has_no_view_import():
+    """app/ 내 모든 .py 파일에 위젯·뷰 모듈 import가 없어야 한다."""
+    py_files = sorted(APP_DIR.rglob("*.py"))
+    assert py_files, "app/에서 .py 파일을 찾지 못했다 — 스캔 대상 경로를 확인할 것"
+
+    violations = []
+    for py_file in py_files:
+        violations.extend(_iter_import_violations(py_file))
+
+    assert not violations, "app(viewmodel)은 뷰를 몰라야 한다. 금지 import 발견:\n" + "\n".join(
+        violations
+    )

--- a/tests/unit/test_content_manager.py
+++ b/tests/unit/test_content_manager.py
@@ -17,7 +17,7 @@ import content.manager as manager_mod
 from content.data import ContentItem
 from content.manager import ContentManager
 from content.view import ContentListView
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_download_data.py
+++ b/tests/unit/test_download_data.py
@@ -6,7 +6,7 @@ DownloadData가 컨텐츠 필드는 Content로, 상태·진행률 필드는 Down
 
 import pytest
 
-from download.data import DownloadData
+from core.models.download_data import DownloadData
 
 
 def _make_data() -> DownloadData:

--- a/tests/unit/test_download_task_adapter.py
+++ b/tests/unit/test_download_task_adapter.py
@@ -1,15 +1,18 @@
-"""download/task.py 어댑터·download/state.py re-export 검증 (#60).
+"""download/task.py 어댑터 검증 (#60).
 
 상태 머신을 core/models로 이주한 뒤에도 기존 호출부 인터페이스
 (state 속성, lock, start/pause/resume/stop/finish/isRunning)가 유지되고,
 ContentItem 상태 반영과 pause_event 공유가 동작하는지 확인한다.
+
+download/state.py·data.py re-export가 제거되어(#171) 동일성 단언
+(test_state_reexport_is_same_class)은 계약 소멸로 함께 삭제됐다 —
+이제 core.models가 유일한 import 경로다.
 """
 
 import threading
 
-from core.models.download_state import DownloadState as CoreDownloadState
-from download.data import DownloadData
-from download.state import DownloadState
+from core.models.download_data import DownloadData
+from core.models.download_state import DownloadState
 from download.task import DownloadTask
 
 
@@ -46,11 +49,6 @@ def _make_task() -> tuple[DownloadTask, DownloadData, _FakeItem, _FakeLogger]:
     item = _FakeItem()
     logger = _FakeLogger()
     return DownloadTask(data, item, logger), data, item, logger
-
-
-def test_state_reexport_is_same_class():
-    """download.state의 DownloadState는 core 정의와 동일 객체여야 한다."""
-    assert DownloadState is CoreDownloadState
 
 
 def test_adapter_keeps_engine_interface():

--- a/tests/unit/test_failure_display.py
+++ b/tests/unit/test_failure_display.py
@@ -17,7 +17,7 @@ from content.manager import ContentManager
 from content.view import ContentListView
 from core.downloaders.base import PostprocessError
 from download.qt_bridge import QtDownloadBridge
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_path_action_logging.py
+++ b/tests/unit/test_path_action_logging.py
@@ -17,7 +17,7 @@ import content.widget as widget_mod
 from content.data import ContentItem
 from content.manager import ContentManager
 from content.view import ContentListView
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 NBSP_SUFFIX = "없는\u00a0폴더"  # 존재하지 않는 + 공백 유사 문자 포함
 

--- a/tests/unit/test_write_probe.py
+++ b/tests/unit/test_write_probe.py
@@ -17,7 +17,7 @@ import content.manager as manager_mod
 from content.data import ContentItem
 from content.manager import ContentManager, probe_writable
 from content.view import ContentListView
-from download.state import DownloadState
+from core.models.download_state import DownloadState
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## 요약

Closes #171 — Phase 5 viewmodel 단계의 5번(마지막) 작업.

Phase 2~3 이주기의 하위호환 껍데기(`download/state.py`·`download/data.py` re-export)를 제거하고 소스·테스트의 import를 `core.models` 직접 경로로 일괄 치환합니다. 마무리로 app 계층의 뷰 무의존을 자동 검증하는 아키텍처 가드 테스트를 추가합니다. UI 무변경.

## 구현

- **re-export 2파일 삭제**: `download/state.py`(9줄)·`download/data.py`(9줄). `download/manager.py`는 #170에서 이미 제거됨
- **import 기계 치환**: 소스 7파일 + 테스트 13파일 — **테스트 diff는 import 줄뿐이고 시나리오·단언 무수정**(계획의 리뷰 기준 그대로). core 테스트 8파일이 `download.data`를 경유하던 "core 안 건드렸는데 연쇄 실패" 함정을 이 PR이 해소합니다
- **동일성 박제 삭제**: `test_state_reexport_is_same_class`(`download.state.DownloadState is core...DownloadState`)는 re-export 계약 자체가 소멸했으므로 함께 삭제 — 박제 훼손이 아니라 계약의 수명 종료입니다(파일 docstring에 기록)
- **`content↔download` 패키지 순환(사이클 A) 완전 해소**: content가 download를 더 이상 import하지 않습니다(잔여는 `ui↔content` 사이클 B뿐 — Designer promoted widget이라 셸 단계 대상)
- **아키텍처 가드 신설**(`tests/unit/test_app_layer_imports.py`): app/ 전 파일을 AST 파싱해 `PySide6.QtWidgets`·`PySide6.QtGui`·`ui`·`content.view`·`content.widget` import 금지 — `test_no_qt_import` 방식 준용. content/download→ui 방향을 잡는 자동 게이트가 없던 공백을 app 계층에 한해 메웁니다

## 검증 — "UI 무변화"

- 전체 스위트 **389 passed, 4 skipped** (기존 388 단언 무수정 + 가드 1 신설 − 동일성 1 삭제)
- main 기준 갤러리 vs 본 브랜치: 10건 전원 이미지 치수 동일(QImage 전수 비교) — 로컬 Windows offscreen

## Phase 5 viewmodel 단계 종결

이 PR 머지로 #167~#171 다섯 작업이 모두 끝납니다. 남은 검증은 릴리즈 게이트 — v2.9.4-rc1로 Nuitka 번들(신규 `app/` 패키지 포함)의 3-OS 기동 스모크를 확인하는 것입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)