### PR TITLE
fix: 로그 폴더 열기를 os.startfile에서 QDesktopServices.openUrl로 — macOS·Linux 지원 (#181)

### DIFF
--- a/config/dialog.py
+++ b/config/dialog.py
@@ -1,6 +1,8 @@
 import os
 import config.config as config
 from PySide6.QtWidgets import QDialog, QMessageBox
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtCore import QUrl
 
 from ui.settingDialog import Ui_SettingDialog
 
@@ -69,7 +71,11 @@ class SettingDialog(QDialog, Ui_SettingDialog):
         QMessageBox.information(self, self.tr("Helper"), msg)
 
     def openLogsFolder(self):
-        os.startfile(os.path.join(config.CONFIG_DIR, "logs"))
+        # os.startfile은 Windows 전용이라 macOS·Linux에서 무조건 AttributeError였다
+        # (#181). QDesktopServices.openUrl은 3-OS 공통으로 폴더를 연다.
+        path = os.path.join(config.CONFIG_DIR, "logs")
+        if not QDesktopServices.openUrl(QUrl.fromLocalFile(path)):
+            QMessageBox.warning(self, self.tr("Warning"), f"'{path}'을(를) 열 수 없습니다.")
 
     def getCookies(self):
         """

--- a/tests/unit/test_dialog.py
+++ b/tests/unit/test_dialog.py
@@ -1,0 +1,30 @@
+"""SettingDialog.openLogsFolder 3-OS 동작 검증 (#181).
+
+os.startfile은 Windows 전용이라 macOS·Linux에서 클릭 시 무조건
+AttributeError였다. QDesktopServices.openUrl로 바꿔 3-OS 공통 동작을
+보장한다.
+"""
+
+from unittest.mock import patch
+
+from config.dialog import SettingDialog
+
+
+def test_open_logs_folder_uses_desktop_services(qapp):
+    dialog = SettingDialog()
+    with patch("config.dialog.QDesktopServices.openUrl", return_value=True) as m:
+        dialog.openLogsFolder()
+
+    assert m.call_count == 1
+    (url,), _ = m.call_args
+    assert url.isLocalFile()
+    assert url.toLocalFile().endswith("logs")
+
+
+def test_open_logs_folder_warns_on_failure(qapp):
+    dialog = SettingDialog()
+    with patch("config.dialog.QDesktopServices.openUrl", return_value=False):
+        with patch("config.dialog.QMessageBox.warning") as warn:
+            dialog.openLogsFolder()
+
+    assert warn.called


### PR DESCRIPTION
#181의 원인 확정 후 수정.

## 리뷰어에게

- `os.startfile`은 Windows 전용(POSIX `os`에는 속성 자체가 없음 — 조건부 실패가 아니라 macOS·Linux에서 100% AttributeError). `content/widget.py`의 "저장 위치 열기"처럼 플랫폼 분기를 추가할 수도 있었지만, 로그 폴더는 "파일 선택 없이 폴더만 열면" 되는 단순 케이스라 Qt의 `QDesktopServices.openUrl` 하나로 3-OS를 다 커버했다(위젯 쪽의 else 분기와 동일한 방식).
- 테스트는 실제 `SettingDialog`를 만들고 `QDesktopServices.openUrl`만 패치했다 — 성공/실패(경고 표시) 두 경로 모두 검증.
- 전체 테스트 391 passed, ruff 통과.

관련: #180(macOS ffmpeg 후처리 실패)은 별도 이슈로 남겨둠 — 원인이 macOS 실기 확인 없이는 확정되지 않아 이번 PR에 포함하지 않았다.
