### PR TITLE
fix: 후처리 병합에 세그먼트 파일 화이트리스트 적용 (#180)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -50,6 +50,7 @@ data·logger는 DownloadData/DownloadLogger 호환 객체를 주입받는다.
 """
 
 import os
+import re
 import threading
 import time as tm
 from abc import ABC, abstractmethod
@@ -260,6 +261,36 @@ class BaseDownloader(ABC):
 
         계획(DownloadPlan)의 requires_postprocess가 참일 때만 run()이 호출한다.
         """
+
+    def _list_segment_files(self, extensions: tuple[str, ...]) -> list[str]:
+        """임시 폴더에서 우리가 만든 세그먼트 파일만 화이트리스트로 골라 정렬해 반환한다.
+
+        os.listdir()은 임시 폴더의 모든 항목을 무차별로 반환한다 — macOS가
+        xattr을 지원하지 않는 파일시스템(exFAT 등)에 쓸 때 만드는 AppleDouble
+        사이드카(``._세그먼트명``)나 Finder의 ``.DS_Store`` 같은 잡파일이 하나만
+        섞여도 이름이 '.'로 시작해 사전순 정렬에서 항상 맨 앞으로 온다 — 그게
+        진짜 세그먼트보다 먼저 ffmpeg stdin에 들어가 파이프 첫 바이트를
+        오염시킨다(#180 — 오너 실기에서 세그먼트 수만큼 실물 확인, 임시
+        폴더가 exFAT 외장 SD 카드 위였다).
+
+        블랙리스트(예: '.'로 시작하는 것만 제외)는 다른 잡파일 유형(동기화
+        도구의 충돌 사본, 백신 격리 사본 등)에 또 뚫린다 — 우리가 직접 만든
+        세그먼트 이름 패턴(숫자 + 다운로더별 확장자)에 맞는 것만 받는다.
+        걸러진 항목은 조용히 넘기지 않고 경고 로그로 남긴다 — 다음에 다른
+        종류의 오염이 왔을 때 또 못 보는 사태를 막기 위함이다.
+        """
+        pattern = re.compile(
+            r"^\d+(?:" + "|".join(re.escape(ext) for ext in extensions) + r")$"
+        )
+        entries = os.listdir(self.temp_dir)
+        matched = sorted(e for e in entries if pattern.match(e))
+        skipped = sorted(set(entries) - set(matched))
+        if skipped:
+            self.logger.warning(
+                f"임시 폴더에서 세그먼트가 아닌 항목 {len(skipped)}개를 건너뜀"
+                f"(병합에서 제외): {skipped!r}"
+            )
+        return matched
 
     def _remux_streamed(self, segment_paths: list[str]) -> None:
         """세그먼트 파일들을 순서대로 ffmpeg stdin에 흘려 산출물을 만든다 (#92).

--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -192,7 +192,7 @@ class HlsAesDownloader(BaseDownloader):
         _remux_streamed 참조).
         """
         self._on_merge_start()
-        segment_files = sorted(os.listdir(self.temp_dir))
+        segment_files = self._list_segment_files((".ts",))
         self._remux_streamed([os.path.join(self.temp_dir, f) for f in segment_files])
 
     # ============ 다운로드 동작 ============

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -137,7 +137,7 @@ class M3U8Downloader(BaseDownloader):
         세그먼트를 보존한다 (규칙은 base의 _remux_streamed 참조).
         """
         self._on_merge_start()
-        segment_files = sorted(os.listdir(self.temp_dir))
+        segment_files = self._list_segment_files((".m4s", ".m4v"))
         self._remux_streamed([os.path.join(self.temp_dir, f) for f in segment_files])
 
     # ============ 다운로드 동작 관련 메서드들 ============

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -8,6 +8,7 @@
 키 값은 테스트에서도 의미 없는 더미를 쓴다 — 실제 키는 어디에도 두지 않는다.
 """
 
+import os
 import threading
 
 import pytest
@@ -324,3 +325,36 @@ def test_run_downloads_decrypts_and_merges_in_order(tmp_path, monkeypatch):
     # TS 경로에는 초기화 세그먼트가 없어 병합 수 = 세그먼트 수다
     assert data.merged_segments == SEGMENT_COUNT
     assert not (tmp_path / "CVDv2_temp_out").exists()  # 임시 폴더 삭제 (#105 산출물 파생 이름)
+
+
+def test_stray_dotfile_in_temp_dir_is_excluded_from_merge(tmp_path, monkeypatch):
+    """세그먼트가 아닌 파일이 임시 폴더에 있어도 병합에서 제외되고 경고가 남는다 (#180).
+
+    m3u8(fMP4) 경로와 같은 오염 경로 — TS 경로는 확장자가 달라(``.ts``)
+    화이트리스트를 경로별로 따로 확인해야 한다는 지시에 따른 검증이다.
+    """
+    engine, data, logger, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch, key_resolver=lambda c, u: KEY
+    )
+
+    def _pollute_then_start_merge():
+        for name in ("._0.ts", ".DS_Store", "notes.txt"):
+            with open(os.path.join(engine.temp_dir, name), "wb") as f:
+                f.write(b"not-a-segment")
+        merge_starts.append(True)
+
+    engine._on_merge_start = _pollute_then_start_merge
+
+    data.model.start()
+    thread = threading.Thread(target=engine.run, daemon=True)
+    thread.start()
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    expected = b"".join(_segment_body(i) for i in range(SEGMENT_COUNT))
+    assert (tmp_path / "out.mp4").read_bytes() == expected  # 오염 없이 정상
+    assert failures == [] and logger.errors == []
+    assert len(logger.warnings) == 1
+    assert "._0.ts" in logger.warnings[0]
+    assert ".DS_Store" in logger.warnings[0]
+    assert "notes.txt" in logger.warnings[0]

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -10,6 +10,7 @@
 - 중단(stop): 결과 파일·임시 폴더 삭제, 완료 콜백 없음
 """
 
+import os
 import threading
 import time
 
@@ -481,3 +482,40 @@ def test_forced_slow_requeue_does_not_corrupt_output(tmp_path, monkeypatch):
     assert data.restart_threads > 0, "저속 재큐가 실제로 발동해야 이 테스트가 유효하다"
     assert output.read_bytes() == _expected_output(chunks_per_segment=20)
     assert failures == []
+
+
+def test_stray_dotfile_in_temp_dir_is_excluded_from_merge(tmp_path, monkeypatch):
+    """세그먼트가 아닌 파일이 임시 폴더에 있어도 병합에서 제외되고 경고가 남는다 (#180).
+
+    exFAT 등 xattr 미지원 파일시스템에 macOS가 쓰는 AppleDouble 사이드카
+    (``._세그먼트명``)나 Finder의 ``.DS_Store``처럼 '.'으로 시작하는 이름은
+    사전순 정렬에서 항상 맨 앞에 온다 — 오너 실기(exFAT 외장 SD 카드)에서
+    세그먼트 수만큼 실물로 확인된 오염이다. ``_list_segment_files``가
+    화이트리스트(숫자+확장자)로 걸러 이 오염을 막는지 검증한다.
+    """
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    def _pollute_then_start_merge():
+        # AppleDouble류 사이드카뿐 아니라 확장자 없는 잡파일까지 함께 심는다
+        for name in ("._0000000.m4s", ".DS_Store", "notes.txt"):
+            with open(os.path.join(engine.temp_dir, name), "wb") as f:
+                f.write(b"not-a-segment")
+        merge_starts.append(True)
+
+    engine._on_merge_start = _pollute_then_start_merge
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    assert finished.wait(timeout=30), "완료 콜백이 호출되지 않았다"
+    thread.join(timeout=10)
+
+    # 오염 파일이 있었는데도 산출물은 오염 없이 정상 그대로다
+    assert output.read_bytes() == _expected_output(chunks_per_segment=3)
+    assert failures == []
+    # 조용히 건너뛰지 않는다 — 무엇을 걸렀는지 경고로 남긴다
+    assert len(logger.warnings) == 1
+    assert "._0000000.m4s" in logger.warnings[0]
+    assert ".DS_Store" in logger.warnings[0]
+    assert "notes.txt" in logger.warnings[0]


### PR DESCRIPTION
Closes #180

#180 수정 — 원인이 오너 실기에서 실물(AppleDouble 사이드카 실측)로 확정된 뒤 진행.

## 리뷰어에게

- 화이트리스트는 `BaseDownloader._list_segment_files(extensions)` 하나로 공유한다 — m3u8은 `(".m4s", ".m4v")`, hls_aes는 `(".ts",)`로 각자 호출. `file_downloader`는 세그먼트 병합 자체가 없어(단일 연속 다운로드, postprocess 없음) 대상 아님.
- 패턴은 `^\d+(?:ext1|ext2)$` — 우리가 직접 만드는 이름(순수 숫자 스템 + 다운로더별 확장자)에만 맞춘 화이트리스트다. 지시대로 블랙리스트(`.`으로 시작하는 것만 제외)는 쓰지 않았다 — 다른 잡파일 유형(동기화 도구 충돌 사본, 백신 격리 사본 등)에도 안 뚫리게.
- 걸러진 항목은 조용히 넘기지 않고 `logger.warning`으로 남긴다 — 다음에 다른 종류의 오염이 왔을 때 로그로 잡을 수 있게.
- 테스트는 m3u8·hls_aes 양쪽에 각각 추가했다: `._세그먼트명`(AppleDouble류) + `.DS_Store` + 확장자 없는 잡파일(`notes.txt`)을 병합 직전에 심고, 산출물이 오염 없이 정상이며 경고 로그에 걸러진 파일명이 다 나오는지 확인.
- 전체 테스트 393 passed(+2), ruff 통과.

관련: #185(별도 PR 예정 — 이 PR과 리버트 단위 분리)

