### PR TITLE
fix: 후처리 실패 시 세그먼트 보존이 비동기 stop() 경쟁 상태로 깨지던 문제 수정 (#185)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -473,6 +473,19 @@ class BaseDownloader(ABC):
             # (5) 정상 경로 종료 후 정리 (중단으로 빠져나온 경우 포함)
             self._cleanup_after_run()
 
+            # 사용자가 강제로 중단한 경우 부분 산출물 삭제 (#185 — try 안으로 이동).
+            # 여기 있어야 하는 이유: 이 블록은 예외 없이 끝난 경로에서만 닿는다.
+            # 예전엔 이 체크가 try/except/finally 전체 바깥에 있어, PostprocessError
+            # 등 except 분기가 이미 각자 정리 여부를 결정한 뒤에도 다시 실행됐다.
+            # 실패 콜백(_on_failed)이 비동기로(Qt 큐드 시그널 등) task.stop()을
+            # 불러 상태가 WAITING으로 바뀌면, 그 바깥 체크가 "유저가 중단한
+            # 경우"로 오인해 PostprocessError가 보존하려던 세그먼트를 도로
+            # 지웠다(#92 정책 위반, #185 실측 확인) — 실패로 인한 stop()과 유저
+            # 중단을 같은 신호(WAITING)로 뭉뚱그려 구분하지 못한 게 뿌리였다
+            # (#135와 같은 자리: 엔진 종료 신호와 실패 처리를 분리해야 한다).
+            if self.state == DownloadState.WAITING:
+                self._cleanup_partial()
+
         except PostprocessError as e:
             # 후처리 실패 (#92) — 다운로드는 완결됐으므로 세그먼트(임시 폴더)를
             # 보존한다. 불완전한 산출물은 후처리 단계가 이미 삭제했다.
@@ -493,10 +506,6 @@ class BaseDownloader(ABC):
             # 실패 후 상태가 RUNNING인 채 남는 경로(헤드리스 등)에서는 기존
             # 관측 루프가 상태 변화만 기다리며 영원히 돌았다
             self._stop_monitor(monitor)
-
-        # 사용자가 강제로 중단한 경우 부분 산출물 삭제
-        if self.state == DownloadState.WAITING:
-            self._cleanup_partial()
 
     # ============ 다운로드 조정 및 콜백 메서드 ============
 

--- a/tests/unit/core/test_m3u8_downloader_run.py
+++ b/tests/unit/core/test_m3u8_downloader_run.py
@@ -519,3 +519,54 @@ def test_stray_dotfile_in_temp_dir_is_excluded_from_merge(tmp_path, monkeypatch)
     assert "._0000000.m4s" in logger.warnings[0]
     assert ".DS_Store" in logger.warnings[0]
     assert "notes.txt" in logger.warnings[0]
+
+
+def test_downstream_stop_after_postprocess_failure_preserves_segments(tmp_path, monkeypatch):
+    """실패 콜백이 비동기로 상태를 WAITING으로 돌려도 세그먼트는 보존된다 (#185).
+
+    base.py의 PostprocessError 분기는 _cleanup_partial()을 부르지 않아 세그먼트를
+    보존하도록 설계됐다(#92 — 재다운로드 강요 방지). 그런데 실제 프로덕션 배선
+    (download/qt_bridge.py)에서는 on_failed 콜백(_relay_failed)이 Qt 큐드 시그널을
+    거쳐 메인 스레드의 _onEngineFailed에서 task.stop()을 호출한다 — 상태를
+    WAITING으로 되돌린다. 고장난 버전에서는 run()의 try/except/finally 전체
+    바깥에 있던 "if WAITING: cleanup_partial()"이 이 비동기 전이를 "유저가
+    중단한 경우"로 오인해 방금 보존하려던 세그먼트를 도로 지웠다(오너 실기
+    관찰과 일치 — #180 조사 중 이 테스트로 고장난 커밋에서 먼저 실패를
+    재현한 뒤 수정함).
+
+    수정: 그 체크를 try 블록 안(예외 없이 끝난 경로에서만 닿는 지점)으로
+    옮겨, except 분기가 이미 내린 정리 결정을 이후의 비동기 상태 변화가
+    다시 뒤집지 못하게 한다 — 엔진 종료 신호(WAITING)와 실패 처리를 같은
+    체크 하나로 뭉뚱그리지 않는다(#135와 같은 자리).
+
+    on_failed 안에서 model.stop()을 호출해 프로덕션의 결과를 직접 재현한다.
+    """
+    engine, data, logger, output, finished, failures, merge_starts = _make_engine(
+        tmp_path, monkeypatch
+    )
+
+    def broken_remux_stream(chunks, dst_path):
+        raise base_module.FFmpegError("가짜 remux 실패")
+
+    monkeypatch.setattr(base_module, "remux_stream", broken_remux_stream)
+
+    # 실제 qt_bridge._onEngineFailed가 (큐드 커넥션을 거쳐) 하는 일 — task.stop()
+    original_on_failed = engine._on_failed
+
+    def on_failed_then_stop(exc):
+        original_on_failed(exc)
+        data.model.stop()
+
+    engine._on_failed = on_failed_then_stop
+
+    data.model.start()
+    thread = _run_in_thread(engine)
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    assert any(isinstance(e, base_module.PostprocessError) for e in failures)
+    temp_dir = tmp_path / "CVDv2_temp_out"
+    # #92 정책: 후처리 실패는 세그먼트를 보존해야 한다 — 실패 콜백이 상태를
+    # WAITING으로 돌리더라도(비동기 stop()) 이 정책은 지켜져야 한다.
+    assert temp_dir.exists(), "후처리 실패 시 세그먼트가 보존돼야 하는데 지워졌다"
+    assert len(list(temp_dir.iterdir())) == SEGMENT_COUNT + 1  # 초기화 세그먼트 포함


### PR DESCRIPTION
Closes #185

#185 수정 — #180과 리버트 단위를 분리하기 위해 별도 PR로 올린다(#180은 단순·안전한 화이트리스트 필터, 이건 실행 순서를 건드리는 조심스러운 수정).

## 리뷰어에게

- 뿌리는 `run()`이 "유저 중단"과 "실패 콜백이 비동기로 부른 stop()"을 같은 신호(`state == WAITING`)로 뭉뚱그려 구분 못 한 것 — #135("실패는 더 이상 정지로 위장하지 않는다")와 같은 자리의 재발이다.
- 고장난 커밋에서 먼저 실패를 재현했다(지시대로): `on_failed` 콜백이 `model.stop()`을 호출하도록 만들고(프로덕션의 `qt_bridge._onEngineFailed`가 큐드 커넥션으로 하는 일과 동일한 결과) `PostprocessError`를 유발했더니 `temp_dir.exists()`가 `False` — 세그먼트가 지워졌다. 커밋 메시지에 재현 과정을 적어뒀고, 이 리뷰 코멘트에도 핵심만 남긴다.
- 수정은 최소 변경이다: "사용자가 강제로 중단한 경우 부분 산출물 삭제" 체크를 `try` 블록 **바깥**(예외 유무와 무관하게 항상 실행)에서 `try` 블록 **안**(정상적으로 끝까지 간 경로에서만 도달)으로 옮겼다. `except PostprocessError`·`except self._failure_exceptions` 두 분기는 각자 이미 정리 여부를 스스로 결정하므로(각각 보존/즉시 정리), 그 결정이 나중에 도착하는 비동기 상태 변화로 재평가되지 않는다.
- 기존 "유저가 전송 중/후처리 중 중단" 시나리오(정상 경로, 예외 없음)는 그대로 이 체크에 닿으므로 동작 변화 없음 — 기존 `test_stop_removes_partial_file_and_temp_dir` 등 전부 무수정 통과로 확인.
- `run()`이 file/m3u8/hls_aes 공유 엔진이라 수정은 `base.py` 한 곳, 회귀 테스트는 m3u8 경로에 추가(같은 공유 코드를 검증하므로 hls_aes 쪽 중복 테스트는 추가하지 않았다).
- 전체 테스트 392 passed(+1), ruff 통과.

관련: #180(별도 PR #186)

