### PR TITLE
test: FAILED→WAITING 전이·AES 키/쿠키 로그 비노출 회귀 테스트 추가 (#193 일부)

### DIFF
--- a/tests/unit/core/test_download_task_model.py
+++ b/tests/unit/core/test_download_task_model.py
@@ -85,6 +85,12 @@ def test_fail_transition():
         (["start", "fail"], "start"),
         (["start", "fail"], "resume"),
         (["start", "fail"], "finish"),
+        # FAILED → WAITING은 되돌릴 수 없다(SPEC §4.2) — stop()으로도 불가.
+        # 엔진 종료(stop)와 실패 표시(fail)를 같은 신호로 되돌리면 #185류
+        # 사고(보존해야 할 세그먼트가 도로 삭제됨)가 재발한다 (#193 감사에서
+        # 이 케이스만 빠져 있음을 실측 — 몽키패치로 허용해봐도 기존 24개
+        # 테스트가 전부 통과했다)
+        (["start", "fail"], "stop"),
     ],
 )
 def test_invalid_transitions_raise(setup: list[str], invalid: str):

--- a/tests/unit/core/test_hls_aes_downloader.py
+++ b/tests/unit/core/test_hls_aes_downloader.py
@@ -302,6 +302,46 @@ def test_wrong_key_fails_fast_instead_of_writing_garbage(tmp_path, monkeypatch):
     assert not (tmp_path / "out.mp4").exists()
 
 
+def test_wrong_key_failure_does_not_leak_key_value(tmp_path, monkeypatch):
+    """키가 틀려 실패해도 실제 키 바이트가 실패 예외·로그 어디에도 남지 않는다 (SPEC §8.1).
+
+    decrypt.py의 예외 메시지는 길이만 담아 이미 안전하지만(코드 확인), 그
+    사실을 지금까지 겨냥해 검증한 테스트는 없었다 — 향후 누군가 디버깅
+    편의로 키 값을 메시지에 실으면(예: f"key={key}") 이 테스트가 잡아야 한다.
+    올바른 키·틀린 키 둘 다(하나라도 새면 실패)를 검사한다.
+    """
+    wrong_key = bytes([0xFF]) * 16
+    engine, data, logger, finished, failures, _ = _make_engine(
+        tmp_path, monkeypatch, key_resolver=lambda c, u: wrong_key
+    )
+
+    data.model.start()
+    engine.run()
+
+    assert not finished.is_set()
+    failure_text = "\n".join(str(e) for e in failures)
+    log_text = "\n".join(logger.errors) + "\n".join(logger.warnings)
+    for secret in (wrong_key, KEY):
+        assert secret.hex() not in failure_text
+        assert secret.hex() not in log_text
+        assert repr(secret) not in failure_text
+        assert repr(secret) not in log_text
+
+
+def test_short_key_failure_does_not_leak_key_value(tmp_path, monkeypatch):
+    """리졸버가 길이가 틀린 키를 주면 값이 아니라 길이만 실패 메시지에 남는다 (SPEC §8.1)."""
+    short_key = b"\xab\xcd\xef"  # 16바이트가 아닌 더미
+    engine, data, *_ = _make_engine(tmp_path, monkeypatch, key_resolver=lambda c, u: short_key)
+
+    with pytest.raises(DecryptionError) as exc_info:
+        engine.prepare(data.content)
+
+    message = str(exc_info.value)
+    assert short_key.hex() not in message
+    assert str(short_key) not in message
+    assert "길이" in message or "3" in message  # 값 대신 길이 정보만 담겼는지 정황 확인
+
+
 # ================================================================ 전체 파이프라인
 
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -212,3 +212,65 @@ def test_run_error_hides_raw_exception_details(monkeypatch):
 
     assert captured == [f"{VOD_URL}\nFailed to fetch video information"]
     assert "secret detail" not in captured[0]
+
+
+def test_run_failure_does_not_leak_cookie_values_to_log_or_error_signal(monkeypatch, caplog):
+    """실패 경로에서도 쿠키 값은 error 시그널·로그(traceback 포함) 어디에도 남지 않는다 (SPEC §7.2).
+
+    run()의 실패 분기는 유저 시그널은 일반 안내로 가리지만(#126) 디버깅을 위해
+    logger.exception으로 원시 예외·traceback은 그대로 남긴다(주석 참조). 그
+    traceback 안에 쿠키 값이 실리지 않는다는 것은 지금까지 검증된 적이 없다 —
+    이 값이 흘러 들어가는 경로(예: 예외 메시지에 cookies를 실수로 포함)가
+    생기면 이 테스트가 잡아야 한다.
+    """
+    secret_cookies = {"NID_AUT": "SECRET-AUT-9f8e7d6c", "NID_SES": "SECRET-SES-1a2b3c4d"}
+
+    from core.services import metadata_service
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(metadata_service, "fetch_content", boom)
+    worker = ContentWorker(VOD_URL, secret_cookies, "downloads")
+    captured: list[str] = []
+    worker.error.connect(captured.append)
+
+    with caplog.at_level("DEBUG"):
+        worker.run()
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    for value in secret_cookies.values():
+        assert value not in captured[0]
+        assert value not in log_text
+
+
+def test_run_success_does_not_leak_cookie_values_to_log(monkeypatch, caplog):
+    """정상 경로(쿠키가 실제로 매니페스트 요청까지 전달됨)에서도 로그에 쿠키 값이 남지 않는다."""
+    secret_cookies = {"NID_AUT": "SECRET-AUT-9f8e7d6c", "NID_SES": "SECRET-SES-1a2b3c4d"}
+
+    def fake_get_video_info(video_no, cookies):
+        return VideoInfo(
+            video_id="video-id",
+            in_key="in-key",
+            adult=False,
+            vod_status="ABR_HLS",
+            live_rewind_playback_json=None,
+            membership_benefit_type="MEMBER_ONLY",
+            encryption_type=None,
+            metadata={"title": "t", "duration": 1},
+        )
+
+    def fake_get_dash_manifest(video_id, in_key, cookies=None):
+        return [[1080, "https://example.invalid/1080"]], 1080, "https://example.invalid/1080"
+
+    monkeypatch.setattr(NetworkManager, "get_video_info", fake_get_video_info)
+    monkeypatch.setattr(NetworkManager, "get_video_dash_manifest", fake_get_dash_manifest)
+
+    worker = ContentWorker(VOD_URL, secret_cookies, "downloads")
+    with caplog.at_level("DEBUG"):
+        results, errors = _run_and_capture(worker)
+
+    assert errors == []
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    for value in secret_cookies.values():
+        assert value not in log_text


### PR DESCRIPTION
#193 SPEC 방침 대조 감사가 드러낸 사각지대 중 오너가 우선 착수를 승인한 두 항목만 채운다(②③). ①(core→app import 스캔 확장)은 셸 단계에서 app이 재편되며 import 관계가 바뀌므로 그때 함께 판단, ④(#149 회귀)는 재발 시 교착으로 금방 드러나 미룸 — 둘 다 이 PR 범위 밖.

## 무엇을 채웠는가

1. **FAILED→WAITING 전이 (`test_download_task_model.py`)** — SPEC §4.2 "FAILED → WAITING은 허용되지 않는 전이"의 `stop()` 경로가 `test_invalid_transitions_raise`의 파라미터 목록에서만 빠져 있었다. `(["start","fail"], "stop")` 한 행 추가.
2. **AES 복호화 키 비노출 (`test_hls_aes_downloader.py`)** — 실패 경로(틀린 키·길이 오류 키) 예외 메시지에 키 값이 안 실리는지 확인하는 테스트 2개 추가.
3. **쿠키(NID_AUT/NID_SES) 비노출 (`test_worker.py`)** — 성공/실패 두 경로 모두에서 `caplog`로 로그 레코드 전체를 캡처해 쿠키 값 부재를 확인하는 테스트 2개 추가.

## 리뷰어에게

세 가지 다 "테스트를 추가했다"가 아니라 "그 테스트가 실제로 잡는지"를 먼저 확인했다. 방법: 소스를 일부러 깨뜨려 새 테스트가 실패하는지 본 뒤, 그 소스 변경은 커밋하지 않고 되돌렸다(diff는 테스트 파일 3개뿐).

- FAILED→WAITING: `_ALLOWED_SOURCES["stop"]`에 `FAILED`를 추가해봤더니 **기존 24개 테스트가 전부 통과**했다(신규 25번째만 실패). 되돌림.
- AES 키: `_resolve_key`의 길이-오류 메시지를 `len(key)` 대신 `key.hex()`로 바꿔봤더니 새 테스트가 잡았다. 되돌림.
- 쿠키: `ContentWorker.run()`의 `logger.exception` 호출에 `self.cookies`를 끼워 넣어봤더니 새 테스트가 잡았다. 되돌림.

이 과정에서 `git status`가 계속 clean한지 매 단계 확인했다 — 커밋에 실험용 변경이 섞이지 않았다.

Refs #193 (이슈는 남은 항목①④때문에 닫지 않음, 진행 중인 조사 이슈라 이 PR로 닫히지 않음)
