### PR TITLE
fix: 개발 버전 표시에서 태그·베이스 버전 중복 제거

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -77,6 +77,38 @@ def _source_commit(repo_root: str) -> str:
     return _git_describe(repo_root) or _exported_commit() or "unknown"
 
 
+def _strip_redundant_tag_prefix(base: str, commit: str) -> str:
+    """git describe 결과에서 base 버전과 중복되는 태그 부분을 제거한다 (#195 후속).
+
+    describe 기본 형태는 "가장 가까운 태그(v 접두 가능)-거리-g해시"라, 그
+    태그가 base 버전과 같으면 표시에서 버전이 두 번 찍힌다
+    (``2.9.5+dev.v2.9.5-6-g55d5f5b``). 접두사가 겹치면 떼고 나머지(거리
+    -g해시, 더티면 -dirty까지)만 남긴다.
+
+    태그를 못 찾아 ``--always``가 대신 내놓은 맨해시(``55d5f5b``)나 git
+    자체가 없어 ``"unknown"``인 경우는 애초에 겹치는 접두사가 없으므로
+    그대로 통과한다 — 이 경우 해시/unknown만 있으면 어느 버전대인지 알 수
+    없으므로, 호출부(_dev_version)가 base를 앞에 붙여 기준선을 보존한다.
+    """
+    for prefix in (f"v{base}", base):
+        if commit == prefix:
+            return ""
+        if commit.startswith(prefix + "-"):
+            return commit[len(prefix) + 1 :]
+    return commit
+
+
+def _dev_version(base: str, commit: str) -> str:
+    """base 버전에 커밋 상세를 붙여 표시 문자열을 만든다 (#195).
+
+    정확히 태그 커밋이라 거리 0으로 상세가 빈 문자열이 되면(describe가
+    태그명만 반환) ``+dev.``로 끝나는 빈 세그먼트를 남기지 않고 ``+dev``만
+    붙인다.
+    """
+    detail = _strip_redundant_tag_prefix(base, commit)
+    return f"{base}+dev.{detail}" if detail else f"{base}+dev"
+
+
 @functools.lru_cache(maxsize=1)
 def get_app_version() -> str:
     """앱 버전 문자열을 반환한다 (#110 — 다운로드 로그 시작 정보용).
@@ -101,11 +133,11 @@ def get_app_version() -> str:
     try:
         with open(pyproject, "rb") as f:
             base = tomllib.load(f)["project"]["version"]
-        return f"{base}+dev.{_source_commit(repo_root)}"
+        return _dev_version(base, _source_commit(repo_root))
     except (OSError, KeyError, tomllib.TOMLDecodeError):
         if IS_RELEASE_BUILD:
             return APP_VERSION
-        return f"{APP_VERSION}+dev.{BUILD_COMMIT}"
+        return _dev_version(APP_VERSION, BUILD_COMMIT)
 
 # 설정 파일 경로 (AppData 디렉토리에 저장)
 APP_NAME = "chzzk-vod-downloader-v2"

--- a/tests/unit/test_build_version.py
+++ b/tests/unit/test_build_version.py
@@ -139,3 +139,52 @@ def test_source_commit_falls_back_through_all_layers(monkeypatch, tmp_path):
     monkeypatch.setattr(config_module, "_exported_commit", lambda: None)
 
     assert config_module._source_commit(str(tmp_path)) == "unknown"
+
+
+# ================================================================ 중복 제거 (#195 후속)
+#
+# git describe는 기본적으로 "가장 가까운 태그-거리-g해시"를 낸다. 그 태그가
+# 현재 버전과 같으면 "2.9.5+dev.v2.9.5-6-g55d5f5b"처럼 버전이 두 번
+# 찍힌다 — 아래는 그 중복을 떼는 로직을 사용자가 준 네 가지 예시 그대로
+# 박제한다.
+
+
+def test_dev_version_strips_matching_tag_with_v_prefix():
+    """태그로부터 N커밋: "v2.9.5-6-g55d5f5b" -> "2.9.5+dev.6-g55d5f5b"."""
+    assert config_module._dev_version("2.9.5", "v2.9.5-6-g55d5f5b") == "2.9.5+dev.6-g55d5f5b"
+
+
+def test_dev_version_strips_matching_tag_and_keeps_dirty_suffix():
+    """로컬 수정: "-dirty"는 거리·해시 뒤에 그대로 남는다."""
+    assert (
+        config_module._dev_version("2.9.5", "v2.9.5-6-g55d5f5b-dirty")
+        == "2.9.5+dev.6-g55d5f5b-dirty"
+    )
+
+
+def test_dev_version_keeps_bare_hash_when_tag_not_found():
+    """태그를 못 찾음(--always가 맨해시만 반환) — 겹치는 접두사가 없어 그대로 둔다."""
+    assert config_module._dev_version("2.9.5", "55d5f5b") == "2.9.5+dev.55d5f5b"
+
+
+def test_dev_version_keeps_unknown_as_is():
+    """git 자체가 없음 — "unknown"도 접두사가 없으니 그대로 둔다."""
+    assert config_module._dev_version("2.9.5", "unknown") == "2.9.5+dev.unknown"
+
+
+def test_dev_version_exact_tag_commit_has_no_trailing_dot():
+    """거리 0(정확히 태그 커밋)이면 describe가 태그명만 반환한다 — 빈 상세를 남기지 않는다."""
+    assert config_module._dev_version("2.9.5", "v2.9.5") == "2.9.5+dev"
+    assert "+dev." not in config_module._dev_version("2.9.5", "v2.9.5")
+
+
+def test_dev_version_base_prefix_is_never_dropped():
+    """앞의 버전 부분은 항상 기준선으로 남는다 — 해시만/unknown이어도 버전대는 알 수 있어야 한다."""
+    for commit in ("55d5f5b", "unknown", "v2.9.5-6-g55d5f5b"):
+        result = config_module._dev_version("2.9.5", commit)
+        assert result.startswith("2.9.5+dev")
+
+
+def test_strip_redundant_tag_prefix_without_v_prefix_also_matches():
+    """v 접두사가 없는 태그(그냥 "2.9.5")도 중복으로 인식해 떼어낸다."""
+    assert config_module._strip_redundant_tag_prefix("2.9.5", "2.9.5-6-g55d5f5b") == "6-g55d5f5b"


### PR DESCRIPTION
Closes #197

`git describe`가 기본적으로 "가장 가까운 태그-거리-g해시"를 반환하는데, 그 태그가 base 버전과 같으면 `2.9.5+dev.v2.9.5-6-g55d5f5b`처럼 **버전이 두 번 찍힌다.** `_strip_redundant_tag_prefix`/`_dev_version`을 추가해 describe 결과가 base로 시작하면(선택적 `v` 접두 포함) 그 접두사만 떼고 나머지를 붙인다.

- `2.9.5+dev.6-g55d5f5b` — 태그로부터 6커밋
- `2.9.5+dev.6-g55d5f5b-dirty` — 로컬 수정
- `2.9.5+dev.55d5f5b` — 태그를 못 찾음(`--always`), 겹치는 접두사가 없어 그대로
- `2.9.5+dev.unknown` — git 없음, 역시 그대로
- `2.9.5+dev` — 정확히 태그 커밋(거리 0)이면 빈 세그먼트 없이 이렇게

앞의 base 버전은 항상 남긴다 — 해시만/unknown이어도 어느 버전대인지는 알 수 있어야 하기 때문이다.

## 리뷰어에게

이 커밋은 원래 `feat/195-build-version-marker`(#195, PR #196)에 올렸던 `d124fcd`인데, **그 커밋이 올라가기 전에 PR #196이 머지돼** main에 반영되지 못했다. 작업 내용은 그대로 재사용하고(`git cherry-pick`), 새 이슈(#197)·새 브랜치·이 PR로 다시 올린다. `git fetch` → `main` 기준 새 브랜치 → cherry-pick 순서로 진행해 main과 완전히 동기화된 상태에서 작업했다.

검증: `_dev_version`을 예전 방식(`f"{base}+dev.{commit}"`, 중복 재현)으로 되돌려 새 테스트 3개(`test_dev_version_strips_matching_tag_with_v_prefix`, `_and_keeps_dirty_suffix`, `_exact_tag_commit_has_no_trailing_dot`)가 실패하는 것을 이 브랜치에서 다시 한 번 확인한 뒤 원복했다. 전체 스위트 424 passed, 4 skipped.
