### PR TITLE
fix: 테스트 전역에서 실유저 config.json 격리

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+import config.config as config_module  # noqa: E402 — sys.path 삽입 후에 와야 한다
+
 # 외부 API 응답을 흉내 내는 픽스처 파일 저장 위치
 MOCK_RESPONSES_DIR = Path(__file__).resolve().parent / "fixtures" / "mock_responses"
 
@@ -27,6 +29,26 @@ def load_mock_response():
         return (MOCK_RESPONSES_DIR / name).read_text(encoding="utf-8")
 
     return _load
+
+
+# ============ 전역 config.json 격리 (#199) ============
+# 개별 테스트가 CONFIG_DIR/CONFIG_FILE을 각자 격리하지 않으면
+# application.mainWindow.VodDownloader 등 앱 계층을 실배선으로 태우는
+# 테스트가 실유저 config.json을 조용히 덮어쓴다 — #150이 만든 경로 찾기
+# 로깅 테스트가 그 배선을 탔는데, #166이 같은 지점("입력 확정"·"창 닫기")에
+# 실제 저장까지 발동하는 보존 로직을 얹으면서 오염이 시작됐다. #166은
+# 자기가 새로 만든 테스트만 메모리로 격리했고, 먼저 있던 테스트는 새는
+# 지점으로 남았다(tests/unit/test_path_action_logging.py::window). 개별
+# 수정 대신 전역 autouse로 막아, 다음에 또 새 진입점이 생겨도 기본이
+# 안전하게 유지되게 한다. 개별 테스트가 이미 갖고 있는 자체 격리
+# (config_store 등, 저장 이력 검증 같은 자기 목적이 있다)는 그대로 둔다 —
+# 같은 값으로 다시 monkeypatch되어도 무해하다.
+@pytest.fixture(autouse=True)
+def _isolate_real_config(tmp_path, monkeypatch):
+    """모든 테스트에서 config.json 읽기·쓰기(및 CONFIG_DIR/logs 로그 파일)를 임시 위치로 돌린다."""
+    isolated_dir = tmp_path / "_isolated_config"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", str(isolated_dir))
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(isolated_dir / "config.json"))
 
 
 # ============ 실패 GUI 테스트 스크린샷 (#154) ============

--- a/tests/unit/test_config_isolation.py
+++ b/tests/unit/test_config_isolation.py
@@ -1,0 +1,53 @@
+"""전역 config.json 격리 픽스처(tests/conftest.py::_isolate_real_config) 검증 (#199).
+
+테스트 스위트가 실유저 config.json(과 CONFIG_DIR/logs의 실 로그 파일)을
+건드리지 않는다는 불변식을 지킨다. 이 픽스처가 나중에 실수로 지워지거나
+무력화되면, 이 테스트가 즉시 실패로 잡아야 한다 — 그렇지 않으면 다른
+테스트들이 조용히 실유저 데이터를 오염시켜도 아무도 못 잡는다(#150이
+만든 경로 찾기 로깅 테스트가 #166의 보존 로직과 만나 실제로 이렇게
+됐던 사고의 재발 방지).
+"""
+
+import os
+import platform
+
+import config.config as config_module
+
+
+def _real_default_config_dir() -> str:
+    """이 OS의 실제 기본 CONFIG_DIR을 config.py와 동일한 규칙으로 재계산한다."""
+    app_name = config_module.APP_NAME
+    if platform.system() == "Windows":
+        return os.path.join(os.getenv("APPDATA"), app_name)
+    if platform.system() == "Darwin":
+        return os.path.join(os.path.expanduser("~/Library/Application Support"), app_name)
+    return os.path.join(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), app_name)
+
+
+def test_config_dir_is_redirected_away_from_real_default_location():
+    """모든 테스트에서 CONFIG_DIR이 실제 OS 기본 위치가 아닌 임시 경로여야 한다."""
+    assert config_module.CONFIG_DIR != _real_default_config_dir()
+    assert "_isolated_config" in config_module.CONFIG_DIR
+
+
+def test_config_file_is_redirected_away_from_real_default_location():
+    """CONFIG_FILE도 같은 임시 위치 아래에 있어야 한다 — CONFIG_DIR만 도는 우회 방지."""
+    real_default_file = os.path.join(_real_default_config_dir(), "config.json")
+    assert config_module.CONFIG_FILE != real_default_file
+    assert config_module.CONFIG_FILE.startswith(config_module.CONFIG_DIR)
+
+
+def test_writing_through_isolated_config_does_not_touch_real_file():
+    """격리된 경로에 실제로 save_config를 호출해도 실 config.json은 그대로다."""
+    real_file = os.path.join(_real_default_config_dir(), "config.json")
+    before = os.path.exists(real_file)
+    before_mtime = os.path.getmtime(real_file) if before else None
+
+    config_module.load_config()  # CONFIG_DIR을 실제로 생성한다(save_config는 안 만든다)
+    config_module.save_config({"marker": "test_writing_through_isolated_config"})
+
+    assert os.path.exists(config_module.CONFIG_FILE)  # 격리된 위치엔 실제로 쓰였다
+    after = os.path.exists(real_file)
+    assert after == before  # 실 파일의 존재 여부 자체가 안 바뀐다
+    if before:
+        assert os.path.getmtime(real_file) == before_mtime  # 수정도 안 됐다


### PR DESCRIPTION
Closes #199

테스트가 실유저 `config.json`을 조용히 오염시키는 문제를 고친다. 증상: 테스트 실행 후 다운로드 경로 설정이 pytest 임시 폴더 경로로 바뀌어 있음(그 폴더는 곧 정리되므로 "없는 경로"가 됨).

## 원인

`application.mainWindow.VodDownloader`의 경로 보존 로직(4개 진입점 — 경로 찾기·입력 확정·조회 관문·창 닫기, 전부 `_rememberDownloadPath()`로 수렴)을 실배선으로 태우는 `tests/unit/test_path_action_logging.py::TestFetchGateLogging.window` 픽스처가 `CONFIG_DIR`을 전혀 격리하지 않았다.

- `#150`이 경로 찾기 로깅 테스트(`test_find_path_selection_is_logged`)를 만들 때는 그 배선이 저장까지 발동하지 않았다.
- `#166`이 같은 지점("입력 확정"·"창 닫기")에 실제 저장까지 발동하는 보존 로직(`_rememberPathIfValid`)을 얹으면서 오염이 시작됐다.
- `#166`은 **자기가 새로 만든** `tests/unit/test_default_download_path.py`만 `config_store` 픽스처(메모리 격리)로 감쌌고, 먼저 있던 `test_path_action_logging.py`는 손대지 않아 새는 지점으로 남았다.

## 전수 확인 (다른 새는 지점이 더 있는지)

`application.mainWindow`·`download/logger.py`(실 로그 파일)를 실배선으로 태우는 모든 테스트 파일을 확인했다. 실제로 실유저 데이터를 건드리는 곳은 위 하나뿐이었다. 이미 안전한 것들: `test_default_download_path.py`(`config_store`), `test_log_setup.py`/`test_logging_setup.py`/`test_download_log_phases.py`(`CONFIG_DIR` 개별 monkeypatch), `test_set_language.py`(`save_config` monkeypatch), `test_qt_bridge.py`(`DownloadLogger` 대역 — 주석에 이유까지 적혀 있음). 잠재 위험으로 `config/dialog.py::SettingDialog.accept()`(쿠키·설정 저장)가 있는데 현재 테스트가 그 경로를 호출하지 않아 아직 발동은 안 하지만 다음에 검증 테스트가 추가되면 바로 새는 지점이 될 수 있었다 — 이번 전역 픽스처가 그것도 함께 막는다. `main.py`는 모든 실 I/O가 `__main__` 가드 안에 있어 `import main` 자체는 안전함을 확인했고, `tests/conftest.py`의 스크린샷 저장은 저장소 로컬(gitignore) 디렉토리라 무관함을 확인했다.

## 수정

- `tests/conftest.py`에 **`autouse=True`** 픽스처 추가 — `config.CONFIG_DIR`·`CONFIG_FILE`을 매 테스트마다 `tmp_path` 하위로 monkeypatch한다. 개별 테스트 수정 대신 전역으로 막아, 다음에 또 새 진입점이 생겨도 기본이 안전하다(사용자 지시대로).
- `tests/unit/test_config_isolation.py` — 이 픽스처가 실제로 OS 기본 위치가 아닌 곳으로 돌렸는지, 격리된 위치에 실제로 써도 실 파일이 그대로인지 단언하는 **영구 회귀 가드**. 픽스처가 나중에 실수로 무력화되면 이 테스트가 즉시 잡는다.
- 기존 개별 격리(`config_store` 등)는 그대로 뒀다 — 저장 이력 검증 등 자기 목적이 있어 중복이어도 무해하다.

## 검증 (실제 개발자 APPDATA는 전혀 건드리지 않음 — `APPDATA` 환경변수를 스크래치 가짜 위치로 돌린 서브프로세스로 진행)

**수정 전 상태 재현**: 픽스처 추가 전 상태에서 `test_find_path_selection_is_logged`를 실행하니 가짜 APPDATA에 실제로 `config.json`이 생기고 `downloadPath`가 pytest 임시 경로로 바뀌었다(신고된 증상과 정확히 일치).

**가드 테스트 검증**: 픽스처를 커밋한 뒤 `autouse=True`를 일부러 `False`로 되돌려(같은 브랜치에서 임시 편집, 즉시 원복) 같은 시나리오를 다시 돌리니 새 가드 테스트 3개가 전부 실패로 잡았다 — 그리고 원래 버그 테스트(`test_find_path_selection_is_logged`) 자체는 **여전히 통과하면서 조용히 오염시키는** 것도 함께 확인했다(원래 버그가 왜 아무도 못 알아챘는지의 증거). `autouse=True`로 원복 후 재확인.

**수정 후**: 같은 시나리오에서 `config.json`이 더 이상 생기지 않는다.

전체 스위트 **427 passed, 4 skipped**(플랫폼 조건부 ffmpeg 테스트 — 기존과 동일하게 정상).
