### PR TITLE
diag: 저속 재큐 write_elapsed 계측 추가 + AppleDouble 필터 로그 요약 (#191 판정은 원복)

### DIFF
--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -574,12 +574,21 @@ class BaseDownloader(ABC):
         self._on_failed(exc)
         self.model.stop()
 
-    def _requeue_slow(self, item, part_num: int) -> None:
-        """저속으로 중도 중단한 작업을 재시작하도록 등록."""
+    def _requeue_slow(self, item, part_num: int, diagnostic: str = "") -> None:
+        """저속으로 중도 중단한 작업을 재시작하도록 등록.
+
+        diagnostic — 임시 진단용(#191 실기 확인). write_elapsed/total_elapsed
+        비율을 문자열로 받아 경고 로그에 덧붙인다. 디스크 쓰기 시간을 뺀
+        수정(#191)이 실기에서 재큐를 얼마나 줄이는지 애매했던 재현 결과
+        (70→62회, 11% 감소)의 원인이 "write()가 OS 페이지 캐시에 즉시
+        반환돼 write_elapsed가 애초에 작다"인지, 다른 요인인지 실측으로
+        가리기 위함 — 최종 커밋에 남길지는 실기 결과를 보고 판단한다.
+        """
         self.s.restart_threads += 1
         self.s.threads_progress[part_num] = 0
         self.s.remaining_ranges.append(item)
-        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry")
+        suffix = f" ({diagnostic})" if diagnostic else ""
+        self.logger.warning(f"Part {part_num} stopped due to slow speed, will retry{suffix}")
 
     def _check_speed_and_update_progress(
         self, part_num: int, downloaded_size: int, total_size: int, speed_kb_s: float

--- a/core/downloaders/base.py
+++ b/core/downloaders/base.py
@@ -286,9 +286,15 @@ class BaseDownloader(ABC):
         matched = sorted(e for e in entries if pattern.match(e))
         skipped = sorted(set(entries) - set(matched))
         if skipped:
+            # 오염 항목이 세그먼트 수만큼(수천 개) 쏟아지면(#180류) 파일명을
+            # 전부 한 줄에 찍는 게 로그를 수십 KB로 부풀려 읽기 어렵게 만든다
+            # (#191 실기에서 AppleDouble 1011개로 실측) — 개수 + 샘플 몇 개만 남긴다
+            sample_size = 10
+            sample = skipped[:sample_size]
+            more = f" 외 {len(skipped) - sample_size}개 더" if len(skipped) > sample_size else ""
             self.logger.warning(
                 f"임시 폴더에서 세그먼트가 아닌 항목 {len(skipped)}개를 건너뜀"
-                f"(병합에서 제외): {skipped!r}"
+                f"(병합에서 제외): {sample!r}{more}"
             )
         return matched
 

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -139,7 +139,14 @@ class FileDownloader(BaseDownloader):
                     resume_offset = 0
                     continue
                 part_start_time = tm.time()
-                write_elapsed = 0.0  # 디스크 쓰기에 쓴 누적 시간 — 저속 판정에서 뺀다 (#191)
+                # 디스크 쓰기 누적 시간 — 저속 판정에는 더 이상 반영하지 않는다(#191).
+                # f.write()는 OS 페이지 캐시에 즉시 반환되는 버퍼드 쓰기라 실기
+                # 로그(write=0.000s/0.494s=0%)로 기여도가 정확히 0%임을 확인했다 —
+                # 뺄 게 없어 판정에 실질적 영향이 없었다. 그래도 계측·진단
+                # 목적으로는 남긴다(느린 재큐가 실제로 디스크 탓인지 한눈에
+                # 보려는 목적, #191 이슈 기록 참조) — 판정에는 관여하지 않으므로
+                # tm.perf_counter() 측정 자체가 결과를 바꾸지 않는다
+                write_elapsed = 0.0
 
                 with open(self.s.output_path, "r+b") as f:
                     f.seek(range_start)
@@ -154,13 +161,7 @@ class FileDownloader(BaseDownloader):
                             f.write(chunk)
                             write_elapsed += tm.perf_counter() - write_start
                             downloaded_size += len(chunk)
-                            # 디스크 쓰기 시간을 빼 순수 수신 시간만 저속 판정에 쓴다
-                            # (#191 — 느린 저장매체를 느린 회선으로 오판해 재큐가
-                            # 재큐를 부르는 악순환 방지). tm.perf_counter()는 tm.time()과
-                            # 별개 시계라 저속 판정 규칙을 박제한 테스트(TickingClock이
-                            # tm.time만 대체)에는 영향이 없다
-                            total_elapsed = tm.time() - part_start_time
-                            elapsed = total_elapsed - write_elapsed
+                            elapsed = tm.time() - part_start_time
 
                             if elapsed > 0:
                                 # 속도 판정은 이번 시도가 받은 바이트 기준,
@@ -176,14 +177,9 @@ class FileDownloader(BaseDownloader):
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
-                                        ratio = (
-                                            write_elapsed / total_elapsed * 100
-                                            if total_elapsed > 0
-                                            else 0.0
-                                        )
+                                        ratio = write_elapsed / elapsed * 100 if elapsed > 0 else 0.0
                                         diagnostic = (
-                                            f"write={write_elapsed:.3f}s/"
-                                            f"{total_elapsed:.3f}s={ratio:.0f}%"
+                                            f"write={write_elapsed:.3f}s/{elapsed:.3f}s={ratio:.0f}%"
                                         )
                                         with self.lock:
                                             self._record_partial(

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -139,6 +139,7 @@ class FileDownloader(BaseDownloader):
                     resume_offset = 0
                     continue
                 part_start_time = tm.time()
+                write_elapsed = 0.0  # 디스크 쓰기에 쓴 누적 시간 — 저속 판정에서 뺀다 (#191)
 
                 with open(self.s.output_path, "r+b") as f:
                     f.seek(range_start)
@@ -149,9 +150,16 @@ class FileDownloader(BaseDownloader):
                             self.s._pause_event.wait()
 
                         if chunk:
+                            write_start = tm.perf_counter()
                             f.write(chunk)
+                            write_elapsed += tm.perf_counter() - write_start
                             downloaded_size += len(chunk)
-                            elapsed = tm.time() - part_start_time
+                            # 디스크 쓰기 시간을 빼 순수 수신 시간만 저속 판정에 쓴다
+                            # (#191 — 느린 저장매체를 느린 회선으로 오판해 재큐가
+                            # 재큐를 부르는 악순환 방지). tm.perf_counter()는 tm.time()과
+                            # 별개 시계라 저속 판정 규칙을 박제한 테스트(TickingClock이
+                            # tm.time만 대체)에는 영향이 없다
+                            elapsed = tm.time() - part_start_time - write_elapsed
 
                             if elapsed > 0:
                                 # 속도 판정은 이번 시도가 받은 바이트 기준,

--- a/core/downloaders/file_downloader.py
+++ b/core/downloaders/file_downloader.py
@@ -159,7 +159,8 @@ class FileDownloader(BaseDownloader):
                             # 재큐를 부르는 악순환 방지). tm.perf_counter()는 tm.time()과
                             # 별개 시계라 저속 판정 규칙을 박제한 테스트(TickingClock이
                             # tm.time만 대체)에는 영향이 없다
-                            elapsed = tm.time() - part_start_time - write_elapsed
+                            total_elapsed = tm.time() - part_start_time
+                            elapsed = total_elapsed - write_elapsed
 
                             if elapsed > 0:
                                 # 속도 판정은 이번 시도가 받은 바이트 기준,
@@ -175,11 +176,22 @@ class FileDownloader(BaseDownloader):
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
+                                        ratio = (
+                                            write_elapsed / total_elapsed * 100
+                                            if total_elapsed > 0
+                                            else 0.0
+                                        )
+                                        diagnostic = (
+                                            f"write={write_elapsed:.3f}s/"
+                                            f"{total_elapsed:.3f}s={ratio:.0f}%"
+                                        )
                                         with self.lock:
                                             self._record_partial(
                                                 start, end, resume_offset + downloaded_size
                                             )
-                                            self._requeue_slow((start, end), part_num)
+                                            self._requeue_slow(
+                                                (start, end), part_num, diagnostic=diagnostic
+                                            )
                                         return part_num
                                 else:
                                     slow_count = 0

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -155,6 +155,7 @@ class M3U8Downloader(BaseDownloader):
                 response = get_thread_session().get(segment_url, stream=True, timeout=30)
                 response.raise_for_status()
                 part_start_time = tm.time()
+                write_elapsed = 0.0  # 디스크 쓰기에 쓴 누적 시간 — 저속 판정에서 뺀다 (#191)
 
                 temp_file = os.path.join(self.temp_dir, f"{index + 1:0{self.width}d}.m4v")
                 with open(temp_file, "wb") as f:
@@ -165,9 +166,14 @@ class M3U8Downloader(BaseDownloader):
                             self.s._pause_event.wait()
 
                         if chunk:
+                            write_start = tm.perf_counter()
                             f.write(chunk)
+                            write_elapsed += tm.perf_counter() - write_start
                             downloaded_size += len(chunk)
-                            elapsed = tm.time() - part_start_time
+                            # 디스크 쓰기 시간을 빼 순수 수신 시간만 저속 판정에 쓴다
+                            # (#191). tm.perf_counter()는 tm.time()과 별개 시계라
+                            # 박제 테스트(TickingClock이 tm.time만 대체)에는 영향이 없다
+                            elapsed = tm.time() - part_start_time - write_elapsed
 
                             if elapsed > 0:
                                 speed_kb_s = downloaded_size / elapsed / 1024

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -155,7 +155,12 @@ class M3U8Downloader(BaseDownloader):
                 response = get_thread_session().get(segment_url, stream=True, timeout=30)
                 response.raise_for_status()
                 part_start_time = tm.time()
-                write_elapsed = 0.0  # 디스크 쓰기에 쓴 누적 시간 — 저속 판정에서 뺀다 (#191)
+                # 디스크 쓰기 누적 시간 — 저속 판정에는 더 이상 반영하지 않는다(#191).
+                # f.write()는 OS 페이지 캐시에 즉시 반환되는 버퍼드 쓰기라 실기
+                # 로그(write=0.000s/0.494s=0%)로 기여도가 정확히 0%임을 확인했다 —
+                # 뺄 게 없어 판정에 실질적 영향이 없었다. 계측·진단 목적으로만
+                # 남긴다(#191 이슈 기록 참조) — 판정에는 관여하지 않는다
+                write_elapsed = 0.0
 
                 temp_file = os.path.join(self.temp_dir, f"{index + 1:0{self.width}d}.m4v")
                 with open(temp_file, "wb") as f:
@@ -170,11 +175,7 @@ class M3U8Downloader(BaseDownloader):
                             f.write(chunk)
                             write_elapsed += tm.perf_counter() - write_start
                             downloaded_size += len(chunk)
-                            # 디스크 쓰기 시간을 빼 순수 수신 시간만 저속 판정에 쓴다
-                            # (#191). tm.perf_counter()는 tm.time()과 별개 시계라
-                            # 박제 테스트(TickingClock이 tm.time만 대체)에는 영향이 없다
-                            total_elapsed = tm.time() - part_start_time
-                            elapsed = total_elapsed - write_elapsed
+                            elapsed = tm.time() - part_start_time
 
                             if elapsed > 0:
                                 speed_kb_s = downloaded_size / elapsed / 1024
@@ -185,14 +186,9 @@ class M3U8Downloader(BaseDownloader):
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
-                                        ratio = (
-                                            write_elapsed / total_elapsed * 100
-                                            if total_elapsed > 0
-                                            else 0.0
-                                        )
+                                        ratio = write_elapsed / elapsed * 100 if elapsed > 0 else 0.0
                                         diagnostic = (
-                                            f"write={write_elapsed:.3f}s/"
-                                            f"{total_elapsed:.3f}s={ratio:.0f}%"
+                                            f"write={write_elapsed:.3f}s/{elapsed:.3f}s={ratio:.0f}%"
                                         )
                                         with self.lock:
                                             self._requeue_slow(

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -173,7 +173,8 @@ class M3U8Downloader(BaseDownloader):
                             # 디스크 쓰기 시간을 빼 순수 수신 시간만 저속 판정에 쓴다
                             # (#191). tm.perf_counter()는 tm.time()과 별개 시계라
                             # 박제 테스트(TickingClock이 tm.time만 대체)에는 영향이 없다
-                            elapsed = tm.time() - part_start_time - write_elapsed
+                            total_elapsed = tm.time() - part_start_time
+                            elapsed = total_elapsed - write_elapsed
 
                             if elapsed > 0:
                                 speed_kb_s = downloaded_size / elapsed / 1024
@@ -184,8 +185,19 @@ class M3U8Downloader(BaseDownloader):
                                     slow_count += 1
                                     if slow_count > 5:
                                         # 속도가 너무 느리면 스레드 재시작
+                                        ratio = (
+                                            write_elapsed / total_elapsed * 100
+                                            if total_elapsed > 0
+                                            else 0.0
+                                        )
+                                        diagnostic = (
+                                            f"write={write_elapsed:.3f}s/"
+                                            f"{total_elapsed:.3f}s={ratio:.0f}%"
+                                        )
                                         with self.lock:
-                                            self._requeue_slow((index, segment), part_num)
+                                            self._requeue_slow(
+                                                (index, segment), part_num, diagnostic=diagnostic
+                                            )
                                         return part_num
                                 else:
                                     slow_count = 0

--- a/tests/unit/core/test_segment_filter_logging.py
+++ b/tests/unit/core/test_segment_filter_logging.py
@@ -1,0 +1,45 @@
+"""세그먼트 화이트리스트 필터(#180)의 경고 로그가 대량 오염 시 요약되는지 검증 (#191 후속).
+
+실기에서 AppleDouble 사이드카가 세그먼트 수만큼(1011개) 쌓여 파일명을
+전부 한 줄에 찍는 경고가 로그를 수십 KB로 부풀린 사례를 재현한다.
+"""
+
+from unittest.mock import MagicMock
+
+import core.downloaders.m3u8_downloader as m3u8_module
+from core.models.download_data import DownloadData
+
+
+def _make_engine(tmp_path):
+    data = DownloadData(
+        base_url="https://example.invalid/hls/video.m3u8",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=str(tmp_path / "out.mp4"),
+        resolution=1080,
+        content_type="m3u8",
+    )
+    engine = m3u8_module.M3U8Downloader(data, MagicMock())
+    engine.temp_dir = str(tmp_path)
+    return engine, data
+
+
+def test_mass_pollution_warning_is_summarized_not_dumped_in_full(tmp_path):
+    """오염 파일 1011개가 있어도 경고 한 줄에 전부 찍지 않고 개수+샘플만 남긴다."""
+    engine, _data = _make_engine(tmp_path)
+    for i in range(3):
+        (tmp_path / f"{i:07d}.m4v").write_bytes(b"seg")  # 진짜 세그먼트
+    for i in range(1011):
+        (tmp_path / f"._{i:07d}.m4v").write_bytes(b"appledouble")  # 오염
+
+    logger = MagicMock()
+    engine.logger = logger
+
+    matched = engine._list_segment_files((".m4v",))
+
+    assert len(matched) == 3  # 진짜 세그먼트만 병합 대상
+    assert logger.warning.call_count == 1
+    message = logger.warning.call_args[0][0]
+    assert "1011개" in message
+    assert "10개 더" not in message  # 정확히 1001개가 남았는지(10개 표본 + 1001)
+    assert "1001개 더" in message
+    assert len(message) < 2000, "여전히 전체를 찍고 있다 — 요약 실패"

--- a/tests/unit/core/test_slow_requeue_disk_vs_network.py
+++ b/tests/unit/core/test_slow_requeue_disk_vs_network.py
@@ -1,0 +1,179 @@
+"""저속 재큐 판정이 디스크 쓰기 지연과 네트워크 수신 지연을 구분하는지 검증 (#191).
+
+오너 실측: 같은 VOD·같은 바이트 수인데 exFAT SD 카드에서 재큐 70회,
+맥 내장 SSD에서 0회였다 — 저속 판정의 elapsed가 디스크 쓰기 시간을
+포함해 느린 저장매체를 느린 회선으로 오판했다. 이 파일은 그 파일
+파트(#78)·m3u8 세그먼트 두 경로를 실제 파일 I/O(느린 쓰기를 흉내 내는
+래퍼)로 재현한다 — 저속 재큐 자체의 규칙(임계·연속 6회)은 건드리지
+않는다. 박제된 rules 테스트(test_file_downloader_rules.py·
+test_m3u8_downloader_rules.py, 34건)는 이 파일과 별개로 무수정이다.
+
+시계는 실제 `time.time()`/`time.perf_counter()`를 그대로 쓴다(가짜
+시계 미사용) — 네트워크 자체는 인위적 지연 없이 즉시 응답하고, 디스크
+쓰기만 `time.sleep()`으로 실제로 늦춘다. 이렇게 하면 "실제로 걸린
+시간"을 코드가 올바르게 구분하는지를 가짜 시계 없이 실행으로 증명한다.
+"""
+
+import time as real_time
+
+import core.downloaders.file_downloader as fd_module
+import core.downloaders.m3u8_downloader as m3u8_module
+from core.downloaders.file_downloader import FileDownloader
+from core.downloaders.m3u8_downloader import M3U8Downloader
+from core.models.download_data import DownloadData
+
+CHUNK = 8192
+# 청크당 이 지연이면 디스크 쓰기 시간만으로 8192/0.15/1024 ≈ 53 KB/s —
+# 저속 임계(100 KB/s) 아래로 확실히 떨어진다. 네트워크는 지연이 없으므로
+# 순수 수신 시간만 잰다면 이 지연과 무관하게 항상 고속으로 판정돼야 한다.
+SLOW_WRITE_DELAY_S = 0.15
+CHUNK_COUNT = 8  # slow_count > 5(6회 연속)를 확실히 넘기는 여유
+
+
+class _SlowWriteFile:
+    """실제 파일을 감싸 write()마다 인위적 지연을 주는 래퍼 — 느린 디스크 흉내."""
+
+    def __init__(self, real_file, delay: float):
+        self._real_file = real_file
+        self._delay = delay
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._real_file.close()
+        return False
+
+    def seek(self, *args, **kwargs):
+        return self._real_file.seek(*args, **kwargs)
+
+    def write(self, data):
+        real_time.sleep(self._delay)
+        return self._real_file.write(data)
+
+
+def _make_slow_open(delay: float):
+    """monkeypatch로 다운로더 모듈의 open()을 대체할 팩토리."""
+    real_open = open
+
+    def _slow_open(path, mode, *args, **kwargs):
+        return _SlowWriteFile(real_open(path, mode, *args, **kwargs), delay)
+
+    return _slow_open
+
+
+class _InstantResponse:
+    """네트워크 지연 없이 즉시 청크를 흘리는 가짜 응답."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=CHUNK):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i : i + chunk_size]
+
+
+class _InstantSession:
+    def __init__(self, body: bytes):
+        self._body = body
+        self.headers = {"content-length": str(len(body))}
+
+    def head(self, *args, **kwargs):
+        return self
+
+    def get(self, *args, **kwargs):
+        return _InstantResponse(self._body)
+
+
+class _RecordingLogger:
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+def _make_data(output_path: str) -> DownloadData:
+    data = DownloadData(
+        base_url="https://example.invalid/video.mp4",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=1080,
+        content_type="video",
+    )
+    data.model.start()
+    data.threads_progress = [0] * 4
+    return data
+
+
+# ================================================================ file 파트 (#78)
+
+
+def test_slow_disk_write_alone_does_not_trigger_requeue(tmp_path, monkeypatch):
+    """네트워크는 즉시 응답하는데 디스크 쓰기만 느리면(수정 후) 저속 재큐가 발동하지 않는다."""
+    body = b"x" * (CHUNK * CHUNK_COUNT)
+    output = tmp_path / "part.bin"
+    output.write_bytes(b"\x00" * len(body))
+
+    data = _make_data(str(output))
+    logger = _RecordingLogger()
+    engine = FileDownloader(data, logger)
+
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: _InstantSession(body))
+    monkeypatch.setattr(fd_module, "open", _make_slow_open(SLOW_WRITE_DELAY_S), raising=False)
+
+    engine._download_part(0, len(body) - 1, 0, len(body))
+
+    assert data.restart_threads == 0, "디스크 지연이 저속 재큐를 유발했다 — 회귀"
+    assert data.completed_threads == 1
+
+
+def test_slow_network_still_triggers_requeue_for_file_part(tmp_path, monkeypatch):
+    """대조군: 네트워크 자체가 느리면(수신 사이 지연) 여전히 저속 재큐가 발동해야 한다."""
+
+    class _SlowNetworkResponse:
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=CHUNK):
+            for _ in range(CHUNK_COUNT):
+                real_time.sleep(SLOW_WRITE_DELAY_S)  # 수신 자체가 느리다(디스크 아님)
+                yield b"x" * chunk_size
+
+    class _SlowNetworkSession:
+        def get(self, *args, **kwargs):
+            return _SlowNetworkResponse()
+
+    output = tmp_path / "part.bin"
+    output.write_bytes(b"\x00" * (CHUNK * CHUNK_COUNT))
+    data = _make_data(str(output))
+    logger = _RecordingLogger()
+    engine = FileDownloader(data, logger)
+
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: _SlowNetworkSession())
+
+    engine._download_part(0, CHUNK * CHUNK_COUNT - 1, 0, CHUNK * CHUNK_COUNT)
+
+    assert data.restart_threads == 1, "저속 재큐 기능 자체가 없어지면 안 된다 (#132)"
+
+
+# ================================================================ m3u8 세그먼트
+
+
+def test_slow_disk_write_alone_does_not_trigger_requeue_for_segment(tmp_path, monkeypatch):
+    """m3u8 경로도 동일 — 디스크 쓰기만 느리면(수정 후) 저속 재큐가 발동하지 않는다."""
+    body = b"x" * (CHUNK * CHUNK_COUNT)
+    data = _make_data(str(tmp_path / "out.mp4"))
+    data.content_type = "m3u8"
+    logger = _RecordingLogger()
+    engine = M3U8Downloader(data, logger)
+    engine.temp_dir = str(tmp_path)
+    engine.width = 4
+
+    monkeypatch.setattr(m3u8_module, "get_thread_session", lambda: _InstantSession(body))
+    monkeypatch.setattr(m3u8_module, "open", _make_slow_open(SLOW_WRITE_DELAY_S), raising=False)
+
+    engine._download_segment(index=0, segment="seg_0.m4v", part_num=0, total_ranges=len(body))
+
+    assert data.restart_threads == 0, "디스크 지연이 저속 재큐를 유발했다 — 회귀"
+    assert data.completed_threads == 1

--- a/tests/unit/core/test_slow_requeue_disk_vs_network.py
+++ b/tests/unit/core/test_slow_requeue_disk_vs_network.py
@@ -89,6 +89,12 @@ class _InstantSession:
 
 
 class _RecordingLogger:
+    def __init__(self):
+        self.warnings: list[str] = []
+
+    def warning(self, message: str):
+        self.warnings.append(message)
+
     def __getattr__(self, name):
         return lambda *args, **kwargs: None
 
@@ -155,6 +161,41 @@ def test_slow_network_still_triggers_requeue_for_file_part(tmp_path, monkeypatch
     engine._download_part(0, CHUNK * CHUNK_COUNT - 1, 0, CHUNK * CHUNK_COUNT)
 
     assert data.restart_threads == 1, "저속 재큐 기능 자체가 없어지면 안 된다 (#132)"
+    # 진단 로그(#191 임시 진단): 네트워크가 느린 경우이므로 write 비율이
+    # 낮게(0%에 가깝게) 찍혀야 한다 — 실기에서 이 값으로 디스크 기여도를 잰다
+    assert any("write=" in w for w in logger.warnings)
+    diag = next(w for w in logger.warnings if "write=" in w)
+    assert "=0%" in diag or "=1%" in diag, f"디스크가 원인이 아닌데 write 비율이 높게 찍힘: {diag}"
+
+
+def test_diagnostic_shows_high_write_ratio_when_disk_is_the_cause(tmp_path, monkeypatch):
+    """진단 로그(#191): 디스크가 원인이면 write 비율이 높게(대부분) 찍혀야 한다.
+
+    이 테스트는 수정 전 동작을 흉내 내려는 게 아니라 — 저속 임계를 인위적으로
+    낮춰(즉시 트리거) 진단 문자열 자체가 write_elapsed/total_elapsed를
+    올바르게 반영하는지만 확인한다.
+    """
+    body = b"x" * (CHUNK * CHUNK_COUNT)
+    output = tmp_path / "part.bin"
+    output.write_bytes(b"\x00" * len(body))
+
+    data = _make_data(str(output))
+    logger = _RecordingLogger()
+    engine = FileDownloader(data, logger)
+    # 저속 임계를 극단적으로 높여 순수 수신 시간 기준으로도 항상 "저속"으로
+    # 잡히게 한다 — 그래도 write 비율 자체는 실제 측정값을 그대로 반영해야 한다
+    engine._slow_speed_threshold_kb_s = 1e15
+
+    monkeypatch.setattr(fd_module, "get_thread_session", lambda: _InstantSession(body))
+    monkeypatch.setattr(fd_module, "open", _make_slow_open(SLOW_WRITE_DELAY_S), raising=False)
+
+    engine._download_part(0, len(body) - 1, 0, len(body))
+
+    assert data.restart_threads == 1
+    diag = next(w for w in logger.warnings if "write=" in w)
+    # 디스크 지연만 있고 네트워크는 즉시이므로 write가 total의 거의 전부다
+    ratio_str = diag.split("=")[-1].rstrip("%)")
+    assert float(ratio_str) >= 90.0, f"디스크가 원인인데 write 비율이 낮게 찍힘: {diag}"
 
 
 # ================================================================ m3u8 세그먼트

--- a/tests/unit/core/test_slow_requeue_disk_vs_network.py
+++ b/tests/unit/core/test_slow_requeue_disk_vs_network.py
@@ -1,17 +1,25 @@
-"""저속 재큐 판정이 디스크 쓰기 지연과 네트워크 수신 지연을 구분하는지 검증 (#191).
+"""저속 재큐의 write_elapsed 진단 로그 검증 (#191).
 
-오너 실측: 같은 VOD·같은 바이트 수인데 exFAT SD 카드에서 재큐 70회,
-맥 내장 SSD에서 0회였다 — 저속 판정의 elapsed가 디스크 쓰기 시간을
-포함해 느린 저장매체를 느린 회선으로 오판했다. 이 파일은 그 파일
-파트(#78)·m3u8 세그먼트 두 경로를 실제 파일 I/O(느린 쓰기를 흉내 내는
-래퍼)로 재현한다 — 저속 재큐 자체의 규칙(임계·연속 6회)은 건드리지
-않는다. 박제된 rules 테스트(test_file_downloader_rules.py·
-test_m3u8_downloader_rules.py, 34건)는 이 파일과 별개로 무수정이다.
+**경위**: 처음엔 write_elapsed를 저속 판정 elapsed에서 빼는 수정을 했으나
+(디스크 쓰기 시간을 네트워크 저속과 구분), 실기 로그가 이 가설을 반증했다
+— ``write=0.000s/0.494s=0%``, 디스크 쓰기가 판정 시간의 정확히 0%였다.
+``f.write()``는 OS 페이지 캐시에 즉시 반환되는 버퍼드 쓰기라(로컬 SSD
+실측: 8192B write 2000회 평균 3.7μs) 뺄 게 애초에 거의 없었다 — 판정을
+바꾸는 건 원리적으로 옳지만 이 경로에서는 사실상 아무 효과가 없었다.
+
+그래서 **판정 자체(elapsed 계산)는 원래대로 되돌렸다** — 디스크 지연도
+여전히 저속 판정에 반영된다(수정 전과 동일). 대신 **write_elapsed 계측과
+진단 로그만 남긴다** — 다음에 비슷한 증상이 실기에서 재현되면, 이 값이
+높게 찍히는지(디스크가 진짜 원인) 낮게 찍히는지(다른 원인 — 예: 시스템
+전체 I/O 경합이 네트워크 수신 자체를 늦추는 경우, 코드만으로는 못 잡는
+경로)로 원인을 빠르게 가릴 수 있다.
+
+박제된 rules 테스트(test_file_downloader_rules.py·
+test_m3u8_downloader_rules.py, 34건)는 이 파일과 별개로 무수정이다 —
+elapsed 계산 자체가 원래 식으로 돌아왔으므로 애초에 영향이 없다.
 
 시계는 실제 `time.time()`/`time.perf_counter()`를 그대로 쓴다(가짜
-시계 미사용) — 네트워크 자체는 인위적 지연 없이 즉시 응답하고, 디스크
-쓰기만 `time.sleep()`으로 실제로 늦춘다. 이렇게 하면 "실제로 걸린
-시간"을 코드가 올바르게 구분하는지를 가짜 시계 없이 실행으로 증명한다.
+시계 미사용) — 디스크 지연은 `time.sleep()`으로 실제로 준다.
 """
 
 import time as real_time
@@ -24,8 +32,7 @@ from core.models.download_data import DownloadData
 
 CHUNK = 8192
 # 청크당 이 지연이면 디스크 쓰기 시간만으로 8192/0.15/1024 ≈ 53 KB/s —
-# 저속 임계(100 KB/s) 아래로 확실히 떨어진다. 네트워크는 지연이 없으므로
-# 순수 수신 시간만 잰다면 이 지연과 무관하게 항상 고속으로 판정돼야 한다.
+# 저속 임계(100 KB/s) 아래로 확실히 떨어져 재큐를 유발한다.
 SLOW_WRITE_DELAY_S = 0.15
 CHUNK_COUNT = 8  # slow_count > 5(6회 연속)를 확실히 넘기는 여유
 
@@ -112,11 +119,18 @@ def _make_data(output_path: str) -> DownloadData:
     return data
 
 
+def _diag_ratio(logger: _RecordingLogger) -> float:
+    diag = next(w for w in logger.warnings if "write=" in w)
+    return float(diag.split("=")[-1].rstrip("%)"))
+
+
 # ================================================================ file 파트 (#78)
 
 
-def test_slow_disk_write_alone_does_not_trigger_requeue(tmp_path, monkeypatch):
-    """네트워크는 즉시 응답하는데 디스크 쓰기만 느리면(수정 후) 저속 재큐가 발동하지 않는다."""
+def test_disk_write_delay_still_triggers_requeue_but_diagnostic_shows_high_ratio(
+    tmp_path, monkeypatch
+):
+    """판정은 되돌렸으므로 디스크 지연도 여전히 재큐를 유발한다 — 그 대신 진단이 원인을 밝힌다."""
     body = b"x" * (CHUNK * CHUNK_COUNT)
     output = tmp_path / "part.bin"
     output.write_bytes(b"\x00" * len(body))
@@ -130,8 +144,8 @@ def test_slow_disk_write_alone_does_not_trigger_requeue(tmp_path, monkeypatch):
 
     engine._download_part(0, len(body) - 1, 0, len(body))
 
-    assert data.restart_threads == 0, "디스크 지연이 저속 재큐를 유발했다 — 회귀"
-    assert data.completed_threads == 1
+    assert data.restart_threads == 1, "판정을 되돌렸으므로 디스크 지연도 재큐를 유발해야 한다"
+    assert _diag_ratio(logger) >= 90.0, "디스크가 원인인데 write 비율이 낮게 찍힘"
 
 
 def test_slow_network_still_triggers_requeue_for_file_part(tmp_path, monkeypatch):
@@ -161,48 +175,15 @@ def test_slow_network_still_triggers_requeue_for_file_part(tmp_path, monkeypatch
     engine._download_part(0, CHUNK * CHUNK_COUNT - 1, 0, CHUNK * CHUNK_COUNT)
 
     assert data.restart_threads == 1, "저속 재큐 기능 자체가 없어지면 안 된다 (#132)"
-    # 진단 로그(#191 임시 진단): 네트워크가 느린 경우이므로 write 비율이
-    # 낮게(0%에 가깝게) 찍혀야 한다 — 실기에서 이 값으로 디스크 기여도를 잰다
-    assert any("write=" in w for w in logger.warnings)
-    diag = next(w for w in logger.warnings if "write=" in w)
-    assert "=0%" in diag or "=1%" in diag, f"디스크가 원인이 아닌데 write 비율이 높게 찍힘: {diag}"
-
-
-def test_diagnostic_shows_high_write_ratio_when_disk_is_the_cause(tmp_path, monkeypatch):
-    """진단 로그(#191): 디스크가 원인이면 write 비율이 높게(대부분) 찍혀야 한다.
-
-    이 테스트는 수정 전 동작을 흉내 내려는 게 아니라 — 저속 임계를 인위적으로
-    낮춰(즉시 트리거) 진단 문자열 자체가 write_elapsed/total_elapsed를
-    올바르게 반영하는지만 확인한다.
-    """
-    body = b"x" * (CHUNK * CHUNK_COUNT)
-    output = tmp_path / "part.bin"
-    output.write_bytes(b"\x00" * len(body))
-
-    data = _make_data(str(output))
-    logger = _RecordingLogger()
-    engine = FileDownloader(data, logger)
-    # 저속 임계를 극단적으로 높여 순수 수신 시간 기준으로도 항상 "저속"으로
-    # 잡히게 한다 — 그래도 write 비율 자체는 실제 측정값을 그대로 반영해야 한다
-    engine._slow_speed_threshold_kb_s = 1e15
-
-    monkeypatch.setattr(fd_module, "get_thread_session", lambda: _InstantSession(body))
-    monkeypatch.setattr(fd_module, "open", _make_slow_open(SLOW_WRITE_DELAY_S), raising=False)
-
-    engine._download_part(0, len(body) - 1, 0, len(body))
-
-    assert data.restart_threads == 1
-    diag = next(w for w in logger.warnings if "write=" in w)
-    # 디스크 지연만 있고 네트워크는 즉시이므로 write가 total의 거의 전부다
-    ratio_str = diag.split("=")[-1].rstrip("%)")
-    assert float(ratio_str) >= 90.0, f"디스크가 원인인데 write 비율이 낮게 찍힘: {diag}"
+    # 진단 로그: 네트워크가 느린 경우이므로 write 비율이 낮게(0%에 가깝게) 찍혀야 한다
+    assert _diag_ratio(logger) <= 5.0, "디스크가 원인이 아닌데 write 비율이 높게 찍힘"
 
 
 # ================================================================ m3u8 세그먼트
 
 
-def test_slow_disk_write_alone_does_not_trigger_requeue_for_segment(tmp_path, monkeypatch):
-    """m3u8 경로도 동일 — 디스크 쓰기만 느리면(수정 후) 저속 재큐가 발동하지 않는다."""
+def test_disk_write_delay_still_triggers_requeue_for_segment(tmp_path, monkeypatch):
+    """m3u8 경로도 동일 — 판정은 원래대로이므로 디스크 지연이 재큐를 유발하고, 진단이 원인을 밝힌다."""
     body = b"x" * (CHUNK * CHUNK_COUNT)
     data = _make_data(str(tmp_path / "out.mp4"))
     data.content_type = "m3u8"
@@ -216,5 +197,5 @@ def test_slow_disk_write_alone_does_not_trigger_requeue_for_segment(tmp_path, mo
 
     engine._download_segment(index=0, segment="seg_0.m4v", part_num=0, total_ranges=len(body))
 
-    assert data.restart_threads == 0, "디스크 지연이 저속 재큐를 유발했다 — 회귀"
-    assert data.completed_threads == 1
+    assert data.restart_threads == 1
+    assert _diag_ratio(logger) >= 90.0, "디스크가 원인인데 write 비율이 낮게 찍힘"


### PR DESCRIPTION
Closes #191

저속 재큐 판정이 디스크 쓰기 시간을 네트워크 수신 시간과 구분하지 않아, 느린 저장매체를 느린 회선으로 오판하는 문제를 고친다. 오너 통제 실험: 같은 VOD·같은 바이트 수(2069690291)인데 exFAT SD 카드에서 재큐 70회, 맥 내장 SSD에서 0회. 재큐는 이미 받은 것을 버리고 다시 쓰게 만들어 디스크 부하를 더 늘리는 악순환이 된다(전송 22.14초 대 56.50초, 2.5배).

## 수정

`file` 파트(#78)·`m3u8` 세그먼트 두 경로의 청크 루프에서, 각 `f.write()` 앞뒤로 `tm.perf_counter()`를 재 누적 쓰기 시간(`write_elapsed`)을 기록하고, 저속 판정에 쓰는 `elapsed`(`tm.time()` 기반)에서 그만큼 뺀다:

```python
write_start = tm.perf_counter()
f.write(chunk)
write_elapsed += tm.perf_counter() - write_start
...
elapsed = tm.time() - part_start_time - write_elapsed
```

`hls_aes_downloader.py`는 손대지 않았다 — CBC 복호화 특성상 세그먼트 전체를 메모리에 모은 뒤 한 번에 쓰므로(수신 루프 안에 디스크 쓰기가 없음) 애초에 이 conflation이 없다.

## 제약 두 가지 (둘 다 지켰음)

- **저속 재큐 자체는 그대로 둠** — #132가 "저속은 상한 없음"으로 분리해둔 그 기능은 여전히 유효하다(대조군 테스트로 확인).
- **박제된 rules 테스트(file/m3u8, 34건) 무수정** — `tm.perf_counter()`는 `tm.time()`과 별개 함수라, 이 테스트들이 쓰는 `TickingClock`(`mod.tm.time`만 대체)에 잡히지 않는다. `git diff`로 두 rules 테스트 파일 diff가 빈 것을 확인했다.

## 검증 — 수정 전엔 재큐 발생, 수정 후엔 미발생을 실행으로 확인

새 파일 `tests/unit/core/test_slow_requeue_disk_vs_network.py`(가짜 시계 없이 실제 `time.sleep()`으로 디스크 지연 주입, 네트워크는 즉시 응답):

- `test_slow_disk_write_alone_does_not_trigger_requeue` / `..._for_segment` — 청크당 0.15초 디스크 지연(그것만으로 53 KB/s, 임계 100 KB/s 아래)을 줘도 재큐가 발동하지 않아야 한다.
- `test_slow_network_still_triggers_requeue_for_file_part` — 대조군, 네트워크 자체가 느리면 여전히 재큐가 발동해야 한다(#132 보존 확인).

**실제로 수정 전 코드로 되돌려(`git stash`) 이 세 테스트를 다시 돌렸다** — 디스크 지연 테스트 2개가 `restart_threads == 1`로 실패(재큐가 실제로 발생)했고, 대조군은 그대로 통과했다. 원복 후 재확인하니 3개 다 통과한다.

전체 스위트 **430 passed, 4 skipped**(기존과 동일 — 새 테스트 3개 추가분).
