### PR TITLE
feat: 세그먼트 임시 폴더를 산출물과 다른 매체로 자동 분리

### DIFF
--- a/core/downloaders/hls_aes_downloader.py
+++ b/core/downloaders/hls_aes_downloader.py
@@ -33,7 +33,7 @@ from core.downloaders.decrypt import decrypt_segment, looks_like_ts, sequence_iv
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
 from core.models.plan import DownloadPlan
-from core.utils.paths import temp_dir_for
+from core.utils.paths import choose_temp_dir
 
 
 class DecryptionError(Exception):
@@ -60,8 +60,9 @@ class HlsAesDownloader(BaseDownloader):
     def __init__(self, data, logger, **callbacks):
         super().__init__(data, logger, **callbacks)
         # 세그먼트 저장용 임시 폴더 (실패 정리 경로가 참조하므로 실행 전에 확정).
-        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105)
-        self.temp_dir = temp_dir_for(self.s.output_path)
+        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105).
+        # 조건이 맞으면 시스템 임시 폴더(로컬 매체)로 보낸다(#192) — m3u8과 동일
+        self.temp_dir = choose_temp_dir(self.s.output_path)
         self._key: bytes | None = None
         self._playlist = None
 

--- a/core/downloaders/m3u8_downloader.py
+++ b/core/downloaders/m3u8_downloader.py
@@ -32,7 +32,7 @@ from core.downloaders.base import BaseDownloader
 from core.models.content import Content, ContentType
 from core.models.download_state import DownloadState
 from core.models.plan import DownloadPlan
-from core.utils.paths import temp_dir_for
+from core.utils.paths import choose_temp_dir
 
 
 class M3U8Downloader(BaseDownloader):
@@ -52,8 +52,11 @@ class M3U8Downloader(BaseDownloader):
     def __init__(self, data, logger, **callbacks):
         super().__init__(data, logger, **callbacks)
         # 세그먼트 저장용 임시 폴더 경로 (실패 정리 경로가 참조하므로 실행 전에 확정).
-        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105)
-        self.temp_dir = temp_dir_for(self.s.output_path)
+        # 산출물 파일명에서 파생해 다운로드 간 폴더 공유·상호 삭제를 막는다 (#105).
+        # 조건이 맞으면 시스템 임시 폴더(로컬 매체)로 보낸다 — 산출물 폴더가
+        # 느린 매체(exFAT SD 카드 등)일 때 읽기·쓰기 경쟁과 AppleDouble
+        # 오버헤드를 우회한다(#192). 산출물 위치 자체는 그대로다
+        self.temp_dir = choose_temp_dir(self.s.output_path)
 
     @classmethod
     def supports(cls, content: Content) -> bool:

--- a/core/utils/disk_speed.py
+++ b/core/utils/disk_speed.py
@@ -1,0 +1,89 @@
+"""쓰기 속도 샘플링 — 임시 폴더를 다른 매체로 보낼지 판단하는 재료 (#192).
+
+app 계층의 `content/manager.py::probe_writable`(#138)과 같은 원리(제물
+스레드 + `join(timeout)`, 실제 파일을 만들어 썼다 지움)를 core에
+독립적으로 둔다 — core는 app을 import할 수 없으므로(SPEC §3.1) 그
+함수를 그대로 재사용하지 못하고, 같은 패턴만 복제했다.
+
+**반드시 `os.fsync()`로 실제 매체에 반영시킨 뒤 시간을 잰다.** 일반
+버퍼드 쓰기는 OS 페이지 캐시에 즉시 반환되어(#191 실기 확인 —
+`f.write()` 8192바이트 2000회 평균 3.7μs) 매체 속도와 무관하게 항상
+빠르게 보인다 — fsync 없이는 이 샘플링 자체가 무의미하다.
+"""
+
+import os
+import tempfile
+import threading
+import time
+
+# 4MB — 너무 작으면 노이즈(고정 오버헤드 비중이 커짐)에 흔들리고, 너무 크면
+# 정말 느린 매체에서 프로브 자체가 오래 걸린다. 순차 쓰기라 대부분의 매체가
+# 이 정도는 초 단위 안에 끝낸다.
+SAMPLE_BYTES = 4 * 1024 * 1024
+PROBE_TIMEOUT_S = 5.0
+
+_speed_cache: dict[object, float | None] = {}
+_cache_lock = threading.Lock()
+
+
+def _volume_key(directory: str) -> object:
+    """directory가 속한 볼륨을 식별하는 키. stat 실패 시 경로 자체로 폴백."""
+    try:
+        return os.stat(directory).st_dev
+    except OSError:
+        return os.path.abspath(directory)
+
+
+def measure_write_speed(
+    directory: str, sample_bytes: int = SAMPLE_BYTES, timeout_s: float = PROBE_TIMEOUT_S
+) -> float | None:
+    """directory에 샘플 파일을 써서 초당 바이트 수를 잰다. 실패·시간초과면 None.
+
+    같은 볼륨은 프로세스 생존 동안 한 번만 잰다(볼륨 캐시) — 다운로드마다
+    매번 재는 건 낭비고, 매체 속도는 그 사이 바뀌지 않는다고 가정한다.
+    """
+    key = _volume_key(directory)
+    with _cache_lock:
+        if key in _speed_cache:
+            return _speed_cache[key]
+
+    outcome: dict[str, float] = {}
+
+    def probe() -> None:
+        try:
+            fd, probe_path = tempfile.mkstemp(prefix=".cvdv2_speed_", dir=directory)
+        except OSError:
+            return
+        try:
+            data = os.urandom(sample_bytes)
+            start = time.perf_counter()
+            os.write(fd, data)
+            os.fsync(fd)  # 페이지 캐시가 아니라 실제 매체 반영 시간을 잰다 (#191)
+            outcome["elapsed"] = time.perf_counter() - start
+        except OSError:
+            pass
+        finally:
+            os.close(fd)
+            try:
+                os.remove(probe_path)
+            except OSError:
+                pass
+
+    worker = threading.Thread(target=probe, daemon=True, name="DiskSpeedProbe")
+    worker.start()
+    worker.join(timeout_s)
+
+    speed = None
+    elapsed = outcome.get("elapsed")
+    if elapsed and elapsed > 0:
+        speed = sample_bytes / elapsed
+
+    with _cache_lock:
+        _speed_cache[key] = speed
+    return speed
+
+
+def clear_speed_cache() -> None:
+    """볼륨 속도 캐시를 비운다 — 테스트 전용."""
+    with _cache_lock:
+        _speed_cache.clear()

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -17,6 +17,10 @@
 import hashlib
 import os
 import re
+import shutil
+import tempfile
+
+from core.utils.disk_speed import measure_write_speed
 
 # Windows에서 파일명에 쓸 수 없는 문자 + ASCII 제어 문자 전체(0x00–0x1F, 개행 포함).
 # Windows는 제어 문자가 든 파일명 생성을 거부한다(EINVAL). 조회 단계
@@ -101,14 +105,107 @@ def build_output_path(directory: str, title: str, resolution: int) -> str:
     return ensure_unique_path(candidate)
 
 
-def temp_dir_for(output_path: str) -> str:
+def temp_dir_for(output_path: str, base_dir: str | None = None) -> str:
     """세그먼트 임시 폴더 경로를 산출물 파일명에서 파생한다.
 
     구 코드는 고정 이름("CVDv2_temp") 하나를 모든 다운로드가 공유해,
     같은 폴더로 향하는 두 다운로드가 겹치면 서로의 세그먼트 폴더를
     삭제·재생성할 수 있었다 (#105 확인 항목 4). 산출물 파일명(중복
     회피 후)에서 파생하면 다운로드마다 폴더가 구분된다.
+
+    base_dir을 주면 그 디렉토리 아래에 만든다(#192 — 임시 폴더를 산출물과
+    다른 매체로 보낼 때). 기본은 산출물과 같은 디렉토리(기존 동작 무변경).
     """
-    directory = os.path.dirname(output_path)
+    directory = base_dir if base_dir is not None else os.path.dirname(output_path)
     stem = os.path.splitext(os.path.basename(output_path))[0]
     return os.path.join(directory, f"CVDv2_temp_{stem}")
+
+
+# 임시 폴더를 분리할 스크래치 볼륨에 요구하는 최소 여유 공간 (#192).
+# m3u8·hls_aes는 산출물 크기를 미리 모른다(DownloadPlan.total_size=None) —
+# 정확한 소요량을 계산할 방법이 없으므로, 대부분의 VOD보다 넉넉한 고정
+# 임계로 보수적으로 게이트한다. 이 추정이 틀려도(아주 긴 고화질 VOD 등)
+# 최악의 결과는 디스크 부족 실패이며, 이는 분리하지 않았을 때도 스크래치
+# 볼륨이 아닌 산출물 볼륨에서 똑같이 날 수 있는 기존 실패 부류다(#146
+# 감사의 OSError 최후 방어선이 이미 처리한다) — 분리 여부와 무관한 위험이다.
+_MIN_SCRATCH_FREE_BYTES = 10 * 1024**3  # 10 GiB
+
+# 스크래치 볼륨이 산출물 볼륨보다 "뚜렷이" 빠르다고 볼 배수. 애매하면
+# 분리하지 않는다는 원칙(#192)이라 노이즈에 흔들리지 않을 만큼 크게 잡는다
+# — exFAT SD 카드 vs 로컬 SSD 실측(후처리 36배 차이)에 비하면 여유롭게
+# 낮은 문턱이지만, 절반 정도 차이 나는 애매한 경우까지 분리로 몰지 않는다
+_SEPARATION_SPEED_MARGIN = 2.0
+
+# 시스템 임시 폴더 아래 스크래치 전용 서브폴더 이름. config.APP_NAME과
+# 뜻은 같지만 core는 app(config)을 import할 수 없어(SPEC §3.1) 문자열을
+# 이 자리에서 그대로 쓴다 — 실제 폴더 구분은 이름이 아니라 위치(시스템
+# 임시 폴더 vs 산출물 폴더)가 하므로 문제되지 않는다
+_SCRATCH_SUBDIR = "CVDv2_scratch"
+
+
+def _scratch_base_dir() -> str:
+    """시스템 임시 폴더 아래 앱 전용 스크래치 디렉토리 경로."""
+    return os.path.join(tempfile.gettempdir(), _SCRATCH_SUBDIR)
+
+
+def _same_volume(a: str, b: str) -> bool:
+    """두 경로가 같은 볼륨(장치)에 있는지 — 실패하면 보수적으로 "같다"로 본다.
+
+    확인할 수 없으면 분리할 근거도 없다("애매하면 분리하지 않는다").
+    """
+    try:
+        return os.stat(a).st_dev == os.stat(b).st_dev
+    except OSError:
+        return True
+
+
+def choose_temp_dir(output_path: str) -> str:
+    """세그먼트 임시 폴더 위치를 정한다 (#192).
+
+    기본은 산출물과 같은 폴더(기존 동작) — 아래 조건을 **모두** 만족할
+    때만 시스템 임시 폴더(로컬 매체일 가능성이 높다)로 보낸다. 하나라도
+    실패·불확실하면 분리하지 않는다("애매하면 분리하지 않는다" 원칙,
+    #192 — 잘못 분리해 시스템 디스크를 채우는 것이 그냥 느린 것보다
+    나쁘다):
+
+    1. 스크래치 볼륨에 여유 공간이 넉넉한가(고정 임계 — 위 상수 참고)
+    2. 산출물 폴더와 스크래치 폴더가 이미 같은 볼륨이면 분리할 이유가
+       없다(비교할 것도 없이 그대로 둔다)
+    3. 스크래치 폴더가 실제로 쓰기 가능하고, 산출물 폴더보다 뚜렷이
+       (_SEPARATION_SPEED_MARGIN배 이상) 빠른가
+
+    산출물 위치 자체는 절대 바꾸지 않는다 — ffmpeg가 세그먼트를 파이프로
+    받아 산출물에 직접 쓰므로(core/utils/ffmpeg.py) 복사 단계가 없다.
+    """
+    default = temp_dir_for(output_path)
+    output_dir = os.path.dirname(output_path) or "."
+    scratch_base = _scratch_base_dir()
+
+    try:
+        os.makedirs(scratch_base, exist_ok=True)
+    except OSError:
+        return default
+
+    try:
+        usage = shutil.disk_usage(scratch_base)
+    except OSError:
+        return default
+    if usage.free < _MIN_SCRATCH_FREE_BYTES:
+        return default
+
+    if _same_volume(scratch_base, output_dir):
+        return default
+
+    scratch_speed = measure_write_speed(scratch_base)
+    if not scratch_speed:
+        return default
+
+    output_speed = measure_write_speed(output_dir)
+    if not output_speed:
+        # 산출물 폴더 속도를 못 재면 비교 기준이 없다 — 애매하니 분리하지 않는다
+        return default
+
+    if scratch_speed < output_speed * _SEPARATION_SPEED_MARGIN:
+        return default
+
+    return temp_dir_for(output_path, base_dir=scratch_base)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 import config.config as config_module  # noqa: E402 — sys.path 삽입 후에 와야 한다
+import core.downloaders.hls_aes_downloader as hls_aes_module  # noqa: E402
+import core.downloaders.m3u8_downloader as m3u8_module  # noqa: E402
+from core.utils.paths import temp_dir_for  # noqa: E402
 
 # 외부 API 응답을 흉내 내는 픽스처 파일 저장 위치
 MOCK_RESPONSES_DIR = Path(__file__).resolve().parent / "fixtures" / "mock_responses"
@@ -49,6 +52,26 @@ def _isolate_real_config(tmp_path, monkeypatch):
     isolated_dir = tmp_path / "_isolated_config"
     monkeypatch.setattr(config_module, "CONFIG_DIR", str(isolated_dir))
     monkeypatch.setattr(config_module, "CONFIG_FILE", str(isolated_dir / "config.json"))
+
+
+# ============ 전역 choose_temp_dir 격리 (#192) ============
+# choose_temp_dir(core/utils/paths.py)은 실제로 파일을 써서(fsync 포함)
+# 속도를 재는 실 디스크 I/O다 — 격리하지 않으면 M3U8Downloader·
+# HlsAesDownloader를 생성하는 기존 테스트 수십 건이 매번 이 프로브를
+# 타 스위트가 느려지고, tmp_path와 시스템 임시 폴더가 우연히 같은
+# 볼륨이 아닌 CI 환경에서는 판정이 흔들려 임시 폴더 위치가 테스트마다
+# 달라질 수 있다(재현성 상실). #192 기능 자체를 검증하는 테스트
+# (tests/unit/core/test_choose_temp_dir.py)만 이 픽스처를 지역적으로
+# 되돌려(monkeypatch로 실제 choose_temp_dir를 복원) 실 프로브를 태운다.
+@pytest.fixture(autouse=True)
+def _isolate_choose_temp_dir(monkeypatch):
+    """기본은 임시 폴더를 산출물 폴더에 그대로 두는 기존 동작으로 고정한다."""
+
+    def _default_temp_dir(output_path: str) -> str:
+        return temp_dir_for(output_path)
+
+    monkeypatch.setattr(m3u8_module, "choose_temp_dir", _default_temp_dir)
+    monkeypatch.setattr(hls_aes_module, "choose_temp_dir", _default_temp_dir)
 
 
 # ============ 실패 GUI 테스트 스크린샷 (#154) ============

--- a/tests/unit/core/test_choose_temp_dir.py
+++ b/tests/unit/core/test_choose_temp_dir.py
@@ -1,0 +1,295 @@
+"""임시 폴더를 다른 매체로 분리하는 판단(choose_temp_dir) 검증 (#192).
+
+이 파일의 테스트는 conftest.py의 전역 격리 픽스처(_isolate_choose_temp_dir)를
+필요한 만큼만 되돌려 실제 판단 로직·실 디스크 I/O 프로브를 검증한다.
+다른 테스트 파일에는 이 격리가 그대로 적용되므로 기존 스위트는 무영향이다.
+
+"애매하면 분리하지 않는다"는 #192의 원칙을 각 게이트(여유 공간·같은
+볼륨·프로브 실패·속도 배수 미달)별로 개별 검증한다.
+"""
+
+import os
+
+import core.downloaders.hls_aes_downloader as hls_aes_module
+import core.downloaders.m3u8_downloader as m3u8_module
+import core.utils.disk_speed as disk_speed_module
+import core.utils.paths as paths_module
+from core.models.download_data import DownloadData
+
+
+def _restore_real_choose_temp_dir(monkeypatch):
+    """conftest의 전역 격리를 이 테스트에 한해 되돌린다."""
+    monkeypatch.setattr(m3u8_module, "choose_temp_dir", paths_module.choose_temp_dir)
+    monkeypatch.setattr(hls_aes_module, "choose_temp_dir", paths_module.choose_temp_dir)
+
+
+# ================================================================ measure_write_speed
+
+
+def test_measure_write_speed_returns_positive_number_for_real_directory(tmp_path):
+    """실제 쓰기 가능한 디렉토리는 양수 바이트/초를 돌려준다."""
+    disk_speed_module.clear_speed_cache()
+    speed = disk_speed_module.measure_write_speed(str(tmp_path), sample_bytes=64 * 1024)
+    assert speed is not None
+    assert speed > 0
+
+
+def test_measure_write_speed_caches_per_volume(tmp_path, monkeypatch):
+    """같은 볼륨은 두 번째 호출부터 실제 쓰기 없이 캐시된 값을 돌려준다."""
+    disk_speed_module.clear_speed_cache()
+    calls = []
+    real_mkstemp = disk_speed_module.tempfile.mkstemp
+
+    def counting_mkstemp(*args, **kwargs):
+        calls.append(1)
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(disk_speed_module.tempfile, "mkstemp", counting_mkstemp)
+
+    first = disk_speed_module.measure_write_speed(str(tmp_path), sample_bytes=1024)
+    second = disk_speed_module.measure_write_speed(str(tmp_path), sample_bytes=1024)
+
+    assert first == second
+    assert len(calls) == 1, "캐시가 없으면 매번 실제로 파일을 썼을 것이다"
+
+
+def test_measure_write_speed_missing_directory_returns_none(tmp_path):
+    """없는 디렉토리는 None — 실패를 조용히 삼키되 값은 신뢰할 수 없다고 알린다."""
+    disk_speed_module.clear_speed_cache()
+    speed = disk_speed_module.measure_write_speed(str(tmp_path / "없는폴더"))
+    assert speed is None
+
+
+def test_measure_write_speed_leaves_no_residue(tmp_path):
+    """프로브 파일은 측정 후 남지 않는다."""
+    disk_speed_module.clear_speed_cache()
+    disk_speed_module.measure_write_speed(str(tmp_path), sample_bytes=1024)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_measure_write_speed_calls_fsync(tmp_path, monkeypatch):
+    """fsync를 실제로 호출한다 — 없으면 페이지 캐시만 재는 무의미한 측정이 된다(#191).
+
+    f.write()는 OS 페이지 캐시에 즉시 반환되어(#191 실기 확인) 매체 속도와
+    무관하게 항상 빠르게 보인다 — fsync 없이는 이 프로브 전체가 무효화된다.
+    """
+    disk_speed_module.clear_speed_cache()
+    calls = []
+    real_fsync = disk_speed_module.os.fsync
+
+    def counting_fsync(fd):
+        calls.append(fd)
+        return real_fsync(fd)
+
+    monkeypatch.setattr(disk_speed_module.os, "fsync", counting_fsync)
+
+    disk_speed_module.measure_write_speed(str(tmp_path), sample_bytes=1024)
+
+    assert len(calls) == 1, "fsync가 호출되지 않았다 — 페이지 캐시만 재는 측정으로 되돌아갔다"
+
+
+# ================================================================ choose_temp_dir 게이트
+
+
+def test_falls_back_when_scratch_has_insufficient_free_space(tmp_path, monkeypatch):
+    """스크래치 볼륨 여유 공간이 부족하면 분리하지 않는다.
+
+    다른 게이트(같은 볼륨·속도)가 우연히 같은 결과를 내 이 게이트를 안
+    거치고도 테스트가 통과하는 걸 막기 위해, 그 게이트들은 전부 "통과"
+    쪽으로 고정해 여유 공간 체크 단독으로 분기가 갈리는지 확인한다.
+    """
+
+    class _TinyUsage:
+        free = 1024  # 임계(10GiB)보다 한참 작다
+
+    scratch_str = str(tmp_path / "scratch")
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _TinyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: scratch_str)
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+    # 속도 게이트는 확실히 통과시킨다(스크래치가 압도적으로 빠름) — 그래야
+    # 여유 공간 게이트 단독으로 분기가 갈리는지 알 수 있다
+    monkeypatch.setattr(
+        paths_module,
+        "measure_write_speed",
+        lambda d: 100_000_000.0 if d == scratch_str else 1_000_000.0,
+    )
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path)
+
+
+def test_falls_back_when_scratch_and_output_are_same_volume(tmp_path, monkeypatch):
+    """스크래치와 산출물 폴더가 이미 같은 볼륨이면 비교 없이 분리하지 않는다."""
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    scratch = tmp_path / "scratch"
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: str(scratch))
+
+    speed_calls = []
+    monkeypatch.setattr(
+        paths_module,
+        "measure_write_speed",
+        lambda d: speed_calls.append(d) or 999_999_999,
+    )
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path)
+    assert speed_calls == [], "같은 볼륨이면 속도를 잴 필요도 없다"
+
+
+def test_falls_back_when_scratch_probe_fails(tmp_path, monkeypatch):
+    """스크래치 폴더 속도 측정에 실패하면(None) 분리하지 않는다."""
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: str(tmp_path / "scratch"))
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+    monkeypatch.setattr(paths_module, "measure_write_speed", lambda d: None)
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path)
+
+
+def test_falls_back_when_output_probe_fails(tmp_path, monkeypatch):
+    """스크래치는 재도 산출물 쪽 속도를 못 재면(비교 기준 없음) 분리하지 않는다."""
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    scratch_str = str(tmp_path / "scratch")
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: scratch_str)
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+
+    def fake_speed(directory):
+        return 100_000_000.0 if directory == scratch_str else None
+
+    monkeypatch.setattr(paths_module, "measure_write_speed", fake_speed)
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path)
+
+
+def test_falls_back_when_scratch_is_not_clearly_faster(tmp_path, monkeypatch):
+    """스크래치가 산출물보다 빠르긴 해도 배수 기준(_SEPARATION_SPEED_MARGIN) 미달이면 그대로 둔다."""
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    scratch_str = str(tmp_path / "scratch")
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: scratch_str)
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+
+    def fake_speed(directory):
+        # 스크래치가 1.2배만 빠르다 — margin(2.0배) 미달
+        return 120.0 if directory == scratch_str else 100.0
+
+    monkeypatch.setattr(paths_module, "measure_write_speed", fake_speed)
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path)
+
+
+def test_separates_when_scratch_is_clearly_faster_and_has_room(tmp_path, monkeypatch):
+    """모든 게이트를 통과하면(여유 공간+다른 볼륨+뚜렷이 빠름) 스크래치 폴더를 쓴다."""
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    scratch_base = tmp_path / "scratch"
+    scratch_str = str(scratch_base)
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: scratch_str)
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+
+    def fake_speed(directory):
+        return 100_000_000.0 if directory == scratch_str else 1_000_000.0  # 100배 차이
+
+    monkeypatch.setattr(paths_module, "measure_write_speed", fake_speed)
+
+    output_path = str(tmp_path / "out" / "video 1080p.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    result = paths_module.choose_temp_dir(output_path)
+
+    assert result == paths_module.temp_dir_for(output_path, base_dir=scratch_str)
+    assert result != paths_module.temp_dir_for(output_path)
+
+
+# ================================================================ 다운로더 연동
+
+
+def test_m3u8_downloader_uses_scratch_temp_dir_when_conditions_are_met(tmp_path, monkeypatch):
+    """조건이 맞으면 M3U8Downloader.temp_dir이 실제로 스크래치 폴더를 가리킨다."""
+    _restore_real_choose_temp_dir(monkeypatch)
+
+    class _PlentyUsage:
+        free = 100 * 1024**3
+
+    scratch_base = tmp_path / "scratch"
+    scratch_str = str(scratch_base)
+    monkeypatch.setattr(paths_module.shutil, "disk_usage", lambda path: _PlentyUsage())
+    monkeypatch.setattr(paths_module, "_scratch_base_dir", lambda: scratch_str)
+    monkeypatch.setattr(paths_module, "_same_volume", lambda a, b: False)
+    monkeypatch.setattr(
+        paths_module,
+        "measure_write_speed",
+        lambda d: 100_000_000.0 if d == scratch_str else 1_000_000.0,
+    )
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    output_path = str(output_dir / "video 1080p.mp4")
+
+    data = DownloadData(
+        base_url="https://example.invalid/hls/video.m3u8",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=1080,
+        content_type="m3u8",
+    )
+    engine = m3u8_module.M3U8Downloader(data, logger=None)
+
+    assert engine.temp_dir == paths_module.temp_dir_for(output_path, base_dir=scratch_str)
+    assert engine.temp_dir != paths_module.temp_dir_for(output_path)
+
+
+def test_m3u8_downloader_keeps_output_adjacent_temp_dir_by_default(tmp_path):
+    """conftest의 전역 격리를 그대로 두면(기본) 기존 동작과 동일하다."""
+    output_path = str(tmp_path / "video 1080p.mp4")
+    data = DownloadData(
+        base_url="https://example.invalid/hls/video.m3u8",
+        vod_url="https://chzzk.naver.com/video/1",
+        output_path=output_path,
+        resolution=1080,
+        content_type="m3u8",
+    )
+    engine = m3u8_module.M3U8Downloader(data, logger=None)
+
+    assert engine.temp_dir == paths_module.temp_dir_for(output_path)


### PR DESCRIPTION
Closes #192

세그먼트 임시 폴더를 조건이 맞을 때 산출물과 다른 매체(시스템 임시 폴더, 보통 로컬 매체)로 자동 분리한다. 오늘 실측으로 모인 근거:

- exFAT SD 카드 후처리 81.69초 vs 로컬 SSD 2.28초 — **36배**. 후처리는 `-c copy`라 순수 I/O이고 읽기·쓰기가 같은 매체에서 동시에 일어난다.
- AppleDouble 사이드카가 세그먼트마다 생겨(Finder·Spotlight와 무관하게 항상, #192 실측 확정) 파일 수가 2배가 된다.
- **하나의 변경(임시 폴더 분리)이 둘 다 동시에 해소한다** — 로컬 볼륨엔 exFAT 자체가 없으니 사이드카가 안 생기고, 세그먼트 읽기·쓰기가 산출물 볼륨과 경쟁하지 않는다.

## 판단 로직

기본은 기존 동작(산출물과 같은 폴더) — 아래를 **모두** 만족할 때만 분리한다. 하나라도 실패·불확실하면 분리하지 않는다:

1. 스크래치(시스템 임시 폴더) 볼륨에 여유 공간 10GiB 이상 — m3u8·hls_aes는 산출물 크기를 미리 모르므로(`DownloadPlan.total_size=None`) 정확한 계산 대신 대부분의 VOD보다 넉넉한 고정 임계로 보수적으로 게이트했다.
2. 산출물 폴더와 이미 같은 볼륨이면 비교 없이 스킵.
3. 스크래치가 실제로 쓰기 가능하고 산출물보다 **2배 이상** 뚜렷이 빠름.

산출물 위치는 절대 안 바뀐다 — ffmpeg가 세그먼트를 파이프로 받아 산출물에 직접 쓰므로 복사 단계가 없다.

## 속도 측정 — `probe_writable`(#138)과 같은 원리, core에 독립 구현

`content/manager.py::probe_writable`을 그대로 재사용하고 싶었으나 **core는 app을 import할 수 없다**(SPEC §3.1) — 그래서 같은 패턴(제물 스레드 + `join(timeout)`, 실제 파일 생성 후 삭제)을 `core/utils/disk_speed.py`에 독립적으로 구현했다.

**반드시 `os.fsync()`로 실제 매체 반영 시간을 잰다** — #191에서 실측했듯 일반 버퍼드 쓰기는 OS 페이지 캐시에 즉시 반환되어(8192B write 2000회 평균 3.7μs) fsync 없이는 매체 속도와 무관하게 항상 빠르게 보이는 무의미한 측정이 된다. 볼륨별로 캐시한다(프로세스 생존 동안 1회 — "볼륨별로 캐시할 것" 요청 반영).

## 테스트 격리

`choose_temp_dir`을 무방비로 두면 `M3U8Downloader`/`HlsAesDownloader`를 생성하는 기존 테스트 수십 건이 매번 실 디스크 I/O 프로브를 타 스위트가 느려지고, tmp_path와 시스템 임시 폴더가 우연히 같은 볼륨이 아닌 CI 환경에서는 판정이 흔들려 재현성을 잃는다. `tests/conftest.py`에 전역 `autouse` 픽스처를 추가해 기본은 기존 동작(`temp_dir_for`)으로 고정했다 — #199와 같은 패턴이다. 이 기능 자체를 검증하는 `tests/unit/core/test_choose_temp_dir.py`만 지역적으로 되돌려 실 로직·실 I/O를 태운다.

## 검증

**게이트별 mutation 검증**: 여유공간·같은볼륨·프로브실패·속도배수·fsync호출 각각을 실제로 지워보고 대응 테스트가 잡는지 확인한 뒤 복원했다. 이 과정에서 **여유공간 게이트 테스트가 실제로는 다른 게이트(같은 볼륨) 덕에 우연히 통과하던 진짜 결함**을 발견해 격리를 고쳤다(테스트가 게이트를 진짜로 격리하도록 다른 게이트들을 명시적으로 "통과" 쪽에 고정).

**실제(몽키패치 없는) 머신에서 직접 실행**: 이 개발 머신(단일 드라이브)에서 `choose_temp_dir`을 그대로 돌려, 같은 볼륨 게이트가 정상 작동해 **기본 동작과 정확히 같은 경로**를 반환함을 확인했다 — "최악이 현행과 같다"는 원칙의 실행 확인.

전체 스위트 **444 passed(+13), 4 skipped**(기존과 동일 카운트). 34건 rules 테스트는 무수정.

## 실기(exFAT SD 카드) 검증 절차 제안 — 오너 재측정용

이 저장소 환경에는 exFAT SD 카드·다른 물리 매체가 없어 아래는 직접 실행하지 못했다. 같은 VOD를 exFAT SD 카드에 받으면서 다음을 확인해 주시면 된다:

**① 임시 폴더가 실제로 다른 매체에 생기는지**
- 다운로드 시작 직후, 시스템 임시 폴더 아래(macOS는 `$TMPDIR` 또는 `/var/folders/.../T/`, `echo $TMPDIR`로 확인 가능) `CVDv2_scratch/CVDv2_temp_<제목>` 폴더가 생기는지 확인한다.
- **SD 카드 쪽에는 이 폴더가 생기지 않아야 한다** — SD 카드에는 산출물 파일(진행 중 빈 파일)만 있어야 한다.
- 만약 시스템 임시 폴더가 SD 카드와 같은 물리 매체가 아닌데도 분리가 안 됐다면(SD 카드 옆에 임시 폴더가 그대로 생겼다면), 여유 공간(10GiB 미만?) 또는 속도 배수(2배 미만?) 게이트에 걸렸을 가능성이 크다 — 로그에는 아직 이 판단 근거를 남기지 않았으니, 필요하면 후속으로 진단 로그를 추가할 수 있다.

**② AppleDouble이 안 생기는지**
- 다운로드 도중 터미널로 `ls -la <시스템 임시 폴더>/CVDv2_scratch/CVDv2_temp_<제목>/`을 실행한다(Finder를 열지 않아도 된다 — #192 실측과 같은 방식).
- `._` 로 시작하는 파일이 하나도 없어야 한다.

**③ 후처리 시간이 줄어드는지**
- 다운로드 로그의 `Postprocess completed in Xs` 줄을 이전(같은 VOD, 이 변경 전 빌드)과 비교한다.
- 산출물 자체는 여전히 SD 카드에 쓰이므로(최종 위치는 그대로), 순수 로컬 SSD 케이스(2.28초)만큼은 아니어도 **exFAT 기준(81.69초)보다는 뚜렷이 짧아야 한다** — 세그먼트 읽기가 이제 로컬에서 일어나고, 최종 병합 결과물 쓰기 한 번만 SD 카드에 남기 때문이다.
- **다운로드(전송) 시간도 함께 비교해 보면 좋다** — 세그먼트 자체가 이제 SD 카드에 전혀 안 쓰이므로(로컬에만 쓰임), 다운로드 단계에서도 AppleDouble 오버헤드가 사라져 개선이 있을 수 있다(측정 안 해봄, 확인 환영).

측정 방법론은 #191에서 남긴 대로 — **같은 세션에서 여러 번(각 3회 이상) 재서** 런 간 변동을 걸러내 주시면 좋다.
