### PR TITLE
fix: Windows에서 scripts/의 한글 print가 로케일 인코딩으로 죽는 문제 수정

### DIFF
--- a/scripts/capture_playback_debug.py
+++ b/scripts/capture_playback_debug.py
@@ -20,6 +20,11 @@ from pathlib import Path
 
 import requests
 
+# Windows 콘솔의 기본 로케일 인코딩(cp1252 등)은 한글을 표현하지 못해 이 스크립트의
+# 한글 print()가 UnicodeEncodeError로 죽을 수 있다 — inject_build_info.py가 CI에서
+# 실제로 겪은 문제와 같은 부류다 (#204).
+sys.stdout.reconfigure(encoding="utf-8")
+
 # scripts/ 하위에서 실행해도 저장소 루트의 config·core를 import할 수 있게 한다
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 

--- a/scripts/inject_build_info.py
+++ b/scripts/inject_build_info.py
@@ -20,7 +20,14 @@ IS_RELEASE_BUILD 두 상수를 실제 값으로 고쳐 쓴다.
 import argparse
 import re
 import subprocess
+import sys
 from pathlib import Path
+
+# Windows 러너의 stdout은 파이프로 리다이렉트되면 로케일 기반 인코딩(cp1252 등)
+# 으로 열려 한글 출력이 UnicodeEncodeError로 죽는다 — macOS·Linux는 stdout이
+# 기본 UTF-8이라 안 보이는 문제였다. Python 3.13은 아직 Windows UTF-8 모드가
+# 기본이 아니므로(PEP 686은 3.15부터) 여기서 명시적으로 고정한다 (#204).
+sys.stdout.reconfigure(encoding="utf-8")
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "config.py"
 

--- a/scripts/summarize_download_log.py
+++ b/scripts/summarize_download_log.py
@@ -21,6 +21,12 @@ import re
 import sys
 from pathlib import Path
 
+# Windows 콘솔의 기본 로케일 인코딩(cp1252 등)은 한글을 표현하지 못해 이 스크립트의
+# 한글 print()가 UnicodeEncodeError로 죽을 수 있다 — inject_build_info.py가 CI에서
+# 실제로 겪은 문제와 같은 부류다 (#204).
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
 # 메시지 본문 패턴 (download/logger.py의 메시지 형식과 1:1).
 # 줄 프리픽스(시각·레벨·스레드 이름)는 의도적으로 매칭하지 않는다.
 _PATTERNS = {


### PR DESCRIPTION
## 요약

`v2.9.6-rc1` 릴리즈 빌드가 Windows 매트릭스에서만 실패했다(#204). `scripts/inject_build_info.py`의 성공 메시지가 한글(`"주입 완료: ..."`)인데, GitHub Actions Windows 러너에서 파이프로 리다이렉트된 Python 프로세스의 `sys.stdout`은 로케일 기반 인코딩(`cp1252`)으로 열려 `print()`가 `UnicodeEncodeError`로 죽었다. macOS·Linux는 stdout이 기본 UTF-8이라 통과했다.

세 스크립트 모두 진입 시점에 `sys.stdout`(및 `stderr` 사용처)을 `encoding="utf-8"`로 명시 고정했다:
- `scripts/inject_build_info.py` — release.yml이 실제로 호출하는 지점, 이번 실패의 직접 원인
- `scripts/capture_playback_debug.py`, `scripts/summarize_download_log.py` — CI에서는 아직 호출되지 않지만 같은 위험(한글 `print` + OS 기본 로케일 의존)을 가진 개발자 도구, 예방적으로 함께 수정

`.github/`은 에이전트가 편집할 수 없는 보호 경로라 워크플로 쪽 우회(`PYTHONIOENCODING` 환경변수 주입)는 제외했다 — 스크립트 자체가 자기 완결적으로 인코딩을 고정하는 쪽이 어떤 셸/워크플로에서 호출되든 재발을 막는다.

## 검증

- `uv run pytest -q tests/unit/test_inject_build_info.py tests/unit/test_download_log_phases.py` — 11 passed
- `uv run ruff check scripts/inject_build_info.py scripts/capture_playback_debug.py scripts/summarize_download_log.py` — All checks passed
- `uv run python scripts/inject_build_info.py`를 로컬(비릴리즈 모드)로 실행해 한글 출력이 정상 표시됨을 확인, 이후 부수효과로 바뀐 `config/config.py`는 되돌림
- Windows CI에서의 재현은 이 PR의 CI 실행 자체 및 이후 재컷 rc 빌드로 확인 예정

## 후속 제안 (이 PR 범위 밖)

- SPEC §8.4(플랫폼 전제 코드)에 "OS 기본 로케일에 의존하지 않는다" 항목 추가를 제안한다 — `os.startfile`처럼 "한 OS에만 있는 API"와 달리 이번 건은 "OS마다 기본값이 다른 API(stdout 인코딩)"라는 같은 부류의 다른 사례다. SPEC은 이 저장소 밖에 있어(위키로 추정) 직접 편집하지 않았다.
- `v2.9.6-rc1` 태그: 릴리즈 자산 없이 만들어진 상태다. 이 PR 병합 후 재빌드할지 태그를 지우고 rc2로 갈지는 오너 판단이 필요하다 — 별도로 보고한다.

Closes #204
